### PR TITLE
Add sprite and chibi GIF/sheet export

### DIFF
--- a/src/SerialLoops.Lib/Items/CharacterSpriteItem.cs
+++ b/src/SerialLoops.Lib/Items/CharacterSpriteItem.cs
@@ -1,6 +1,7 @@
 ﻿using HaruhiChokuretsuLib.Archive;
 using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Archive.Event;
+using HaruhiChokuretsuLib.Archive.Graphics;
 using HaruhiChokuretsuLib.Util;
 using SkiaSharp;
 using System.Collections.Generic;
@@ -26,14 +27,39 @@ namespace SerialLoops.Lib.Items
             PopulateScriptUses(project.Evt);
         }
 
-        public List<(SKBitmap frame, int timing)> GetClosedMouthAnimation(Project project)
+        public List<(SKBitmap Frame, int Timing)> GetClosedMouthAnimation(Project project)
         {
             return Sprite.GetClosedMouthAnimation(project.Grp, project.MessInfo);
         }
 
-        public List<(SKBitmap frame, int timing)> GetLipFlapAnimation(Project project)
+        public List<(SKBitmap Frame, int Timing)> GetLipFlapAnimation(Project project)
         {
             return Sprite.GetLipFlapAnimation(project.Grp, project.MessInfo);
+        }
+
+        public SKBitmap GetBaseLayout(Project project)
+        {
+            List<GraphicsFile> textures = new() { project.Grp.Files.First(f => f.Index == Sprite.TextureIndex1), project.Grp.Files.First(f => f.Index == Sprite.TextureIndex2), project.Grp.Files.First(f => f.Index == Sprite.TextureIndex3) };
+            GraphicsFile layout = project.Grp.Files.First(g => g.Index == Sprite.LayoutIndex);
+            (SKBitmap spriteBitmap, _) = layout.GetLayout(textures, 0, layout.LayoutEntries.Count, darkMode: false, preprocessedList: true);
+
+            return spriteBitmap;
+        }
+
+        public List<(SKBitmap Frame, short Timing)> GetEyeFrames(Project project)
+        {
+            GraphicsFile eyeTexture = project.Grp.Files.First(f => f.Index == Sprite.EyeTextureIndex);
+            GraphicsFile eyeAnimation = project.Grp.Files.First(f => f.Index == Sprite.EyeAnimationIndex);
+
+            return eyeAnimation.GetAnimationFrames(eyeTexture).Select(g => g.GetImage()).Zip(eyeAnimation.AnimationEntries.Select(a => ((FrameAnimationEntry)a).Time)).ToList();
+        }
+
+        public List<(SKBitmap Frame, short Timing)> GetMouthFrames(Project project)
+        {
+            GraphicsFile mouthTexture = project.Grp.Files.First(f => f.Index == Sprite.MouthTextureIndex);
+            GraphicsFile mouthAnimation = project.Grp.Files.First(f => f.Index == Sprite.MouthAnimationIndex);
+
+            return mouthAnimation.GetAnimationFrames(mouthTexture).Select(g => g.GetImage()).ToList().Zip(mouthAnimation.AnimationEntries.Select(a => ((FrameAnimationEntry)a).Time)).ToList();
         }
 
         public void PopulateScriptUses(ArchiveFile<EventFile> evt)
@@ -46,7 +72,7 @@ namespace SerialLoops.Lib.Items
         
         public SKBitmap GetPreview(Project project)
         {
-            return GetClosedMouthAnimation(project).First().frame;
+            return GetClosedMouthAnimation(project).First().Frame;
         }
     }
 }

--- a/src/SerialLoops.Lib/Items/ChibiItem.cs
+++ b/src/SerialLoops.Lib/Items/ChibiItem.cs
@@ -92,5 +92,16 @@ namespace SerialLoops.Lib.Items
             UP_LEFT = 2,
             UP_RIGHT = 3
         }
+
+        public static Direction CodeToDirection(string code)
+        {
+            return code switch
+            {
+                "BR" => Direction.DOWN_RIGHT,
+                "UL" => Direction.UP_LEFT,
+                "UR" => Direction.UP_RIGHT,
+                _ => Direction.DOWN_LEFT,
+            };
+        }
     }
 }

