### PR TITLE
Add fixes and improvements to build & logging and bump Eto version to latest CI

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="eto-myget" value="https://www.myget.org/F/eto/api/v3/index.json" /> <!-- Added for CI builds of Eto, remove when we are on release version again -->
     <add key="haroohie" value="https://pkgs.dev.azure.com/jonko0493/haroohie-public/_packaging/haroohie/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/SerialLoops.Lib/Build.cs
+++ b/src/SerialLoops.Lib/Build.cs
@@ -198,7 +198,7 @@ namespace SerialLoops.Lib
             };
             Process gcc = new() { StartInfo = gccStartInfo };
             gcc.OutputDataReceived += (object sender, DataReceivedEventArgs e) => log.Log(e.Data);
-            gcc.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data, lookForErrors: true);
+            gcc.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => log.LogError(e.Data, lookForWarnings: true);
             gcc.Start();
             await gcc.WaitForExitAsync();
             await Task.Delay(50); // ensures process is actually complete
@@ -206,10 +206,12 @@ namespace SerialLoops.Lib
             {
                 CreateNoWindow = true,
                 WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
             };
             Process objcopy = new() { StartInfo = objcopyStartInfo };
             objcopy.OutputDataReceived += (object sender, DataReceivedEventArgs e) => log.Log(e.Data);
-            objcopy.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data, lookForErrors: true);
+            objcopy.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => log.LogError(e.Data, lookForWarnings: true);
             objcopy.Start();
             await objcopy.WaitForExitAsync();
             await Task.Delay(50); // ensures process is actually complete

--- a/src/SerialLoops.Lib/Build.cs
+++ b/src/SerialLoops.Lib/Build.cs
@@ -78,7 +78,7 @@ namespace SerialLoops.Lib
 
             if (dat is null || evt is null || grp is null)
             {
-                log.LogError("One or more archives is null. Build failed.");
+                log.LogError("One or more archives is null.");
                 return false;
             }
 
@@ -142,17 +142,14 @@ namespace SerialLoops.Lib
             // Save files to disk
             if (!IO.WriteBinaryFile(Path.Combine(directory, "rom", "data", "dat.bin"), dat.GetBytes(), log))
             {
-                log.LogError("Build failed!");
                 return false;
             }
             if (!IO.WriteBinaryFile(Path.Combine(directory, "rom", "data", "evt.bin"), evt.GetBytes(), log))
             {
-                log.LogError("Build failed!");
                 return false;
             }
             if (!IO.WriteBinaryFile(Path.Combine(directory, "rom", "data", "grp.bin"), grp.GetBytes(), log))
             {
-                log.LogError("Build failed!");
                 return false;
             }
 
@@ -214,7 +211,7 @@ namespace SerialLoops.Lib
             (string objFile, string binFile) = await CompileSourceFileAsync(filePath, devkitArm, workingDirectory, log);
             if (!File.Exists(binFile))
             {
-                log.LogError($"Compiled file {binFile} does not exist! Build failed!");
+                log.LogError($"Compiled file {binFile} does not exist!");
                 return false;
             }
             ReplaceSingleFile(archive, binFile, index);
@@ -227,7 +224,7 @@ namespace SerialLoops.Lib
             (string objFile, string binFile) = await CompileSourceFileAsync(filePath, devkitArm, workingDirectory, log);
             if (!File.Exists(binFile))
             {
-                log.LogError($"Compiled file {binFile} does not exist! Build failed!");
+                log.LogError($"Compiled file {binFile} does not exist!");
                 return false;
             }
             ReplaceSingleFile(archive, binFile, index);

--- a/src/SerialLoops.Lib/Build.cs
+++ b/src/SerialLoops.Lib/Build.cs
@@ -196,6 +196,7 @@ namespace SerialLoops.Lib
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
+            log.Log($"Compiling '{filePath}' to '{objFile}' with '{gccStartInfo.FileName}'...");
             Process gcc = new() { StartInfo = gccStartInfo };
             gcc.OutputDataReceived += (object sender, DataReceivedEventArgs e) => log.Log(e.Data);
             gcc.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => log.LogError(e.Data, lookForWarnings: true);
@@ -209,6 +210,7 @@ namespace SerialLoops.Lib
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
+            log.Log($"Objcopying '{objFile}' to '{binFile}' with '{objcopyStartInfo.FileName}'...");
             Process objcopy = new() { StartInfo = objcopyStartInfo };
             objcopy.OutputDataReceived += (object sender, DataReceivedEventArgs e) => log.Log(e.Data);
             objcopy.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => log.LogError(e.Data, lookForWarnings: true);

