### PR TITLE
Initial map items/editors work, add map characters tab to script editor

### DIFF
--- a/src/SerialLoops.Lib/Items/ChibiItem.cs
+++ b/src/SerialLoops.Lib/Items/ChibiItem.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace SerialLoops.Lib.Items
 {
-    public class ChibiItem : Item
+    public class ChibiItem : Item, IPreviewableGraphic
     {
         public Chibi Chibi { get; set; }
         public int ChibiIndex { get; set; }
@@ -58,6 +58,11 @@ namespace SerialLoops.Lib.Items
                 .Where(t => t.c.Parameters[0] == ChibiIndex).ToList();
 
             ScriptUses = list.ToArray();
+        }
+
+        SKBitmap IPreviewableGraphic.GetPreview(Project project)
+        {
+            return ChibiAnimations.First().Value.First().Frame;
         }
     }
 

--- a/src/SerialLoops.Lib/Items/IPreviewableGraphic.cs
+++ b/src/SerialLoops.Lib/Items/IPreviewableGraphic.cs
@@ -18,8 +18,8 @@ namespace SerialLoops.Lib.Items
     
     public class NonePreviewableGraphic : ItemDescription, IPreviewableGraphic
     {
-        public static NonePreviewableGraphic BACKGROUND = new(ItemType.Background);
-        public static NonePreviewableGraphic CHARACTER_SPRITE = new(ItemType.Character_Sprite);
+        public static readonly NonePreviewableGraphic BACKGROUND = new(ItemType.Background);
+        public static readonly NonePreviewableGraphic CHARACTER_SPRITE = new(ItemType.Character_Sprite);
 
         private NonePreviewableGraphic(ItemType type) : base("NONE", type, "NONE") { }
 

--- a/src/SerialLoops.Lib/Items/MapItem.cs
+++ b/src/SerialLoops.Lib/Items/MapItem.cs
@@ -1,12 +1,8 @@
 ﻿using HaruhiChokuretsuLib.Archive;
 using HaruhiChokuretsuLib.Archive.Data;
-using HaruhiChokuretsuLib.Archive.Event;
 using HaruhiChokuretsuLib.Archive.Graphics;
-using System;
-using System.Collections.Generic;
+using SkiaSharp;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SerialLoops.Lib.Items
 {
@@ -24,9 +20,27 @@ namespace SerialLoops.Lib.Items
             QmapIndex = qmapIndex;
         }
 
+        public SKBitmap GetMapWithGrid(ArchiveFile<GraphicsFile> grp)
+        {
+            SKBitmap map;
+            if (Map.Settings.BackgroundLayoutStartIndex > 0)
+            {
+                map = Map.GetMapImages(grp, 0, Map.Settings.BackgroundLayoutStartIndex);
+            }
+            else
+            {
+                map = Map.GetMapImages(grp, 0, grp.Files.First(f => f.Index == Map.Settings.LayoutFileIndex).LayoutEntries.Count);
+            }
+            SKBitmap mapWithGrid = new(map.Width, map.Height);
+            SKCanvas canvas = new(mapWithGrid);
+            canvas.DrawBitmap(map, new SKPoint(0, 0));
+
+            canvas.Flush();
+            return mapWithGrid;
+        }
+
         public override void Refresh(Project project)
         {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/SerialLoops.Lib/Items/MapItem.cs
+++ b/src/SerialLoops.Lib/Items/MapItem.cs
@@ -20,7 +20,13 @@ namespace SerialLoops.Lib.Items
             QmapIndex = qmapIndex;
         }
 
-        public SKBitmap GetMapWithGrid(ArchiveFile<GraphicsFile> grp)
+        public SKPoint GetOrigin(ArchiveFile<GraphicsFile> grp)
+        {
+            GraphicsFile layout = grp.Files.First(f => f.Index == Map.Settings.LayoutFileIndex);
+            return new SKPoint(layout.LayoutEntries[Map.Settings.LayoutSizeDefinitionIndex].ScreenX, layout.LayoutEntries[Map.Settings.LayoutSizeDefinitionIndex].ScreenY);
+        }
+
+        public SKBitmap GetMapImage(ArchiveFile<GraphicsFile> grp, bool displayPathingMap)
         {
             SKBitmap map;
             if (Map.Settings.BackgroundLayoutStartIndex > 0)
@@ -35,8 +41,62 @@ namespace SerialLoops.Lib.Items
             SKCanvas canvas = new(mapWithGrid);
             canvas.DrawBitmap(map, new SKPoint(0, 0));
 
+            if (displayPathingMap)
+            {
+                SKPoint gridZero = GetOrigin(grp);
+
+                if (Map.Settings.SlgMode)
+                {
+                    for (int y = 0; y < Map.PathingMap.Length; y++)
+                    {
+                        for (int x = 0; x < Map.PathingMap[y].Length; x++)
+                        {
+                            SKPoint origin = new(gridZero.X - x * 32 + y * 32, gridZero.Y + x * 16 + y * 16);
+                            SKPath diamond = new();
+                            diamond.AddPoly(new SKPoint[]
+                            {
+                                origin,
+                                new SKPoint(origin.X - 32, origin.Y + 16),
+                                new SKPoint(origin.X, origin.Y + 32),
+                                new SKPoint(origin.X + 32, origin.Y + 16)
+                            });
+                            canvas.DrawRegion(new SKRegion(diamond), GetPathingCellPaint(x, y));
+                        }
+                    }
+                }
+                else
+                {
+                    for (int x = 0; x < Map.PathingMap.Length; x++)
+                    {
+                        for (int y = 0; y < Map.PathingMap[x].Length; y++)
+                        {
+                            SKPoint origin = new(gridZero.X - x * 16 + y * 16, gridZero.Y + x * 8 + y * 8);
+                            SKPath diamond = new();
+                            diamond.AddPoly(new SKPoint[]
+                            {
+                                origin,
+                                new SKPoint(origin.X - 16, origin.Y + 8),
+                                new SKPoint(origin.X, origin.Y + 16),
+                                new SKPoint(origin.X + 16, origin.Y + 8),
+                            });
+                            canvas.DrawRegion(new SKRegion(diamond), GetPathingCellPaint(x, y));
+                        }
+                    }
+                }
+            }
+
             canvas.Flush();
             return mapWithGrid;
+        }
+
+        private SKPaint GetPathingCellPaint(int x, int y)
+        {
+            return Map.PathingMap[x][y] switch
+            {
+                1 => new() { Color = new SKColor(0, 128, 0, 186) }, // walkable
+                2 => new() { Color = new SKColor(0, 200, 200, 186) }, // spawnable
+                _ => new() { Color = new SKColor(255, 0, 0, 186) }, // unwalkable
+            };
         }
 
         public override void Refresh(Project project)

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.20.1" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.20.2" />
     <PackageReference Include="NitroPacker.Core" Version="2.0.1" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />
   </ItemGroup>

--- a/src/SerialLoops/Controls/EditorTabsPanel.cs
+++ b/src/SerialLoops/Controls/EditorTabsPanel.cs
@@ -80,7 +80,7 @@ namespace SerialLoops.Controls
                 case ItemDescription.ItemType.Group_Selection:
                     return new GroupSelectionEditor((GroupSelectionItem)project.Items.First(i => i.Name == item.Name), log, project, this);
                 case ItemDescription.ItemType.Map:
-                    return new MapEditor((MapItem)project.Items.First(i => i.Name == item.Name), log);
+                    return new MapEditor((MapItem)project.Items.First(i => i.Name == item.Name), project, log);
                 case ItemDescription.ItemType.Puzzle:
                     return new PuzzleEditor((PuzzleItem)project.Items.First(i => i.Name == item.Name), project, this, log);
                 case ItemDescription.ItemType.Scenario:

--- a/src/SerialLoops/Controls/ItemEditorControls.cs
+++ b/src/SerialLoops/Controls/ItemEditorControls.cs
@@ -1,4 +1,5 @@
-﻿using Eto.Forms;
+﻿using Eto.Drawing;
+using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
@@ -94,6 +95,7 @@ namespace SerialLoops.Controls
     public class ChibiStackLayout : StackLayout
     {
         public int ChibiIndex { get; set; }
+        public Size ChibiSize { get; set; }
     }
 
     public class CommandGraphicSelectionButton : Panel

--- a/src/SerialLoops/Controls/ItemEditorControls.cs
+++ b/src/SerialLoops/Controls/ItemEditorControls.cs
@@ -91,6 +91,11 @@ namespace SerialLoops.Controls
         }
     }
 