--- a/src/SerialLoops.Lib/Items/ChibiItem.cs
+++ b/src/SerialLoops.Lib/Items/ChibiItem.cs
@@ -37,7 +37,26 @@ namespace SerialLoops.Lib.Items
             ChibiEntry entry = ChibiEntries.First(c => c.Name == entryName).Chibi;
             GraphicsFile animation = grp.Files.First(f => f.Index == entry.Animation);
 
-            IEnumerable<SKBitmap> frames = animation.GetAnimationFrames(grp.Files.First(f => f.Index == entry.Texture)).Select(f => f.GetImage());
+            IEnumerable<SKBitmap> rawFrames = animation.GetAnimationFrames(grp.Files.First(f => f.Index == entry.Texture)).Select(f => f.GetImage());
+            int maxWidth = rawFrames.Max(r => r.Width);
+            int maxHeight = rawFrames.Max(r => r.Height);
+            // Frames need to be resized to have a constant width/height
+            List<SKBitmap> frames = new();
+            if (rawFrames.Any(f => f.Width != maxWidth || f.Height != maxHeight))
+            {
+                foreach (SKBitmap rawFrame in rawFrames)
+                {
+                    SKBitmap frame = new(maxWidth, maxHeight);
+                    using SKCanvas canvas = new(frame);
+                    canvas.DrawBitmap(rawFrame, 0, 0);
+                    canvas.Flush();
+                    frames.Add(frame);
+                }
+            }
+            else
+            {
+                frames.AddRange(rawFrames);
+            }
             IEnumerable<int> timings = animation.AnimationEntries.Select(a => (int)((FrameAnimationEntry)a).Time);
 
             return frames.Zip(timings);

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -305,10 +305,13 @@ namespace SerialLoops.Lib
             Items.AddRange(chrdata.Sprites.Where(s => (int)s.Character > 0).Select(s => new CharacterSpriteItem(s, chrdata, this)));
             tracker.Finished++;
 
-            tracker.Focus("Chibis", 1);
-            Items.AddRange(Dat.Files.First(d => d.Name == "CHIBIS").CastTo<ChibiFile>()
-                .Chibis.Select(c => new ChibiItem(c, this)));
-            tracker.Finished++;
+            ChibiFile chibiFile = Dat.Files.First(d => d.Name == "CHIBIS").CastTo<ChibiFile>();
+            tracker.Focus("Chibis", chibiFile.Chibis.Count);
+            foreach (Chibi chibi in chibiFile.Chibis)
+            {
+                Items.Add(new ChibiItem(chibi, this));
+                tracker.Finished++;
+            }
 
             tracker.Focus("Dialogue Configs", 1);
             Items.AddRange(Dat.Files.First(d => d.Name == "MESSINFOS").CastTo<MessageInfoFile>()

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="2.8.2.3" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.29.0" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.29.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NitroPacker.Core" Version="2.1.0" />
     <PackageReference Include="NLayer" Version="1.14.0" />

--- a/src/SerialLoops/Controls/ChibiDirectionSelector.cs
+++ b/src/SerialLoops/Controls/ChibiDirectionSelector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Eto.Forms;
+using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib.Items;
 using SerialLoops.Utility;
@@ -37,11 +38,12 @@ public class ChibiDirectionSelector : Panel
     private readonly ILogger _log;
     private TableLayout _grid;
     
-    public ChibiDirectionSelector(ILogger log)
+    public ChibiDirectionSelector(ChibiItem chibi, string currentPrefix, ILogger log)
     {
         _availableDirections = Enum.GetValues<ChibiItem.Direction>().ToList();
         _log = log;
         InitializeComponent();
+        UpdateAvailableDirections(chibi, currentPrefix);
     }
     
     private void InitializeComponent()
@@ -75,6 +77,16 @@ public class ChibiDirectionSelector : Panel
             y++;
         }
         Content = _grid;
+    }
+
+    public void UpdateAvailableDirections(ChibiItem chibi, string prefix)
+    {
+        _availableDirections.Clear();
+        foreach ((string name, ChibiEntry entry) in chibi.ChibiEntries.Where(c => c.Name.StartsWith(prefix)))
+        {
+            _availableDirections.Add(ChibiItem.CodeToDirection(name[^2..]));
+        }
+        UpdateSelected();
     }
 
     private void UpdateSelected()

