### PR TITLE
Lock down project names, add save button to the toolbar, and add view logs menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ To assemble ASM hacks you want to apply, you will need to decide whether to use 
   install [Docker Desktop](https://www.docker.com/products/docker-desktop/) or the Docker Engine. Ensure the Docker engine is running and make sure
   to check the "Use Docker for ASM Hacks" option in Preferences. You may want to occasionally clean up containers created by Serial Loops, as it will
   create many of them.
+    - On Windows, though, you will additionally need to install [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install).
+      From an admin PowerShell or Terminal window (Winkey + X + A), simply type `wsl --install` to install it.
 
 In general, Make is recommended, but it can be more difficult to get working on Windows systems sometimes. In this case, feel free to use Docker.
 

--- a/src/SerialLoops/Dialogs/ProjectCreationDialog.eto.cs
+++ b/src/SerialLoops/Dialogs/ProjectCreationDialog.eto.cs
@@ -22,8 +22,7 @@ namespace SerialLoops
         private Label _romPath;
 
         private const string NO_ROM_TEXT = "None Selected";
-        private const string ASSETS_URL = "https://github.com/haroohie-club/ChokuretsuTranslationAssets/archive/refs/heads/main.zip";
-        private const string STRINGS_URL = "https://github.com/haroohie-club/ChokuretsuTranslationStrings/archive/refs/heads/main.zip";
+        private const string ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
 
         void InitializeComponent()
         {
@@ -34,7 +33,14 @@ namespace SerialLoops
             _nameBox = new()
             {
                 PlaceholderText = "Haroohie",
-                Size = new Size(150, 25)
+                Size = new Size(150, 25),
+            };
+            _nameBox.TextChanging += (sender, args) =>
+            {
+                if (args.NewText.Any(c => !ALLOWED_CHARACTERS.Contains(c)))
+                {
+                    args.Cancel = true;
+                }
             };
             _languageDropDown = new();
             _languageDropDown.Items.AddRange(_availableLanguages.Select(a => new ListItem() { Text = a.Key, Key = a.Value }));

--- a/src/SerialLoops/Dialogs/ProjectCreationDialog.eto.cs
+++ b/src/SerialLoops/Dialogs/ProjectCreationDialog.eto.cs
@@ -8,6 +8,7 @@ using SerialLoops.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace SerialLoops
 {
@@ -22,7 +23,7 @@ namespace SerialLoops
         private Label _romPath;
 
         private const string NO_ROM_TEXT = "None Selected";
-        private const string ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
+        private static readonly Regex ALLOWED_CHARACTERS_REGEX = new(@"[A-z\d-_\.]");
 
         void InitializeComponent()
         {
@@ -37,7 +38,7 @@ namespace SerialLoops
             };
             _nameBox.TextChanging += (sender, args) =>
             {
-                if (args.NewText.Any(c => !ALLOWED_CHARACTERS.Contains(c)))
+                if (args.NewText.Any(c => !ALLOWED_CHARACTERS_REGEX.IsMatch(c.ToString())))
                 {
                     args.Cancel = true;
                 }

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -147,6 +147,28 @@ namespace SerialLoops
             Command preferencesCommand = new();
             preferencesCommand.Executed += PreferencesCommand_Executed;
 
+            Command viewLogsCommand = new()
+            {
+                MenuText = "View Logs",
+                ToolBarText = "View Logs",
+            };
+            viewLogsCommand.Executed += (sender, args) =>
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = Path.Combine(CurrentConfig.UserDirectory, "Logs", "SerialLoops.log"),
+                        UseShellExecute = true,
+                    });
+                }
+                catch (Exception)
+                {
+                    Log.LogError("Failed to open log file directly. " +
+                        $"Logs can be found at {Path.Combine(CurrentConfig.UserDirectory, "Logs", "SerialLoops.log")}");
+                }
+            };
+
             // Check For Updates
             Command checkForUpdatesCommand = new();
             checkForUpdatesCommand.Executed += (sender, e) => new UpdateChecker(this).Check();
