### PR TITLE
Add ASM hack description to dialog, Makefile & hack updating, devkitARM version detection, and disabling of attract sequence for Skip OP hack

### DIFF
--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -99,6 +99,17 @@ namespace SerialLoops.Lib
                 Hacks.AddRange(missingHacks);
                 File.WriteAllText(Path.Combine(HacksDirectory, "hacks.json"), JsonSerializer.Serialize(Hacks));
             }
+
+            IEnumerable<AsmHack> updatedHacks = builtinHacks.Where(h => !Hacks.FirstOrDefault(o => h.Name == o.Name)?.DeepEquals(h) ?? false);
+            if (updatedHacks.Any())
+            {
+                IO.CopyFiles(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "Hacks"), HacksDirectory);
+                foreach (AsmHack updatedHack in updatedHacks)
+                {
+                    Hacks[Hacks.FindIndex(h => h.Name == updatedHack.Name)] = updatedHack;
+                }
+                File.WriteAllText(Path.Combine(HacksDirectory, "hacks.json"), JsonSerializer.Serialize(Hacks));
+            }
         }
 
         private static Config GetDefault(ILogger log)
@@ -136,7 +147,7 @@ namespace SerialLoops.Lib
                 DevkitArmPath = devkitArmDir,
                 EmulatorPath = emulatorPath,
                 UseDocker = false,
-                DevkitArmDockerTag = "20221115",
+                DevkitArmDockerTag = "latest",
                 AutoReopenLastProject = true,
                 RememberProjectWorkspace = true,
                 RemoveMissingProjects = false,

--- a/src/SerialLoops.Lib/Hacks/AsmHack.cs
+++ b/src/SerialLoops.Lib/Hacks/AsmHack.cs
@@ -18,7 +18,7 @@ namespace SerialLoops.Lib.Hacks
         {
             foreach (InjectionSite site in InjectionSites)
             {
-                if (site.Equals("ARM9"))
+                if (site.Code.Equals("ARM9"))
                 {
                     using FileStream arm9 = File.OpenRead(Path.Combine(project.IterativeDirectory, "rom", "arm9.bin"));
                     arm9.Seek(site.Offset + 3, SeekOrigin.Begin);
@@ -62,16 +62,22 @@ namespace SerialLoops.Lib.Hacks
 
         public void Revert(Project project, ILogger log)
         {
+            bool oneSuccess = false;
             try
             {
                 foreach (HackFile file in Files)
                 {
                     File.Delete(Path.Combine(project.BaseDirectory, "src", file.Destination));
+                    oneSuccess = true;
                 }
             }
             catch (IOException)
             {
-                log.LogError($"Failed to delete files for hack '{Name}' -- this hack is likely applied in the ROM base and can't be disabled.");
+                // If there's at least one success, we assume that an older version of the hack was applied and we've now rolled it back
+                if (!oneSuccess)
+                {
+                    log.LogError($"Failed to delete files for hack '{Name}' -- this hack is likely applied in the ROM base and can't be disabled.");
+                }
             }
         }
 

--- a/src/SerialLoops.Lib/Hacks/AsmHack.cs
+++ b/src/SerialLoops.Lib/Hacks/AsmHack.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Emit;
 using System.Text.Json.Serialization;
 
 namespace SerialLoops.Lib.Hacks
@@ -9,6 +10,7 @@ namespace SerialLoops.Lib.Hacks
     public class AsmHack
     {
         public string Name { get; set; }
+        public string Description { get; set; }
         public List<InjectionSite> InjectionSites { get; set; }
         public List<HackFile> Files { get; set; }
 
@@ -77,6 +79,16 @@ namespace SerialLoops.Lib.Hacks
         {
             return ((AsmHack)obj).Name.Equals(Name);
         }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+
+        public bool DeepEquals(AsmHack other)
+        {
+            return other.Name.Equals(Name) && other.Description.Equals(Description) && other.InjectionSites.SequenceEqual(InjectionSites) && other.Files.SequenceEqual(Files);
+        }
     }
 
     public class InjectionSite
@@ -113,6 +125,16 @@ namespace SerialLoops.Lib.Hacks
                 Offset = (uint)(uint.Parse(value, System.Globalization.NumberStyles.HexNumber) - startAddress);
             }
         }
+
+        public override bool Equals(object obj)
+        {
+            return ((InjectionSite)obj).Offset == Offset && ((InjectionSite)obj).Code.Equals(Code);
+        }
+
+        public override int GetHashCode()
+        {
+            return Offset.GetHashCode() * Code.GetHashCode() - (Offset.GetHashCode() + Code.GetHashCode());
+        }
     }
 
     public class HackFile