--- a/src/SerialLoops/Dialogs/PreferencesDialog.cs
+++ b/src/SerialLoops/Dialogs/PreferencesDialog.cs
@@ -201,7 +201,7 @@ namespace SerialLoops.Dialogs
             protected override void SelectButton_OnClick(object sender, EventArgs e)
             {
                 SelectFolderDialog selectFolderDialog = new();
-                if (selectFolderDialog.ShowAndReportIfFileSelected(GetControl()))
+                if (selectFolderDialog.ShowAndReportIfFolderSelected(GetControl()))
                 {
                     _pathBox.Text = selectFolderDialog.Directory;
                 }

--- a/src/SerialLoops/Editors/CharacterSpriteEditor.cs
+++ b/src/SerialLoops/Editors/CharacterSpriteEditor.cs
@@ -75,6 +75,7 @@ namespace SerialLoops.Editors
                             _log.LogError($"Failed to export mouth animation {i} for sprite {_sprite.DisplayName} to file: {ex.Message}\n\n{ex.StackTrace}");
                         }
                     }
+                    MessageBox.Show("Character sprite frames exported!!", "Success!", MessageBoxType.Information);
                 }
             };
 
@@ -109,7 +110,7 @@ namespace SerialLoops.Editors
                     }
 
                     LoopyProgressTracker tracker = new();
-                    _ = new ProgressDialog(() => frames.SaveGif(saveFileDialog.FileName, tracker), () => MessageBox.Show("GIF exported!"), tracker, "Exporting GIF...");
+                    _ = new ProgressDialog(() => frames.SaveGif(saveFileDialog.FileName, tracker), () => MessageBox.Show("GIF exported!", "Success!", MessageBoxType.Information), tracker, "Exporting GIF...");
                 }
             };
 

--- a/src/SerialLoops/Editors/CharacterSpriteEditor.cs
+++ b/src/SerialLoops/Editors/CharacterSpriteEditor.cs
@@ -1,8 +1,13 @@
 ﻿using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
+using SerialLoops.Dialogs;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Utility;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace SerialLoops.Editors
 {
@@ -21,11 +26,109 @@ namespace SerialLoops.Editors
             _animatedImage = new AnimatedImage(_sprite.GetLipFlapAnimation(_project));
             _animatedImage.Play();
 
+            Button exportFramesButton = new() { Text = "Export Frames" };
+            exportFramesButton.Click += (sender, args) =>
+            {
+                SelectFolderDialog folderDialog = new()
+                {
+                    Title = "Select character sprite export folder"
+                };
+                if (folderDialog.ShowAndReportIfFolderSelected(this))
+                {
+                    SKBitmap layout = _sprite.GetBaseLayout(_project);
+                    List<(SKBitmap frame, short timing)> eyeFrames = _sprite.GetEyeFrames(_project);
+                    List<(SKBitmap frame, short timing)> mouthFrames = _sprite.GetMouthFrames(_project);
+
+                    try
+                    {
+                        using FileStream layoutStream = File.Create(Path.Combine(folderDialog.Directory, $"{_sprite.DisplayName}_BODY.png"));
+                        layout.Encode(layoutStream, SKEncodedImageFormat.Png, 1);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.LogError($"Failed to export layout for sprite {_sprite.DisplayName} to file: {ex.Message}\n\n{ex.StackTrace}");
+                    }
+
+                    int i = 0;
+                    foreach ((SKBitmap frame, short timing) in eyeFrames)
+                    {
+                        try
+                        {
+                            using FileStream frameStream = File.Create(Path.Combine(folderDialog.Directory, $"{_sprite.DisplayName}_EYE_{i++:D3}_{timing}f.png"));
+                            frame.Encode(frameStream, SKEncodedImageFormat.Png, 1);
+                        }
+                        catch (Exception ex)
+                        {
+                            _log.LogError($"Failed to export eye animation {i} for sprite {_sprite.DisplayName} to file: {ex.Message}\n\n{ex.StackTrace}");
+                        }
+                    }
+                    i = 0;
+                    foreach ((SKBitmap frame, short timing) in mouthFrames)
+                    {
+                        try
+                        {
+                            using FileStream frameStream = File.Create(Path.Combine(folderDialog.Directory, $"{_sprite.DisplayName}_MOUTH_{i++:D3}_{timing}f.png"));
+                            frame.Encode(frameStream, SKEncodedImageFormat.Png, 1);
+                        }
+                        catch (Exception ex)
+                        {
+                            _log.LogError($"Failed to export mouth animation {i} for sprite {_sprite.DisplayName} to file: {ex.Message}\n\n{ex.StackTrace}");
+                        }
+                    }
+                }
+            };
+
+            Button exportGifButton = new() { Text = "Export GIF" };
+            exportGifButton.Click += (sender, args) =>
+            {
+                List<(SKBitmap bitmap, int timing)> animationFrames;
+                if (MessageBox.Show("Include lip flap animation?", "Animation Export Option", MessageBoxButtons.YesNo, MessageBoxType.Question, MessageBoxDefaultButton.Yes) == DialogResult.Yes)
+                {
+                    animationFrames = _sprite.GetLipFlapAnimation(_project);
+                }
+                else
+                {
+                    animationFrames = _sprite.GetClosedMouthAnimation(_project);
+                }
+
+                SaveFileDialog saveFileDialog = new()
+                {
+                    Title = "Save character sprite GIF",
+                };
+                saveFileDialog.Filters.Add(new("GIF file", ".gif"));
+
+                if (saveFileDialog.ShowAndReportIfFileSelected(this))
+                {
+                    List<SKBitmap> frames = new();
+                    foreach ((SKBitmap frame, int timing) in animationFrames)
+                    {
+                        for (int i = 0; i < timing; i++)
+                        {
+                            frames.Add(frame);
+                        }
+                    }
+
+                    LoopyProgressTracker tracker = new();
+                    _ = new ProgressDialog(() => frames.SaveGif(saveFileDialog.FileName, tracker), () => MessageBox.Show("GIF exported!"), tracker, "Exporting GIF...");
+                }
+            };
+
             return new StackLayout
             {
+                Spacing = 10,
                 Items =
                 {
-                    _animatedImage
+                    _animatedImage,
+                    new StackLayout
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Spacing = 3,
+                        Items =
+                        {
+                            exportFramesButton,
+                            exportGifButton,
+                        },
+                    }
                 },
             };
         }

