### PR TITLE
Fixup #182 (menus not populating on Linux)

### DIFF
--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -194,7 +194,7 @@ namespace SerialLoops
             };
 
             // Add project items to existing File menu
-            if (Menu.Items.FirstOrDefault(x => x.Text == "&File") is SubMenuItem fileMenu)
+            if (Menu.Items.FirstOrDefault(x => x.Text.Contains("File")) is SubMenuItem fileMenu)
             {
                 fileMenu.Items.AddRange(new[] { saveProjectCommand, projectSettingsCommand, migrateProjectCommand, exportPatchCommand, closeProjectCommand });
             }


### PR DESCRIPTION
Fixes #182. Issue was just that `Menu.Text` on Linux does not return the `&` as part of the text.