@@ -120,5 +142,15 @@ namespace SerialLoops.Lib.Hacks
         public string File { get; set; }
         public string Destination { get; set; }
         public string[] Symbols { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return ((HackFile)obj).File.Equals(File) && ((HackFile)obj).Destination.Equals(Destination) && ((HackFile)obj).Symbols.SequenceEqual(Symbols);
+        }
+
+        public override int GetHashCode()
+        {
+            return File.GetHashCode();
+        }
     }
 }

--- a/src/SerialLoops.Lib/Sources/Hacks/disableAttractSequenceTimer_asm.s
+++ b/src/SerialLoops.Lib/Sources/Hacks/disableAttractSequenceTimer_asm.s
@@ -1,0 +1,3 @@
+@ Disable the attract sequence timer, preventing the OP from ever playing
+ahook_20C77FC:
+    bx lr

--- a/src/SerialLoops.Lib/Sources/Hacks/nullifyAttractSequenceTimer_asm.s
+++ b/src/SerialLoops.Lib/Sources/Hacks/nullifyAttractSequenceTimer_asm.s
@@ -1,0 +1,3 @@
+@ Prevent decrement of the attract sequence timer, preventing the OP from every playing
+ahook_20C77FC:
+    bx lr

--- a/src/SerialLoops.Lib/Sources/Hacks/nullifyAttractSequenceTimer_asm.s
+++ b/src/SerialLoops.Lib/Sources/Hacks/nullifyAttractSequenceTimer_asm.s
@@ -1,3 +1,0 @@
-@ Prevent decrement of the attract sequence timer, preventing the OP from every playing
-ahook_20C77FC:
-    bx lr

--- a/src/SerialLoops.Lib/Sources/Hacks/skipOp_asm.s
+++ b/src/SerialLoops.Lib/Sources/Hacks/skipOp_asm.s
@@ -1,4 +1,4 @@
-@ Skip video
+@ Skip OP video after logos
 ahook_20C7888:
     mov r0, #0
     mov r1, #2