--- a/src/SerialLoops/Editors/ChibiEditor.cs
+++ b/src/SerialLoops/Editors/ChibiEditor.cs
@@ -52,7 +52,7 @@ namespace SerialLoops.Editors
             _animationSelection.SelectedIndex = 0;
             _animationSelection.SelectedKeyChanged += ChibiSelection_SelectedKeyChanged;
 
-            _directionSelector = new(_log)
+            _directionSelector = new(_chibi, _animationSelection.SelectedKey.Trim(), _log)
             {
                 Direction = ChibiItem.Direction.DOWN_LEFT
             };
@@ -188,16 +188,15 @@ namespace SerialLoops.Editors
 
         private void ChibiSelection_SelectedKeyChanged(object sender, EventArgs e)
         {
+            _directionSelector.UpdateAvailableDirections(_chibi, _animationSelection.SelectedKey.Trim());
             string selectedAnimationKey = GetSelectedAnimationKey();
             if (!_chibi.ChibiAnimations.ContainsKey(selectedAnimationKey))
             {
-                _animatedImage.FramesWithTimings = new() { (new SKGuiImage(new SKBitmap(32, 32)), -1) };
+                selectedAnimationKey = _chibi.ChibiAnimations.Keys.First();
+                _directionSelector.Direction = ChibiItem.CodeToDirection(selectedAnimationKey[^2..]);
             }
-            else
-            {
-                AnimatedImage newImage = new(_chibi.ChibiAnimations[selectedAnimationKey]);
-                _animatedImage.FramesWithTimings = newImage.FramesWithTimings;
-            }
+            AnimatedImage newImage = new(_chibi.ChibiAnimations[selectedAnimationKey]);
+            _animatedImage.FramesWithTimings = newImage.FramesWithTimings;
             _animatedImage.CurrentFrame = 0;
             _animatedImage.UpdateImage();
             UpdateFramesStack();

--- a/src/SerialLoops/Editors/ChibiEditor.cs
+++ b/src/SerialLoops/Editors/ChibiEditor.cs
@@ -48,7 +48,7 @@ namespace SerialLoops.Editors
         {
             _animationSelection = new();
             _animationSelection.Items.AddRange(_chibi.ChibiEntries
-                .Select(c => c.Name.Substring(0, c.Name.Length - 3)).Distinct().Select(c => new ListItem() { Text = c, Key = c }));
+                .Select(c => c.Name[..^3]).Distinct().Select(c => new ListItem() { Text = c, Key = c }));
             _animationSelection.SelectedIndex = 0;
             _animationSelection.SelectedKeyChanged += ChibiSelection_SelectedKeyChanged;
 
@@ -79,7 +79,7 @@ namespace SerialLoops.Editors
                     }
 
                     LoopyProgressTracker tracker = new();
