### PR TITLE
Fix scenario listbox up and down arrows not working

### DIFF
--- a/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
@@ -1,5 +1,4 @@
-﻿using HaruhiChokuretsuLib.Archive.Data;
-using HaruhiChokuretsuLib.Archive.Event;
+﻿using HaruhiChokuretsuLib.Archive.Event;
 using HaruhiChokuretsuLib.Util;
 using QuikGraph;
 using QuikGraph.Algorithms.Observers;

--- a/src/SerialLoops/Controls/ScenarioCommandListPanel.cs
+++ b/src/SerialLoops/Controls/ScenarioCommandListPanel.cs
@@ -2,20 +2,35 @@
 using Eto.Forms;
 using HaruhiChokuretsuLib.Util;
 using System.Collections.Generic;
+using System.Linq;
 using static HaruhiChokuretsuLib.Archive.Event.ScenarioCommand;
 
 namespace SerialLoops.Controls
 {
     public class ScenarioCommandListPanel : Panel
     {
-        public List<(ScenarioVerb Verb, string Parameter)> Commands 
+        public List<(ScenarioVerb Verb, string Parameter)> Commands
         {
-            get => _commands; 
+            get => _commands;
             set
             {
                 _commands = value;
-                Viewer?.Items.Clear();
-                _commands.ForEach(c => Viewer?.Items.Add($"{c.Verb} {c.Parameter}"));
+                int selectedIndex = -1;
+                if (Viewer is not null)
+                {
+                    selectedIndex = Viewer.SelectedIndex;
+                    Viewer.Items.Clear();
+                    Viewer.Items.AddRange(_commands.Select(c => new ListItem { Text = $"{c.Verb} {c.Parameter}" }));
+                    if (selectedIndex < 0)
+                    {
+                        selectedIndex = 0;
+                    }
+                    if (_commands.Count > selectedIndex)
+                    {
+                        Viewer.SelectedIndex = selectedIndex;
+                        Viewer.Focus();
+                    }
+                }
             }
         }
         public ListBox Viewer { get; private set; }

--- a/src/SerialLoops/Editors/ScenarioEditor.cs
+++ b/src/SerialLoops/Editors/ScenarioEditor.cs
@@ -304,13 +304,7 @@ namespace SerialLoops.Editors
 
         private void RefreshCommands()
         {
-            int index = _commandsPanel.Viewer.SelectedIndex;
             _commandsPanel.Commands = _scenario.ScenarioCommands;
-            if (index < 0) index = 0;
-            if (_commandsPanel.Commands.Count > index)
-            {
-                _commandsPanel.Viewer.SelectedIndex = index;
-            }
             _deleteButton.Enabled = _commandsPanel.SelectedCommand is not null;
         }
     }


### PR DESCRIPTION
Fixes #217.

Turns out that removing all the items from the listbox can cause it to lose focus on WPF, which makes the whole "set the selected index" rigamarole pointless. If we call Focus at the end of the set, the arrow keys work.