+    public class ChibiStackLayout : StackLayout
+    {
+        public int ChibiIndex { get; set; }
+    }
+
     public class CommandGraphicSelectionButton : Panel
     {
         private readonly EditorTabsPanel _editorTabs;

--- a/src/SerialLoops/Controls/ItemEditorControls.cs
+++ b/src/SerialLoops/Controls/ItemEditorControls.cs
@@ -103,11 +103,22 @@ namespace SerialLoops.Controls
         private readonly EditorTabsPanel _editorTabs;
         private readonly ILogger _log;
         public IPreviewableGraphic Selected { get; private set; }
+        public int SelectedIndex { get; set; }
         public ScriptItemCommand Command { get; set; }
         public int ParameterIndex { get; set; }
         public Command SelectedChanged { get; }
         public List<IPreviewableGraphic> Items { get; }
         public Project Project { get; set; }
+
+        public CommandGraphicSelectionButton(EditorTabsPanel editorTabs, ILogger log)
+        {
+            _editorTabs = editorTabs;
+            _log = log;
+
+            SelectedChanged = new();
+            Items = new List<IPreviewableGraphic>();
+            InitializeComponent();
+        }
 
         public CommandGraphicSelectionButton(IPreviewableGraphic selected, EditorTabsPanel editorTabs, ILogger log)
         {
@@ -137,7 +148,7 @@ namespace SerialLoops.Controls
                 Items =
                 {
                     button,
-                    ControlGenerator.GetFileLink(((ItemDescription)Selected), _editorTabs, _log)
+                    ControlGenerator.GetFileLink((ItemDescription)Selected, _editorTabs, _log)
                 }
             };
         }
