### PR TITLE
Progress tracking on loading item tabs

### DIFF
--- a/src/SerialLoops/Controls/SoundPlayerPanel.cs
+++ b/src/SerialLoops/Controls/SoundPlayerPanel.cs
@@ -15,16 +15,20 @@ namespace SerialLoops.Controls
         private MediaPlayer _player;
         private Button _playPauseButton;
 
-        public SoundPlayerPanel(IWaveProvider sound, ILogger log)
+        public SoundPlayerPanel(IWaveProvider sound, ILogger log, IProgressTracker tracker)
         {
             _log = log;
             _sound = sound;
 
+            tracker.Focus("Copying Audio Stream", 1);
             MemoryStream memoryStream = new();
             WaveProviderStream waveStream = new(_sound);
             WaveFileWriter writer = new(memoryStream, _sound.WaveFormat);
             waveStream.CopyTo(writer);
             memoryStream.Position = 0;
+            tracker.Loaded++;
+
+            tracker.Focus("Preparing Player", 1);
             LibVLC libVlc;
             try
             {
@@ -38,6 +42,7 @@ namespace SerialLoops.Controls
             StreamMediaInput mediaInput = new(memoryStream);
             Media media = new(libVlc, mediaInput);
             _player = new(media);
+            tracker.Loaded++;
 
             InitializeComponent();
         }

--- a/src/SerialLoops/Editors/BackgroundEditor.cs
+++ b/src/SerialLoops/Editors/BackgroundEditor.cs
@@ -1,6 +1,7 @@
 ﻿using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using SerialLoops.Utility;
 
 namespace SerialLoops.Editors
@@ -9,7 +10,7 @@ namespace SerialLoops.Editors
     {
         private BackgroundItem _bg;
 
-        public BackgroundEditor(BackgroundItem item, ILogger log) : base(item, log)
+        public BackgroundEditor(BackgroundItem item, ILogger log, IProgressTracker tracker) : base(item, log, tracker)
         {
         }
 

--- a/src/SerialLoops/Editors/BackgroundMusicEditor.cs
+++ b/src/SerialLoops/Editors/BackgroundMusicEditor.cs
@@ -3,6 +3,7 @@ using HaruhiChokuretsuLib.Audio;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Controls;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using System;
 using System.IO;
 
@@ -13,14 +14,15 @@ namespace SerialLoops.Editors
         private BackgroundMusicItem _bgm;
         public SoundPlayerPanel BgmPlayer { get; set; }
 
-        public BackgroundMusicEditor(BackgroundMusicItem item, ILogger log) : base(item, log)
+        public BackgroundMusicEditor(BackgroundMusicItem item, ILogger log, IProgressTracker tracker) : base(item, log, tracker)
         {
         }
 
         public override Container GetEditorPanel()
         {
             _bgm = (BackgroundMusicItem)Description;
-
+            
+            _tracker.Focus("BGM ADX data", 1);
             byte[] adxBytes = Array.Empty<byte>();
             try
             {
@@ -37,9 +39,10 @@ namespace SerialLoops.Editors
                     _log.LogError($"Failed to load BGM file {_bgm.BgmFile}: file invalid.");
                 }
             }
+            _tracker.Loaded++;
 
             AdxWaveProvider waveProvider = new(new AdxDecoder(adxBytes, _log));
-            BgmPlayer = new(waveProvider, _log);
+            BgmPlayer = new(waveProvider, _log, _tracker);
             
             return new TableLayout(new TableRow(new StackLayout
             {

--- a/src/SerialLoops/Editors/CharacterSpriteEditor.cs
+++ b/src/SerialLoops/Editors/CharacterSpriteEditor.cs
@@ -2,6 +2,7 @@
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using SerialLoops.Utility;
 
 namespace SerialLoops.Editors
@@ -11,7 +12,7 @@ namespace SerialLoops.Editors
         private CharacterSpriteItem _sprite;
         private AnimatedImage _animatedImage;
 
-        public CharacterSpriteEditor(CharacterSpriteItem item, Project project, ILogger log) : base(item, log, project)
+        public CharacterSpriteEditor(CharacterSpriteItem item, Project project, ILogger log, IProgressTracker tracker) : base(item, log, tracker, project)
         {
         }
 

--- a/src/SerialLoops/Editors/ChibiEditor.cs
+++ b/src/SerialLoops/Editors/ChibiEditor.cs
@@ -1,6 +1,7 @@
 ﻿using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using SerialLoops.Utility;
 using System;
 using System.Collections.Generic;
@@ -18,7 +19,7 @@ namespace SerialLoops.Editors
         private AnimatedImage _animatedImage;
         private StackLayout _framesStack;
 
-        public ChibiEditor(ChibiItem chibi, ILogger log) : base(chibi, log)
+        public ChibiEditor(ChibiItem chibi, ILogger log, IProgressTracker tracker) : base(chibi, log, tracker)
         {
         }
 

--- a/src/SerialLoops/Editors/Editor.cs
+++ b/src/SerialLoops/Editors/Editor.cs
@@ -3,6 +3,7 @@ using HaruhiChokuretsuLib.Util;
 using SerialLoops.Controls;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using SerialLoops.Utility;
 
 namespace SerialLoops.Editors
@@ -10,16 +11,18 @@ namespace SerialLoops.Editors
     public abstract class Editor : DocumentPage
     {
         protected ILogger _log;
+        protected IProgressTracker _tracker;
         protected Project _project;
         protected EditorTabsPanel _tabs;
         public ItemDescription Description { get; private set; }
 
-        public Editor(ItemDescription description, ILogger log, Project project = null, EditorTabsPanel tabs = null)
+        public Editor(ItemDescription description, ILogger log, IProgressTracker tracker, Project project = null, EditorTabsPanel tabs = null)
         {
             Description = description;
             _project = project;
             _tabs = tabs;
             _log = log;
+            _tracker = tracker;
             InitializeComponent();
         }
 

--- a/src/SerialLoops/Editors/MapEditor.cs
+++ b/src/SerialLoops/Editors/MapEditor.cs
@@ -1,6 +1,7 @@
 ﻿using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 
 namespace SerialLoops.Editors
 {
@@ -8,7 +9,7 @@ namespace SerialLoops.Editors
     {
         private MapItem _map;
 
-        public MapEditor(MapItem map, ILogger log) : base(map, log)
+        public MapEditor(MapItem map, ILogger log, IProgressTracker tracker) : base(map, log, tracker)
         {
         }
 

--- a/src/SerialLoops/Editors/PuzzleEditor.cs
+++ b/src/SerialLoops/Editors/PuzzleEditor.cs
@@ -2,6 +2,7 @@
 using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using SerialLoops.Utility;
 using System.Linq;
 
@@ -11,7 +12,7 @@ namespace SerialLoops.Editors
     {
         private PuzzleItem _puzzle;
 
-        public PuzzleEditor(PuzzleItem item, ILogger log) : base(item, log)
+        public PuzzleEditor(PuzzleItem item, ILogger log, IProgressTracker tracker) : base(item, log, tracker)
         {
         }
 

--- a/src/SerialLoops/Editors/ScenarioEditor.cs
+++ b/src/SerialLoops/Editors/ScenarioEditor.cs
@@ -5,6 +5,7 @@ using HaruhiChokuretsuLib.Util;
 using SerialLoops.Controls;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace SerialLoops.Editors
     {
         private ScenarioItem _scenario;
 
-        public ScenarioEditor(ScenarioItem item, ILogger log, Project project, EditorTabsPanel tabs) : base(item, log, project, tabs)
+        public ScenarioEditor(ScenarioItem item, ILogger log, IProgressTracker tracker, Project project, EditorTabsPanel tabs) : base(item, log, tracker, project, tabs)
         {
         }
 

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -8,6 +8,7 @@ using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Script;
 using SerialLoops.Lib.Script.Parameters;
+using SerialLoops.Lib.Util;
 using SerialLoops.Utility;
 using SkiaSharp;
 using System;
@@ -27,7 +28,7 @@ namespace SerialLoops.Editors
         private StackLayout _editorControls = new();
         private ScriptCommandListPanel _commandsPanel;
 
-        public ScriptEditor(ScriptItem item, Project project, ILogger log, EditorTabsPanel tabs) : base(item, log, project, tabs)
+        public ScriptEditor(ScriptItem item, Project project, ILogger log, IProgressTracker tracker, EditorTabsPanel tabs) : base(item, log, tracker, project, tabs)
         {
         }
 

--- a/src/SerialLoops/Editors/VoicedLineEditor.cs
+++ b/src/SerialLoops/Editors/VoicedLineEditor.cs
@@ -3,6 +3,7 @@ using HaruhiChokuretsuLib.Audio;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Controls;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
 using System;
 using System.IO;
 
@@ -13,7 +14,7 @@ namespace SerialLoops.Editors
         private VoicedLineItem _vce;
         public SoundPlayerPanel VcePlayer { get; set; }
 
-        public VoicedLineEditor(VoicedLineItem vce, ILogger log) : base(vce, log)
+        public VoicedLineEditor(VoicedLineItem vce, ILogger log, IProgressTracker tracker) : base(vce, log, tracker)
         {
         }
 
@@ -51,7 +52,7 @@ namespace SerialLoops.Editors
             }
 
             AdxWaveProvider waveProvider = new(decoder);
-            VcePlayer = new(waveProvider, _log);
+            VcePlayer = new(waveProvider, _log, _tracker);
 
             return new TableLayout(new TableRow(new StackLayout
             {


### PR DESCRIPTION
This works, but is flawed: Because an `Editor` extends `DocumentPanel`, we _must_ instantiate it on the UI thread. Given that all logic for loading items is tangled up in the actual constructors of control objects, the result is that the progress bar is only able to update between breaks in main thread processing block calls. In the future, this may be worth another refactor. 

It does work, though, at the very least, and means it doesn't look like the application has crashed every time you load an audio item -- it's just that the bar isn't able to be that accurate when loading BGMs, for instance.

![image](https://user-images.githubusercontent.com/31187453/218548588-55a13e4d-17d7-4e6a-99f4-e307cfa2dfa3.png)
