### PR TITLE
Fixup script editor bugs

### DIFF
--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -63,6 +63,10 @@ namespace SerialLoops.Lib.Items
                             .Select(s => new ScriptSectionEdge() { Source = section, Target = s }));
                         @continue = true;
                     }
+                    else if (command.Verb == CommandVerb.NEXT_SCENE)
+                    {
+                        @continue = true;
+                    }
                 }
                 if (@continue)
                 {

--- a/src/SerialLoops.Lib/Script/ScriptCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptCommand.cs
@@ -272,16 +272,16 @@ namespace SerialLoops.Lib.Script
                         switch (i)
                         {
                             case 0:
-                                parameters.Add(new OptionScriptParameter("Option 1", eventFile.ChoicesSection.Objects[parameter + 1]));
+                                parameters.Add(new OptionScriptParameter("Option 1", eventFile.ChoicesSection.Objects[parameter]));
                                 break;
                             case 1:
-                                parameters.Add(new OptionScriptParameter("Option 2", eventFile.ChoicesSection.Objects[parameter + 1]));
+                                parameters.Add(new OptionScriptParameter("Option 2", eventFile.ChoicesSection.Objects[parameter]));
                                 break;
                             case 2:
-                                parameters.Add(new OptionScriptParameter("Option 3", eventFile.ChoicesSection.Objects[parameter + 1]));
+                                parameters.Add(new OptionScriptParameter("Option 3", eventFile.ChoicesSection.Objects[parameter]));
                                 break;
                             case 3:
-                                parameters.Add(new OptionScriptParameter("Option 4", eventFile.ChoicesSection.Objects[parameter + 1]));
+                                parameters.Add(new OptionScriptParameter("Option 4", eventFile.ChoicesSection.Objects[parameter]));
                                 break;
                             case 4:
                                 parameters.Add(new ShortScriptParameter("unknown08", parameter));


### PR DESCRIPTION
Fix up a couple of minor script editor bugs:

* Fixes an issue where I was messing up the option indices for the `SELECT` command
* Fixes an issue with the command graph creation that didn't properly account for the `NEXT_SCENE` command.