@@ -148,6 +159,61 @@ namespace SerialLoops.Controls
             IPreviewableGraphic description = dialog.ShowModal(this);
             if (description == null) return;
             Selected = description;
+            SelectedIndex = Items.IndexOf(Selected);
+            SelectedChanged?.Execute();
+            Content = GetButtonPanel();
+        }
+    }
+
+    public class GraphicSelectionButton : Panel
+    {
+        private readonly ILogger _log;
+        public IPreviewableGraphic Selected { get; private set; }
+        public int SelectedIndex { get; set; }
+        public Command SelectedChanged { get; }
+        public List<IPreviewableGraphic> Items { get; }
+        public Project Project { get; set; }
+
+        private string _text;
+
+        public GraphicSelectionButton(string text, ILogger log)
+        {
+            _log = log;
+            _text = text;
+
+            SelectedChanged = new();
+            Items = new List<IPreviewableGraphic>();
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            Content = GetButtonPanel();
+        }
+
+        private StackLayout GetButtonPanel()
+        {
+            Button button = new() { Text = _text };
+            button.Click += GraphicSelectionButton_Click;
+
+            return new StackLayout
+            {
+                Spacing = 10,
+                Orientation = Orientation.Horizontal,
+                Items =
+                {
+                    button
+                }
+            };
+        }
+
+        private void GraphicSelectionButton_Click(object sender, EventArgs e)
+        {
+            GraphicSelectionDialog dialog = new(new(Items), Selected, Project, _log);
+            IPreviewableGraphic description = dialog.ShowModal(this);
+            if (description == null) return;
+            Selected = description;
+            SelectedIndex = Items.IndexOf(Selected);
             SelectedChanged?.Execute();
             Content = GetButtonPanel();
         }

--- a/src/SerialLoops/Controls/ItemEditorControls.cs
+++ b/src/SerialLoops/Controls/ItemEditorControls.cs
@@ -1,10 +1,10 @@
-﻿using Eto.Drawing;
-using Eto.Forms;
+﻿using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Script;
 using SerialLoops.Utility;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 
@@ -95,7 +95,7 @@ namespace SerialLoops.Controls
     public class ChibiStackLayout : StackLayout
     {
         public int ChibiIndex { get; set; }
-        public Size ChibiSize { get; set; }
+        public SKBitmap ChibiBitmap { get; set; }
     }
 
     public class CommandGraphicSelectionButton : Panel

--- a/src/SerialLoops/Editors/MapEditor.cs
+++ b/src/SerialLoops/Editors/MapEditor.cs
@@ -1,6 +1,8 @@
 ﻿using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
+using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
+using SerialLoops.Utility;
 
 namespace SerialLoops.Editors
 {
@@ -8,19 +10,20 @@ namespace SerialLoops.Editors
     {
         private MapItem _map;
 
-        public MapEditor(MapItem map, ILogger log) : base(map, log)
+        public MapEditor(MapItem map, Project project, ILogger log) : base(map, log, project)
         {
         }
 
         public override Container GetEditorPanel()
         {
             _map = (MapItem)Description;
+
             return new StackLayout
             {
                 Orientation = Orientation.Vertical,
                 Items =
                 {
-                    new Label { Text = "Map Editor..todo!" }
+                    new SKGuiImage(_map.GetMapWithGrid(_project.Grp))
                 }
             };
         }

--- a/src/SerialLoops/Editors/MapEditor.cs
+++ b/src/SerialLoops/Editors/MapEditor.cs
@@ -3,6 +3,7 @@ using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Utility;
+using System;
 
 namespace SerialLoops.Editors
 {
@@ -18,12 +19,27 @@ namespace SerialLoops.Editors
         {
             _map = (MapItem)Description;
 
+            StackLayout mapLayout = new()
+            {
+                Items =
+                {
+                    new SKGuiImage(_map.GetMapImage(_project.Grp, false)),
+                }
+            };
+
+            CheckBox drawPathingMapBox = new() { Text = "Draw Pathing Map", Checked = false };
+            drawPathingMapBox.CheckedChanged += (obj, args) =>
+            {
+                mapLayout.Content = new SKGuiImage(_map.GetMapImage(_project.Grp, drawPathingMapBox.Checked ?? true));
+            };
+
             return new StackLayout
             {
                 Orientation = Orientation.Vertical,
                 Items =
                 {
-                    new SKGuiImage(_map.GetMapWithGrid(_project.Grp))
+                    mapLayout,
+                    drawPathingMapBox,
                 }
             };
         }

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -276,8 +276,8 @@ namespace SerialLoops.Editors
                     = ((short)grid[newLocation].X, (short)grid[newLocation].Y);
                 mapLayout.Remove(sourceChibiLayout);
                 mapLayout.Add(sourceChibiLayout,
-                    ((int)gridZero.X - _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].Y * 16 + _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].X * 16 - sourceChibiLayout.ChibiSize.Width / 2) / 2,
-                    ((int)gridZero.Y + _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].X * 8 + _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].Y * 8 - sourceChibiLayout.ChibiSize.Height / 2 - 24) / 2);
+                    ((int)gridZero.X - _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].Y * 16 + _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].X * 16 - sourceChibiLayout.ChibiBitmap.Width / 2) / 2,
+                    ((int)gridZero.Y + _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].X * 8 + _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].Y * 8 - sourceChibiLayout.ChibiBitmap.Height / 2 - 24) / 2);
                 UpdateTabTitle(false);
             };
 
