### PR TITLE
Fixup chibi selector button width on Gtk

### DIFF
--- a/src/SerialLoops/Controls/ChibiDirectionSelector.cs
+++ b/src/SerialLoops/Controls/ChibiDirectionSelector.cs
@@ -68,6 +68,10 @@ public class ChibiDirectionSelector : Panel
                 MinimumSize = new(35, 35),
                 ToolTip = direction.ToString(),
             };
+            if (Platform.IsGtk)
+            {
+                button.Width = 0;
+            }
             button.Click += (sender, e) => { Direction = direction; };
             _grid.Add(button, x, y);
             


### PR DESCRIPTION
Fixes #162.

Seems like the way buttons with images are implemented on Gtk doesn't respect the button width property but rather adds that to the width of the image, making for wide buttons. I just set the button width to zero which makes it take the space of the image and thus fits perfectly in the selector lol.

![image](https://github.com/haroohie-club/SerialLoops/assets/69772986/86f691ae-66e6-42bc-92b8-87568948e434)
