### PR TITLE
Fixup mac context menu crash

### DIFF
--- a/src/SerialLoops/Controls/EditorTabsPanel.cs
+++ b/src/SerialLoops/Controls/EditorTabsPanel.cs
@@ -49,7 +49,14 @@ namespace SerialLoops.Controls
 
             // Open a new editor for the item -- This is where the item can be loaded from the project files
             DocumentPage newPage = CreateTab(item, _project, log);
-            newPage.ContextMenu = null;
+            if (Platform.IsMac)
+            {
+                newPage.ContextMenu = new();
+            }
+            else
+            {
+                newPage.ContextMenu = null;
+            }
 
             Tabs.Pages.Add(newPage);
             Tabs.SelectedPage = newPage;


### PR DESCRIPTION
This fixes the context menu crash on macOS. On Linux and Windows, null is fine, but it crashes on Mac.