@@ -315,7 +315,7 @@ namespace SerialLoops.Editors
                         chibiIcon
                     },
                     ChibiIndex = i,
-                    ChibiSize = new(chibiBitmap.Width, chibiBitmap.Height),
+                    ChibiBitmap = new(chibiBitmap.Width, chibiBitmap.Height),
                 };
                 chibiLayout.MouseEnter += (o, args) =>
                 {

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -380,7 +380,7 @@ namespace SerialLoops.Editors
             {
                 _script.Event.MapCharactersSection = new() { Name = "MAPCHARACTERS" };
                 _script.Event.MapCharactersSection.Objects.Add(new()); // Blank map characters entry
-                parent.Content = GetStartingChibisLayout(parent);
+                parent.Content = GetMapCharactersLayout(parent);
                 UpdateTabTitle(false);
                 Application.Instance.Invoke(() => UpdatePreview());
             };

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -220,7 +220,7 @@ namespace SerialLoops.Editors
                 parent.Content = GetMapCharactersLayout(parent);
             };
 
-            Button removeButton = new() { Text = "Remove Map Characters" };
+            Button removeButton = new() { Text = "Remove Map Characters", AllowDrop = true };
             removeButton.Click += (o, args) =>
             {
                 _script.Event.MapCharactersSection = null;
@@ -268,14 +268,19 @@ namespace SerialLoops.Editors
                 Console.WriteLine("Hello");
             };
 
