### PR TITLE
Adjust build to run at 23:00UTC

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -190,18 +190,14 @@ stages:
           ${{ parameters.releaseNotes }}
 
           ## Installation Notes
-          On macOS, after dragging the app from the dmg into Applications, please run `xattr -cr /Applications/SerialLoops.Mac.app` from the Terminal in order to be able to run the app.
-          This is required because we currently don't codesign the application, meaning macOS will refuse to run it without explicit approval from you.
+          On macOS, after dragging the app from the dmg into Applications, please run `xattr -cr /Applications/SerialLoops.Mac.app` from the Terminal in order to be able to run the app. This is required because we currently don't codesign the application, meaning macOS will refuse to run it without explicit approval from you.
 
-          The `.deb` package can only be used on Debian-based systems (e.g. Ubuntu). Install it with `sudo dpkg -i SerialLoops-$(Version)_amd64.deb`. For other Linux distros, please use the
-          binaries packaged in the `.tar.gz` archive. Regardless of your distro, ensure you install the OpenAL binaries so audio playback works &ndash; on Ubuntu, this can be done with
-          `sudo apt install libopenal-dev`.
+          The `.deb` package can only be used on Debian-based systems (e.g. Ubuntu). Install it with `sudo dpkg -i SerialLoops-$(Version)_amd64.deb`. For other Linux distros, please use the binaries packaged in the `.tar.gz` archive. Regardless of your distro, ensure you install the OpenAL binaries so audio playback works &ndash; on Ubuntu, this can be done with `sudo apt install libopenal-dev`.
 
           Please ensure you have installed [devkitARM from devkitPro](https://devkitpro.org/wiki/Getting_Started) before using the program.
 
           ### Which macOS dmg should I choose?
-          If your Mac is newer, you will probably want the ARM dmg. If it is older, you will want the x64 one. If unsure, download the ARM one first and attempt to run it &ndash; it will throw
-          an error saying it can't be run on this computer if your computer is not able to run it. If that's the case, download the x64 one instead.
+          If your Mac is newer, you will probably want the ARM dmg. If it is older, you will want the x64 one. If unsure, download the ARM one first and attempt to run it &ndash; it will throw an error saying it can't be run on this computer if your computer is not able to run it. If that's the case, download the x64 one instead.
         ${{ if eq(parameters['version'], '') }}:
           isPreRelease: true
         ${{ if ne(parameters['version'], '') }}:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 0 * * *"
+- cron: "0 23 * * *"
   displayName: Nightly build
   branches:
     include:


### PR DESCRIPTION
The current  job conflicts with the Chokuretsu build job at 00:00 UTC. This will offset them by an hour.

Also, put all the release text on one line bc apparently it takes new lines more seriously than markdown does.