--- a/src/SerialLoops.Lib/Sources/Makefile_main
+++ b/src/SerialLoops.Lib/Sources/Makefile_main
@@ -118,7 +118,7 @@ export INCLUDE    :=    $(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/12.2.0
+export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
 
  
 .PHONY: $(BUILD) clean

--- a/src/SerialLoops.Lib/Sources/Makefile_overlay
+++ b/src/SerialLoops.Lib/Sources/Makefile_overlay
@@ -118,7 +118,7 @@ export INCLUDE    :=    $(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/12.2.0
+export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
 
  
 .PHONY: $(BUILD) clean

--- a/src/SerialLoops.Lib/Sources/hacks.json
+++ b/src/SerialLoops.Lib/Sources/hacks.json
@@ -1,10 +1,11 @@
 [
     {
         "Name": "Skip OP",
+        "Description": "Prevents the opening song/movie from playing. Logos fade directly to title screen and attract sequence timer is disabled.",
         "InjectionSites": [
             {
                 "Code": "01",
-                "Location": "20C7888"
+                "Location": "020C7888"
             }
         ],
         "Files": [

--- a/src/SerialLoops.Lib/Sources/hacks.json
+++ b/src/SerialLoops.Lib/Sources/hacks.json
@@ -6,12 +6,21 @@
             {
                 "Code": "01",
                 "Location": "020C7888"
+            },
+            {
+                "Code": "02",
+                "Location": "020C77FC"
             }
         ],
         "Files": [
             {
                 "File": "skipOp_asm.s",
                 "Destination": "overlays/main_0001/source/skipOp_asm.s",
+                "Symbols": []
+            },
+            {
+                "File": "nullifyAttractSequenceTimer_asm.s",
+                "Destination": "overlays/main_0002/source/nullifyAttractSequenceTimer_asm.s",
                 "Symbols": []
             }
         ]

--- a/src/SerialLoops.Wpf/Program.cs
+++ b/src/SerialLoops.Wpf/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Eto.Wpf;
+using Eto.Wpf.Forms.Controls;
 using Eto.Wpf.Forms.ToolBar;
 using SerialLoops.Utility;
 using System;

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -1,4 +1,5 @@
-﻿using Eto.Forms;
+﻿using Eto.Drawing;
+using Eto.Forms;
 using HaroohieClub.NitroPacker.Patcher.Nitro;
 using HaroohieClub.NitroPacker.Patcher.Overlay;
 using HaruhiChokuretsuLib.Util;
@@ -14,25 +15,41 @@ using System.Text.Json;
 
 namespace SerialLoops.Dialogs
 {
-    public class RomHacksDialog : Dialog
+    public class AsmHacksDialog : Dialog
     {
         private const int NUM_OVERLAYS = 26;
 
-        public RomHacksDialog(Project project, Config config, ILogger log)
+        public AsmHacksDialog(Project project, Config config, ILogger log)
         {
-            Title = "Apply ROM Hacks";
+            Title = "Apply Assembly Hacks";
             Padding = 5;
+
 
             StackLayout hacksLayout = new()
             {
                 Orientation = Orientation.Vertical,
                 Spacing = 5,
-                Size = new(200, 300),
+                Padding = 3,
+                Size = new(200, 400),
+            };
+
+            StackLayout descriptionLayout = new()
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 5,
+                Padding = 3,
+                Size = new(300, 400),
             };
 
             foreach (AsmHack hack in config.Hacks)
             {
                 CheckBox hackCheckBox = new() { Text = hack.Name, Checked = hack.Applied(project) };
+                hackCheckBox.MouseEnter += (sender, args) =>
+                {
+                    descriptionLayout.Items.Clear();
+                    descriptionLayout.Items.Add(new Label { Text = hack.Name, Font = SystemFonts.Bold() });
+                    descriptionLayout.Items.Add(new Label { Text = hack.Description, Wrap = WrapMode.Word });
+                };
                 hacksLayout.Items.Add(hackCheckBox);
             }
 
@@ -231,7 +248,8 @@ namespace SerialLoops.Dialogs
                     new Scrollable
                     {
                         Content = hacksLayout,
-                    }
+                    },
+                    descriptionLayout
                     ),
                 new TableRow(
                     buttonsLayout

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -254,7 +254,10 @@ namespace SerialLoops.Dialogs
                 new TableRow(
                     buttonsLayout
                     )
-                );
+                )
+            {
+                Spacing = new(10, 0),
+            };
         }
     }
 }

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -47,7 +47,7 @@ namespace SerialLoops.Dialogs
                 hackCheckBox.MouseEnter += (sender, args) =>
                 {
                     descriptionLayout.Items.Clear();
-                    descriptionLayout.Items.Add(new Label { Text = hack.Name, Font = SystemFonts.Bold() });
+                    descriptionLayout.Items.Add(ControlGenerator.GetTextHeader(hack.Name));
                     descriptionLayout.Items.Add(new Label { Text = hack.Description, Wrap = WrapMode.Word });
                 };
                 hacksLayout.Items.Add(hackCheckBox);

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -271,7 +271,7 @@ namespace SerialLoops
 
             // Tools
             Command applyHacksCommand = new() { MenuText = "Apply Hacks...", Image = ControlGenerator.GetIcon("Apply_Hacks", Log) };
-            applyHacksCommand.Executed += (sender, args) => new RomHacksDialog(OpenProject, CurrentConfig, Log).ShowModal();
+            applyHacksCommand.Executed += (sender, args) => new AsmHacksDialog(OpenProject, CurrentConfig, Log).ShowModal();
 
             Command renameItemCommand = new() { MenuText = "Rename Item", Shortcut = Keys.F2, Image = ControlGenerator.GetIcon("Rename_Item", Log) };
             renameItemCommand.Executed +=


### PR DESCRIPTION
Fixes #224. Closes #226. Closes #227.

Does a couple of things because I got carried away lol.

* ASM hacks now have a description as part of their metadata and that gets displayed in the ASM hack dialog. This description is displayed when you mouse over a particular hack.
* Updated the Makefiles to work with the latest version of devkitARM and added some functionality to detect if the Makefiles are out of date compared to what the application has. Additionally, added functionality to determine if the devkitARM installation can be upgraded.
* Hacks can be updated now. If we add more files or change the description of a hack and push out an update, Serial Loops will detect this and upgrade the hack in the Hacks folder.
* Skip OP ASM hack now also disables the attract sequence timer on the main menu, preventing the OP from ever playing.

![image](https://github.com/haroohie-club/SerialLoops/assets/69772986/bfe4e8f3-137b-456f-b501-a4564790133f)