-                    _ = new ProgressDialog(() => frames.SaveGif(saveFileDialog.FileName, tracker), () => MessageBox.Show("GIF exported!"), tracker, "Exporting GIF...");
+                    _ = new ProgressDialog(() => frames.SaveGif(saveFileDialog.FileName, tracker), () => MessageBox.Show("GIF exported!", "Success!", MessageBoxType.Information), tracker, "Exporting GIF...");
                 }
             };
             Button exportSpritesButton = new() { Text = "Export Sprites" };
@@ -104,6 +104,7 @@ namespace SerialLoops.Editors
                             _log.LogError($"Failed to export chibi animation {i} for chibi {_chibi.DisplayName} to file: {ex.Message}\n\n{ex.StackTrace}");
                         }
                     }
+                    MessageBox.Show("Chibi frames exported!!", "Success!", MessageBoxType.Information);
                 }
             };
 
@@ -123,7 +124,7 @@ namespace SerialLoops.Editors
                                 Spacing = 10,
                                 Items =
                                 {
-                                    _animationSelection, 
+                                    _animationSelection,
                                     _directionSelector
                                 }
                             }
@@ -174,10 +175,13 @@ namespace SerialLoops.Editors
                     HorizontalContentAlignment = HorizontalAlignment.Center,
                     Items =
                     {
-                        image,
-                        $"{timing} frames",
+                        image
                     }
                 };
+                if (timing >= 0)
+                {
+                    frameLayout.Items.Add($"{timing} frames");
+                }
                 _framesStack.Items.Add(frameLayout);
             }
         }
@@ -187,8 +191,9 @@ namespace SerialLoops.Editors
             string selectedAnimationKey = GetSelectedAnimationKey();
             if (!_chibi.ChibiAnimations.ContainsKey(selectedAnimationKey))
             {
-                _animatedImage.FramesWithTimings = new() { (new SKGuiImage(new SkiaSharp.SKBitmap(32, 32)), 1) };
-            } else
+                _animatedImage.FramesWithTimings = new() { (new SKGuiImage(new SKBitmap(32, 32)), -1) };
+            }
+            else
             {
                 AnimatedImage newImage = new(_chibi.ChibiAnimations[selectedAnimationKey]);
                 _animatedImage.FramesWithTimings = newImage.FramesWithTimings;
@@ -218,6 +223,5 @@ namespace SerialLoops.Editors
             }
             return $"{_animationSelection.SelectedKey.Trim()}_{direction}";
         }
-
     }
 }

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1822,7 +1822,7 @@ namespace SerialLoops.Editors
 
                 foreach (PositionedSprite sprite in sprites.Values.OrderBy(p => p.Positioning.Layer))
                 {
-                    SKBitmap spriteBitmap = sprite.Sprite.GetClosedMouthAnimation(_project)[0].frame;
+                    SKBitmap spriteBitmap = sprite.Sprite.GetClosedMouthAnimation(_project)[0].Frame;
                     canvas.DrawBitmap(spriteBitmap, sprite.Positioning.GetSpritePosition(spriteBitmap), sprite.PalEffect);
                 }
 

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -711,7 +711,7 @@ namespace SerialLoops.Editors
                 chibisSelectorDropDown.Items.AddRange(_project.Items.Where(i => i.Type == ItemDescription.ItemType.Chibi).Select(c => new ListItem { Key = c.Name, Text = c.Name }));
                 chibisSelectorDropDown.SelectedKey = chibi.Name;
 
-                ChibiDirectionSelector facingDirectionSelector = new(_log)
+                ChibiDirectionSelector facingDirectionSelector = new(chibi, chibi.ChibiEntries.First().Name[^2..], _log)
                 {
                     Direction = (ChibiItem.Direction)_script.Event.MapCharactersSection.Objects[chibiLayout.ChibiIndex].FacingDirection
                 };

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1248,7 +1248,7 @@ namespace SerialLoops.Editors
                         break;
 
                     case ScriptParameter.ParameterType.SCREEN:
