### PR TITLE
Add starting chibi selector to script editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The following prerequisites need to be installed in order to use Serial Loops:
 * The [.NET 6.0 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 * [devkitARM](https://devkitpro.org/wiki/Getting_Started).
     - Using the Windows graphical installer, you can simply select the devkitARM (Nintendo DS) workloads
-    - On macOS and Linux, run `sudo skp-pacman -S nds-dev` from the terminal after installing the devkitPro pacman distribution.
+    - On macOS and Linux, run `sudo dkp-pacman -S nds-dev` from the terminal after installing the devkitPro pacman distribution.
 
 Additionally, on Linux, you will need to install OpenAL. On Ubuntu/Debian (which are the distros we test on), it can be installed in a single command:
 ```

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.18.3" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.20.1" />
     <PackageReference Include="NitroPacker.Core" Version="2.0.1" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />
   </ItemGroup>

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -15,7 +15,6 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -99,6 +99,7 @@ namespace SerialLoops.Editors
         {
             TabControl propertiesTabs = new();
 
+            // Starting Chibis Properties
             List<ChibiItem> allChibis = _project.Items.Where(i => i.Type == ItemDescription.ItemType.Chibi).Cast<ChibiItem>().ToList();
             List <ChibiItem> usedChibis =  allChibis.Where(c => _script.Event.StartingChibisSection.Objects
                 .Select(sc => sc.ChibiIndex).ToList().Contains((short)c.ChibiIndex)).Cast<ChibiItem>().ToList();

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.7.2-ci-20230201.4059880747" />
-    <PackageReference Include="System.Text.Json" Version="7.0.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69772986/222531426-244e88e4-be98-48e7-bbf4-c1c953122d29.png)
![image](https://user-images.githubusercontent.com/69772986/222531482-582398f5-7f4a-4a4a-9587-550ba5350b9e.png)
![image](https://user-images.githubusercontent.com/69772986/222531583-167609cf-a363-4e7a-8fe2-10ca85180bac.png)

I've changed my mind on the interactable objects/starting chibis items -- I think it actually might make sense to wait on having map items set up. So this just sets up the starting chibis editor to the script editor. Works! Yay!