+            mapLayout.DragOver += (obj, args) =>
+            {
+                args.Effects = DragEffects.Move;
+            };
             mapLayout.DragDrop += (obj, args) =>
             {
                 ChibiStackLayout sourceChibiLayout = (ChibiStackLayout)args.Source;
                 PointF newLocation = grid.Keys.MinBy(p => p.Distance(args.Location));
                 mapLayout.Remove(sourceChibiLayout);
-                mapLayout.Add(sourceChibiLayout, new((int)newLocation.X, (int)newLocation.Y));
+                mapLayout.Add(sourceChibiLayout, new((int)newLocation.X - sourceChibiLayout.Width / 4, (int)newLocation.Y - sourceChibiLayout.Height / 4 - 12));
                 (_script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].X, _script.Event.MapCharactersSection.Objects[sourceChibiLayout.ChibiIndex].Y)
                     = ((short)grid[newLocation].X, (short)grid[newLocation].Y);
+                UpdateTabTitle(false);
             };
 
             StackLayout mapDetailsLayout = new()
@@ -315,7 +320,7 @@ namespace SerialLoops.Editors
                 };
                 chibiLayout.MouseEnter += (o, args) =>
                 {
-                    chibiLayout.BackgroundColor = Colors.SteelBlue;
+                    chibiLayout.BackgroundColor = Color.FromArgb(170, 170, 200, 128);
                 };
                 chibiLayout.MouseLeave += (o, args) =>
                 {
@@ -406,6 +411,16 @@ namespace SerialLoops.Editors
                 {
                     mapsDropdown,
                     mapAndDetailsLayout,
+                    new StackLayout
+                    {
+                        Orientation = Orientation.Horizontal,   
+                        Spacing = 5,
+                        Items =
+                        {
+                            refreshMapListButton,
+                            removeButton,
+                        }
+                    }
                 },
             };
         }
@@ -419,7 +434,6 @@ namespace SerialLoops.Editors
                 _script.Event.MapCharactersSection.Objects.Add(new()); // Blank map characters entry
                 parent.Content = GetMapCharactersLayout(parent);
                 UpdateTabTitle(false);
-                Application.Instance.Invoke(() => UpdatePreview());
             };
 
             return new StackLayout

--- a/src/SerialLoops/GraphicSelectionDialog.cs
+++ b/src/SerialLoops/GraphicSelectionDialog.cs
@@ -95,7 +95,7 @@ namespace SerialLoops
                                     _filter,
                                     _selector
                                 }
-                            }, 
+                            },
                             _preview
                         }
                     }),
@@ -141,7 +141,7 @@ namespace SerialLoops
                 {
                     new Label { Text = _selector.SelectedValue == null ? "No preview available" : ((ItemDescription)_selector.SelectedValue).Name },
                     new SKGuiImage(_selector.SelectedValue == null ? new SKBitmap(64, 64) : 
-                        ((IPreviewableGraphic) _selector.SelectedValue).GetPreview(_project, 250, 400)),
+                        ((IPreviewableGraphic) _selector.SelectedValue).GetPreview(_project, 250, 350)),
                     backgroundTypeLabel,
                 }
             };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69772986/222984690-cc040566-19af-4250-8c5c-6aa4f8cf36b1.png)
![image](https://user-images.githubusercontent.com/69772986/222984706-e69a64fb-5667-4ac0-8071-995608ab6c6d.png)

Adds map previews with pathing map overlay to the map editor as well as adding a "Map Characters" tab to the script editor which allows for editing the chibis, facing directions, and associated script blocks for the chibis on the map, as well as allowing chibis to be removed. You can also add new chibis and drag and drop them around the map.