@@ -171,7 +193,15 @@ namespace SerialLoops
                 {
                     // File submenu
                     new SubMenuItem
-                        {Text = "&File", Items = {newProjectCommand, openProjectCommand, _recentProjectsCommand}}
+                    {
+                        Text = "&File",
+                        Items =
+                        {
+                            newProjectCommand,
+                            openProjectCommand,
+                            _recentProjectsCommand
+                        }
+                    }
                 },
                 ApplicationItems =
                 {
@@ -185,7 +215,11 @@ namespace SerialLoops
                     {
                         Text = "&Check For Updates...", Command = checkForUpdatesCommand,
                         Image = ControlGenerator.GetIcon("Update", Log)
-                    }
+                    },
+                    new ButtonMenuItem
+                    {
+                        Text = "View &Logs", Command = viewLogsCommand,
+                    },
                 },
                 AboutItem = aboutCommand
             };
@@ -211,16 +245,18 @@ namespace SerialLoops
             };
             projectSettingsCommand.Executed += ProjectSettings_Executed;
 
-            Command migrateProjectCommand = new() { 
-                MenuText = "Migrate to new ROM", 
+            Command migrateProjectCommand = new()
+            {
+                MenuText = "Migrate to new ROM",
                 ToolBarText = "Migrate Project",
                 Image = ControlGenerator.GetIcon("Migrate_ROM", Log)
             };
             migrateProjectCommand.Executed += MigrateProject_Executed;
 
-            Command exportPatchCommand = new() { 
-                MenuText = "Export Patch", 
-                ToolBarText = "Export Patch", 
+            Command exportPatchCommand = new()
+            {
+                MenuText = "Export Patch",
+                ToolBarText = "Export Patch",
                 Image = ControlGenerator.GetIcon("Export_Patch", Log)
             };
             exportPatchCommand.Executed += Patch_Executed;
@@ -237,7 +273,7 @@ namespace SerialLoops
             Command applyHacksCommand = new() { MenuText = "Apply Hacks...", Image = ControlGenerator.GetIcon("Apply_Hacks", Log) };
             applyHacksCommand.Executed += (sender, args) => new RomHacksDialog(OpenProject, CurrentConfig, Log).ShowModal();
 
-            Command renameItemCommand = new() { MenuText = "Rename Item", Shortcut = Keys.F2, Image = ControlGenerator.GetIcon("Rename_Item", Log)};
+            Command renameItemCommand = new() { MenuText = "Rename Item", Shortcut = Keys.F2, Image = ControlGenerator.GetIcon("Rename_Item", Log) };
             renameItemCommand.Executed +=
                 (sender, args) => Shared.RenameItem(OpenProject, ItemExplorer, EditorTabs, Log);
 
@@ -274,7 +310,7 @@ namespace SerialLoops
             buildBaseProjectCommand.Executed += BuildBaseProject_Executed;
 
             Command buildAndRunProjectCommand = new()
-            { 
+            {
                 MenuText = "Build and Run",
                 ToolBarText = "Run",
                 Image = ControlGenerator.GetIcon("Build_Run", Log)

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -197,7 +197,7 @@ namespace SerialLoops
             Command saveProjectCommand = new()
             {
                 MenuText = "Save Project",
-                ToolBarText = "Save Project",
+                ToolBarText = "Save",
                 Shortcut = Application.Instance.CommonModifier | Keys.S,
                 Image = ControlGenerator.GetIcon("Save", Log)
             };
@@ -287,6 +287,7 @@ namespace SerialLoops
                 Style = "sl-toolbar",
                 Items =
                 {
+                    ControlGenerator.GetToolBarItem(saveProjectCommand),
                     ControlGenerator.GetToolBarItem(buildIterativeProjectCommand),
                     ControlGenerator.GetToolBarItem(buildAndRunProjectCommand),
                     ControlGenerator.GetToolBarItem(searchProjectCommand)


### PR DESCRIPTION
Fixes #218.

* Project names now have a set of valid characters; attempting to type or paste invalid characters will result in input being canceled.
* Add a save button toolbar (feedback from user study)
* Add a view logs button to the Application/File menu (makes it easier to access the logs file; also feedback from user study). The button opens the SerialLoops.log file with the system associated program for viewing log files.