### PR TITLE
Keep search results open & ontop after opening a result

### DIFF
--- a/src/SerialLoops/Controls/ContextMenu.cs
+++ b/src/SerialLoops/Controls/ContextMenu.cs
@@ -58,7 +58,7 @@ namespace SerialLoops.Controls
             if (item is not null)
             {
                 ReferencesDialog referenceDialog = new(item, _project, _explorer, _tabs, _log);
-                referenceDialog.ShowModal(_explorer);
+                referenceDialog.Show();
             }
         }
     }

--- a/src/SerialLoops/Controls/ItemResultsPanel.cs
+++ b/src/SerialLoops/Controls/ItemResultsPanel.cs
@@ -9,19 +9,18 @@ namespace SerialLoops.Controls
 {
     public class ItemResultsPanel : ItemListPanel
     {
-        public FindItemsDialog Dialog;
+        public FindItemsWindow Window { get; set; }
         public ItemResultsPanel(List<ItemDescription> results, ILogger log, bool expandItems = true) : base(results, new Size(280, 185), expandItems, log) { }
 
         protected override void ItemList_ItemClicked(object sender, EventArgs e)
         {
             if (sender is SectionListTreeGridView view)
             {
-                ItemDescription item = Dialog.Project.FindItem(view.SelectedItem?.Text);
+                ItemDescription item = Window.Project.FindItem(view.SelectedItem?.Text);
                 if (item != null)
                 {
-                    Dialog.Tabs.OpenTab(item, _log);
+                    Window.Tabs.OpenTab(item, _log);
                 }
-                Dialog.Close();
             }
         }
     }

--- a/src/SerialLoops/Dialogs/FindItemsDialog.cs
+++ b/src/SerialLoops/Dialogs/FindItemsDialog.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace SerialLoops.Dialogs
 {
-    public abstract class FindItemsWindow : Form
+    public abstract class FindItemsWindow : FloatingForm
     {
         public ILogger Log { get; set; }
         public EditorTabsPanel Tabs { get; set; }
@@ -16,7 +16,6 @@ namespace SerialLoops.Dialogs
 
         protected override void OnLoad(EventArgs e)
         {
-            Topmost = true;
             if (Log is null)
             {
                 // We can't log that log is null, so we have to throw

--- a/src/SerialLoops/Dialogs/FindItemsDialog.cs
+++ b/src/SerialLoops/Dialogs/FindItemsDialog.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace SerialLoops.Dialogs
 {
-    public abstract class FindItemsDialog : Dialog
+    public abstract class FindItemsWindow : Form
     {
         public ILogger Log { get; set; }
         public EditorTabsPanel Tabs { get; set; }
@@ -16,6 +16,7 @@ namespace SerialLoops.Dialogs
 
         protected override void OnLoad(EventArgs e)
         {
+            Topmost = true;
             if (Log is null)
             {
                 // We can't log that log is null, so we have to throw

--- a/src/SerialLoops/Dialogs/ItemReferenceDialogs.cs
+++ b/src/SerialLoops/Dialogs/ItemReferenceDialogs.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace SerialLoops.Dialogs
 {
-    public class ReferencesDialog : FindItemsDialog
+    public class ReferencesDialog : FindItemsWindow
     {
         public ItemDescription Item;
 
@@ -39,14 +39,14 @@ namespace SerialLoops.Dialogs
                 Items =
                 {
                     $"{results.Count} items that reference {Item.Name}:",
-                    new ItemResultsPanel(results, Log) { Dialog = this }
+                    new ItemResultsPanel(results, Log) { Window = this }
                 }
             };
         }
 
     }
 
-    public class OrphanedItemsDialog : FindItemsDialog
+    public class OrphanedItemsDialog : FindItemsWindow
     {
         private static readonly ItemDescription.ItemType[] IGNORED_ORPHAN_TYPES = {
             ItemDescription.ItemType.Scenario,
@@ -78,7 +78,7 @@ namespace SerialLoops.Dialogs
                 Items =
                 {
                     $"{results.Count} items found that are not referenced by other items:",
-                    new ItemResultsPanel(results, Log, false) { Dialog = this }
+                    new ItemResultsPanel(results, Log, false) { Window = this }
                 }
             };
         }

--- a/src/SerialLoops/Dialogs/SearchDialog.cs
+++ b/src/SerialLoops/Dialogs/SearchDialog.cs
@@ -3,7 +3,7 @@ using SerialLoops.Dialogs;
 
 namespace SerialLoops
 {
-    public partial class SearchDialog : FindItemsDialog
+    public partial class SearchDialog : FindItemsWindow
     {
         public SearchDialog(ILogger log)
         {

--- a/src/SerialLoops/Dialogs/SearchDialog.eto.cs
+++ b/src/SerialLoops/Dialogs/SearchDialog.eto.cs
@@ -11,7 +11,7 @@ using SerialLoops.Utility;
 
 namespace SerialLoops
 {
-    partial class SearchDialog : FindItemsDialog
+    partial class SearchDialog : FindItemsWindow
     {
         private ItemResultsPanel _results;
         private SearchBox _searchInput;
@@ -52,7 +52,7 @@ namespace SerialLoops
 
             _results = new(new List<ItemDescription>(), Log)
             {
-                Dialog = this
+                Window = this
             };
             _searchInput = new()
             {

--- a/src/SerialLoops/Editors/TopicEditor.cs
+++ b/src/SerialLoops/Editors/TopicEditor.cs
@@ -284,7 +284,7 @@ namespace SerialLoops.Editors
             {
                 associatedScript = _project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Script && ((ScriptItem)i).Event.Index == _topic.Topic.EventIndex);
             }
-            return associatedScript;
+            return associatedScript ?? NoneItem.SCRIPT;
         }
 
         private void UpdateKyonTime()

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -702,7 +702,7 @@ namespace SerialLoops
                     Tabs = EditorTabs,
                     Text = SearchBox.Text,
                 };
-                searchDialog.ShowModal(this);
+                searchDialog.Show();
             }
         }
 
@@ -721,7 +721,7 @@ namespace SerialLoops
                             orphanedItemsDialog = new(OpenProject, ItemExplorer, EditorTabs, Log);
                             tracker.Finished++;
                         });
-                    }, () => { Application.Instance.Invoke(() => { orphanedItemsDialog?.ShowModal(this); }); }, tracker,
+                    }, () => { Application.Instance.Invoke(() => { orphanedItemsDialog?.Show(); }); }, tracker,
                     "Finding orphaned items");
             }
         }


### PR DESCRIPTION
Makes it so that you can open multiple items when performing a search or finding references rather than having the dialog close after opening one. On Windows and Mac, it also keeps the search window on top while allowing you to navigate the stuff you just opened. On Linux, the window does not stay on top because of https://github.com/picoe/Eto/issues/2501.