### PR TITLE
Fix the LoopyLogger crashing

### DIFF
--- a/src/SerialLoops/Controls/ScriptCommandSectionTree.cs
+++ b/src/SerialLoops/Controls/ScriptCommandSectionTree.cs
@@ -1,4 +1,5 @@
-﻿using Eto.Drawing;
+﻿using Eto;
+using Eto.Drawing;
 using Eto.Forms;
 using HaruhiChokuretsuLib.Archive.Event;
 using SerialLoops.Lib.Script;
@@ -253,8 +254,21 @@ namespace SerialLoops.Controls
             }
             
             AddCommand?.Invoke(this, new(item.Command));
-            _treeView.DataStore = _treeView.DataStore;
-            _treeView.SelectedItem = item;
+
+            // https://github.com/haroohie-club/SerialLoops/issues/109
+            // In WPF, the selection of the tree item happens automatically, so doing it this way
+            // ends up doubling the selection it seems causing multiple invocations in case of an error
+            // which crashes the LoopyLogger. Wild, I know.
+            if (!Platform.Instance.IsWpf)
+            {
+                _treeView.DataStore = _treeView.DataStore;
+                _treeView.SelectedItem = item;
+            }
+            else
+            {
+                _treeView.SelectedItem = item;
+                _treeView.DataStore = _treeView.DataStore;
+            }
         }
 
         internal void AddSection(ScriptCommandSectionTreeItem section)
@@ -265,8 +279,21 @@ namespace SerialLoops.Controls
             section.Parent = rootNode;
 
             AddCommand?.Invoke(this, new(section.Text));
-            _treeView.DataStore = rootNode;
-            _treeView.SelectedItem = section;
+
+            // https://github.com/haroohie-club/SerialLoops/issues/109
+            // In WPF, the selection of the tree item happens automatically, so doing it this way
+            // ends up doubling the selection it seems causing multiple invocations in case of an error
+            // which crashes the LoopyLogger. Wild, I know.
+            if (!Platform.Instance.IsWpf)
+            {
+                _treeView.DataStore = rootNode;
+                _treeView.SelectedItem = section;
+            }
+            else
+            {
+                _treeView.SelectedItem = section;
+                _treeView.DataStore = rootNode;
+            }
         }
 
         public void SetContents(IEnumerable<ScriptCommandSectionEntry> topNodes, bool expanded)

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -97,7 +97,7 @@ namespace SerialLoops.Editors
                 Image = ControlGenerator.GetIcon("Add", _log),
                 ToolTip = "New Command",
                 Width = 22,
-                Enabled = treeGridView.SelectedCommandTreeItem is not null
+                Enabled = treeGridView.SelectedCommandTreeItem is not null,
             };
             _addCommandButton.Click += (sender, args) =>
             {
@@ -276,7 +276,7 @@ namespace SerialLoops.Editors
                 Image = ControlGenerator.GetIcon("Add_Section", _log),
                 ToolTip = "New Section",
                 Width = 22,
-                Enabled = true
+                Enabled = treeGridView.SelectedCommandTreeItem is not null,
             };
             _addSectionButton.Click += (sender, args) =>
             {
@@ -330,7 +330,7 @@ namespace SerialLoops.Editors
                 Image = ControlGenerator.GetIcon("Remove", _log),
                 ToolTip = "Remove Command/Section",
                 Width = 22,
-                Enabled = treeGridView.SelectedCommandTreeItem is not null
+                Enabled = treeGridView.SelectedCommandTreeItem is not null,
             };
             _deleteButton.Click += (sender, args) =>
             {
@@ -843,6 +843,7 @@ namespace SerialLoops.Editors
             _editorControls.Items.Clear();
 
             _addCommandButton.Enabled = true;
+            _addSectionButton.Enabled = true;
             _deleteButton.Enabled = true;
 
             // if we've selected a script section header


### PR DESCRIPTION
Fixes #109. Also disables the Add Section button if there is no selection in the tree grid view, fixing a crash on macOS.