--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -67,7 +67,7 @@ namespace SerialLoops.Lib
             }
             else
             {
-                devkitArmDir = Path.Combine("opt", "devkitpro", "devkitARM");
+                devkitArmDir = Path.Combine("/opt", "devkitpro", "devkitARM");
             }
             if (!Directory.Exists(devkitArmDir))
             {

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -677,6 +677,7 @@ namespace SerialLoops.Editors
         private void ChibiDropDown_SelectedKeyChanged(object sender, EventArgs e)
         {
             CommandDropDown dropDown = (CommandDropDown)sender;
+            _log.Log($"Attempting to modify parameter {dropDown.ParameterIndex} to chibi {dropDown.SelectedKey} in {dropDown.Command.Index} in file {_script.Name}...");
             ((ChibiScriptParameter)dropDown.Command.Parameters[dropDown.ParameterIndex]).Chibi =
                 (ChibiItem)_project.Items.First(i => i.Name == dropDown.SelectedKey);
             _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(dropDown.Command.Section)]
@@ -692,6 +693,7 @@ namespace SerialLoops.Editors
         private void SpriteDropDown_SelectedKeyChanged(object sender, EventArgs e)
         {
             CommandDropDown dropDown = (CommandDropDown)sender;
+            _log.Log($"Attempting to modify parameter {dropDown.ParameterIndex} to sprite {dropDown.SelectedKey} in {dropDown.Command.Index} in file {_script.Name}...");
             ((SpriteScriptParameter)dropDown.Command.Parameters[dropDown.ParameterIndex]).Sprite =
                 (CharacterSpriteItem)_project.Items.First(i => i.Name == dropDown.SelectedKey);
             _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(dropDown.Command.Section)]

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -168,11 +168,12 @@ namespace SerialLoops
         {
             if (await Build.BuildIterative(OpenProject, CurrentConfig, _log))
             {
-                MessageBox.Show("Build succeeded!");
+                _log.Log("Build succeeded!");
+                MessageBox.Show("Build succeeded!", "Build Result", MessageBoxType.Information);
             }
             else
             {
-                MessageBox.Show("Build failed!");
+                _log.LogError("Build failed!");
             }
         }
 
@@ -180,11 +181,12 @@ namespace SerialLoops
         {
             if (await Build.BuildBase(OpenProject, CurrentConfig, _log))
             {
-                MessageBox.Show("Build succeeded!");
+                _log.Log("Build succeeded!");
+                MessageBox.Show("Build succeeded!", "Build Result", MessageBoxType.Information);
             }
             else
             {
-                MessageBox.Show("Build failed!");
+                _log.LogError("Build failed!");
             }
         }
 

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -166,27 +166,33 @@ namespace SerialLoops
 
         private async void BuildIterativeProject_Executed(object sender, EventArgs e)
         {
-            if (await Build.BuildIterative(OpenProject, CurrentConfig, _log))
+            if (OpenProject is not null)
             {
-                _log.Log("Build succeeded!");
-                MessageBox.Show("Build succeeded!", "Build Result", MessageBoxType.Information);
-            }
-            else
-            {
-                _log.LogError("Build failed!");
+                if (await Build.BuildIterative(OpenProject, CurrentConfig, _log))
+                {
+                    _log.Log("Build succeeded!");
+                    MessageBox.Show("Build succeeded!", "Build Result", MessageBoxType.Information);
+                }
+                else
+                {
+                    _log.LogError("Build failed!");
+                }
             }
         }
 
         private async void BuildBaseProject_Executed(object sender, EventArgs e)
         {
-            if (await Build.BuildBase(OpenProject, CurrentConfig, _log))
+            if (OpenProject is not null)
             {
-                _log.Log("Build succeeded!");
-                MessageBox.Show("Build succeeded!", "Build Result", MessageBoxType.Information);
-            }
-            else
-            {
-                _log.LogError("Build failed!");
+                if (await Build.BuildBase(OpenProject, CurrentConfig, _log))
+                {
+                    _log.Log("Build succeeded!");
+                    MessageBox.Show("Build succeeded!", "Build Result", MessageBoxType.Information);
+                }
+                else
+                {
+                    _log.LogError("Build failed!");
+                }
             }
         }
 

--- a/src/SerialLoops/ProjectCreationDialog.eto.cs
+++ b/src/SerialLoops/ProjectCreationDialog.eto.cs
@@ -153,11 +153,11 @@ namespace SerialLoops
         {
             if (_romPath.Text == NO_ROM_TEXT)
             {
-                MessageBox.Show("Please select a ROM before creating the project.");
+                MessageBox.Show("Please select a ROM before creating the project.", "Project Creation Warning", MessageBoxType.Warning);
             }
             else if (string.IsNullOrWhiteSpace(_nameBox.Text))
             {
-                MessageBox.Show("Please choose a project name before creating the project.");
+                MessageBox.Show("Please choose a project name before creating the project.", "Project Creation Warning", MessageBoxType.Warning);
             }
             else
             {
@@ -165,7 +165,7 @@ namespace SerialLoops
                 bool includeFontHack = false;
                 if (NewProject.LangCode != "ja")
                 {
-                    if (MessageBox.Show("Would you like to install the font hack? If you are using a translated base ROM, select no.", MessageBoxButtons.YesNo, MessageBoxType.Question, MessageBoxDefaultButton.Yes) == DialogResult.Yes)
+                    if (MessageBox.Show("Would you like to install the font hack? If you are using a translated base ROM, select no.", "Project Creation", MessageBoxButtons.YesNo, MessageBoxType.Question, MessageBoxDefaultButton.Yes) == DialogResult.Yes)
                     {
                         includeFontHack = true;
                     }

--- a/src/SerialLoops/SearchDialog.eto.cs
+++ b/src/SerialLoops/SearchDialog.eto.cs
@@ -58,6 +58,8 @@ namespace SerialLoops
                     _results
                 }
             };
+
+            _searchInput.Focus();
         }
 
         private void SearchInput_OnTextChanged(object sender, EventArgs e)

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Eto.Forms/2.7.3">
+﻿<Project Sdk="Eto.Forms/2.7.2-ci-20230201.4059880747">
 
   <!--
     Set the BuildPlatform property to the Eto platform you wish to build for.

--- a/src/SerialLoops/Utility/LoopyLogger.cs
+++ b/src/SerialLoops/Utility/LoopyLogger.cs
@@ -28,7 +28,7 @@ namespace SerialLoops.Utility
 
         public void LogError(string message, bool lookForWarnings = false)
         {
-            MessageBox.Show($"ERROR: {message}", MessageBoxType.Error);
+            MessageBox.Show($"ERROR: {message}", "Error", MessageBoxType.Error);
             _writer.WriteLine($"{DateTimeOffset.Now} - ERROR: {message}");
             _writer.Flush();
         }

--- a/src/SerialLoops/Utility/LoopyLogger.cs
+++ b/src/SerialLoops/Utility/LoopyLogger.cs
@@ -1,23 +1,42 @@
 ﻿using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
+using System;
+using System.IO;
 
 namespace SerialLoops.Utility
 {
     public class LoopyLogger : ILogger
     {
+        public static string LogLocation = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "log");
+        private StreamWriter _writer;
+
+        public LoopyLogger()
+        {
+            if (!Directory.Exists(LogLocation))
+            {
+                Directory.CreateDirectory(LogLocation);
+            }
+
+            _writer = File.AppendText(Path.Combine(LogLocation, $"SerialLoops.log"));
+        }
+
         public void Log(string message)
         {
-            // do nothing for now
+            _writer.WriteLine($"{DateTimeOffset.Now} - {message}");
+            _writer.Flush();
         }
 
         public void LogError(string message, bool lookForWarnings = false)
         {
             MessageBox.Show($"ERROR: {message}", MessageBoxType.Error);
+            _writer.WriteLine($"{DateTimeOffset.Now} - ERROR: {message}");
+            _writer.Flush();
         }
 
         public void LogWarning(string message, bool lookForErrors = false)
         {
-            // do nothing for now
+            _writer.WriteLine($"{DateTimeOffset.Now} - WARNING: {message}");
+            _writer.Flush();
         }
     }
 }


### PR DESCRIPTION
* Fixes a bug on Unix-systems where the specified default path for devkitARM didn't start at root
* Updates to the latest CI version of Eto to fix a bug in Gtk (Linux) with TreeGridView display that was causing crashes
* Fixes a bug where you could try to build without having a loaded project (lol)
* Cleans up the message box titles so they don't all display "Error" as their title on WPF
* Adds a ton of logging to places that needed it