-                        ScriptCommandScreenSelector screenSelector = new(_log, ((ScreenScriptParameter) parameter).Screen, true)
+                        ScriptCommandScreenSelector screenSelector = new(_log, ((ScreenScriptParameter)parameter).Screen, true)
                         {
                             Command = command,
                             ParameterIndex = i,
@@ -2285,9 +2285,9 @@ namespace SerialLoops.Editors
         {
             ScriptCommandScreenSelector selector = (ScriptCommandScreenSelector)sender;
             _log.Log($"Attempting to modify parameter {selector.ParameterIndex} to screen {selector.SelectedScreen} in {selector.Command.Index} in file {_script.Name}...");
-            ((ScreenScriptParameter) selector.Command.Parameters[selector.ParameterIndex]).Screen = selector.SelectedScreen;
+            ((ScreenScriptParameter)selector.Command.Parameters[selector.ParameterIndex]).Screen = selector.SelectedScreen;
             _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(selector.Command.Section)]
-                .Objects[selector.Command.Index].Parameters[selector.CurrentShort] = (short) selector.SelectedScreen;
+                .Objects[selector.Command.Index].Parameters[selector.CurrentShort] = (short)selector.SelectedScreen;
             UpdateTabTitle(false, selector);
             Application.Instance.Invoke(() => UpdatePreview());
         }

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -87,7 +87,8 @@
 
   <ItemGroup>
     <PackageReference Include="Eto.Forms" Version="2.7.5" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SerialLoops/Utility/Shared.cs
+++ b/src/SerialLoops/Utility/Shared.cs
@@ -4,6 +4,12 @@ using SerialLoops.Controls;
 using SerialLoops.Dialogs;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Util;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.PixelFormats;
+using SkiaSharp;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace SerialLoops.Utility
@@ -49,6 +55,30 @@ namespace SerialLoops.Utility
                 project.ItemNames[item.Name] = item.DisplayName;
                 project.Save();
             }
+        }
+
+        public static void SaveGif(this IEnumerable<SKBitmap> frames, string fileName, IProgressTracker tracker)
+        {
+            using Image<Rgba32> gif = new(frames.Max(f => f.Width), frames.Max(f => f.Height));
+            gif.Metadata.GetGifMetadata().RepeatCount = 0;
+
+            tracker.Focus("Converting frames...", 1);
+            IEnumerable<Image<Rgba32>> gifFrames = frames.Select(f => Image.LoadPixelData<Rgba32>(f.Pixels.Select(c => new Rgba32(c.Red, c.Green, c.Blue, c.Alpha)).ToArray(), f.Width, f.Height));
+            tracker.Finished++;
+            tracker.Focus("Adding frames to GIF...", gifFrames.Count());
+            foreach (Image<Rgba32> gifFrame in gifFrames)
+            {
+                GifFrameMetadata metadata = gifFrame.Frames.RootFrame.Metadata.GetGifMetadata();
+                metadata.FrameDelay = 2;
+                metadata.DisposalMethod = GifDisposalMethod.RestoreToBackground;
+                gif.Frames.AddFrame(gifFrame.Frames.RootFrame);
+                tracker.Finished++;
+            }
+            gif.Frames.RemoveFrame(0);
+
+            tracker.Focus("Saving GIF...", 1);
+            gif.SaveAsGif(fileName);
+            tracker.Finished++;
         }
     }
 }

--- a/src/SerialLoops/Utility/XPlatHelpers.cs
+++ b/src/SerialLoops/Utility/XPlatHelpers.cs
@@ -17,7 +17,7 @@ namespace SerialLoops.Utility
             DialogResult result = saveFileDialog.ShowDialog(parent);
             return result == DialogResult.Ok || result == DialogResult.Ignore; // "Ignore" is returned on Linux
         }
-        public static bool ShowAndReportIfFileSelected(this SelectFolderDialog selectFolderDialog, Control parent)
+        public static bool ShowAndReportIfFolderSelected(this SelectFolderDialog selectFolderDialog, Control parent)
         {
             DialogResult result = selectFolderDialog.ShowDialog(parent);
             return result == DialogResult.Ok || result == DialogResult.Ignore; // "Ignore" is returned on Linux


### PR DESCRIPTION
Closes #170.

This adds buttons to the chibi and character sprite editors that will export the sprite/chibi as a GIF or as individual frames. The former is fun and the latter will be useful for editing these items once replacement is added.