### PR TITLE
Change build number to fixup versioning

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -18,13 +18,14 @@ parameters:
   type: string
   default: 'Latest nightly build. **Note that this is likely to have bugs and we recommend you use a regular release instead!**'
 
+name: $(Year:yy).$(Date:MMdd).$(Rev:r)
 
 variables:
   - name: Version
     ${{ if ne(parameters['version'], '') }}:
       value: ${{ parameters.version }}
     ${{ if eq(parameters['version'], '') }}:
-      value: 0.2.$(Build.BuildNumber)
+      value: 0.$(Build.BuildNumber)
 
 stages:
 - stage: Build


### PR DESCRIPTION
Fixes an error in the pre-release builds with the semantic versioning being too high a number. This breaks out the build name a bit more which will make the version happier.