### PR TITLE
Fixup mac chibi drag & drop bug

### DIFF
--- a/src/SerialLoops/Controls/EditorTabsPanel.cs
+++ b/src/SerialLoops/Controls/EditorTabsPanel.cs
@@ -3,7 +3,6 @@ using HaruhiChokuretsuLib.Util;
 using SerialLoops.Editors;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
-using System;
 using System.Linq;
 
 namespace SerialLoops.Controls

--- a/src/SerialLoops/Editors/MapEditor.cs
+++ b/src/SerialLoops/Editors/MapEditor.cs
@@ -3,7 +3,6 @@ using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Utility;
-using System;
 
 namespace SerialLoops.Editors
 {

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -14,12 +14,10 @@ using SerialLoops.Utility;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using static HaruhiChokuretsuLib.Archive.Data.QMapFile;
 
 namespace SerialLoops.Editors
 {
@@ -35,6 +33,7 @@ namespace SerialLoops.Editors
         private ScriptCommandListPanel _commandsPanel;
         private CancellationTokenSource _dialogueCancellation, _optionCancellation;
         private System.Timers.Timer _dialogueRefreshTimer;
+        private int _chibiHighlighted = -1;
 
         public ScriptEditor(ScriptItem item, Project project, ILogger log, EditorTabsPanel tabs) : base(item, log, project, tabs)
         {
@@ -360,23 +359,33 @@ namespace SerialLoops.Editors
             ChibiStackLayout chibiLayout = new()
             {
                 Items =
-                    {
-                        chibiIcon
-                    },
+                {
+                    chibiIcon
+                },
                 ChibiIndex = index,
                 ChibiBitmap = new(chibiBitmap.Width, chibiBitmap.Height),
             };
             chibiLayout.MouseEnter += (o, args) =>
             {
+                if (_chibiHighlighted >= 0)
+                {
+                    return;
+                }
+                _chibiHighlighted = chibiLayout.ChibiIndex;
                 chibiLayout.BackgroundColor = Color.FromArgb(170, 170, 200, 128);
             };
             chibiLayout.MouseLeave += (o, args) =>
             {
+                if (_chibiHighlighted != chibiLayout.ChibiIndex)
+                {
+                    return;
+                }
+                _chibiHighlighted = -1;
                 chibiLayout.BackgroundColor = Colors.Transparent;
             };
             chibiLayout.MouseMove += (o, args) =>
             {
-                if (args.Buttons != MouseButtons.Primary)
+                if (args.Buttons != MouseButtons.Primary || _chibiHighlighted != chibiLayout.ChibiIndex)
                 {
                     return;
                 }


### PR DESCRIPTION
Makes chibi drag/drop exclusive which prevents crashes on mac when two chibis were highlighted simultaneously.