### PR TITLE
Fixup bad item renaming and command tree scrollbar bugs

### DIFF
--- a/src/SerialLoops/Controls/ScriptCommandSectionTree.cs
+++ b/src/SerialLoops/Controls/ScriptCommandSectionTree.cs
@@ -2,12 +2,12 @@
 using Eto.Drawing;
 using Eto.Forms;
 using HaruhiChokuretsuLib.Archive.Event;
+using HaruhiChokuretsuLib.Util;
+using SerialLoops.Editors;
 using SerialLoops.Lib.Script;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using HaruhiChokuretsuLib.Util;
-using SerialLoops.Editors;
 
 namespace SerialLoops.Controls
 {
@@ -105,6 +105,7 @@ namespace SerialLoops.Controls
     {
         private TreeGridView _treeView;
         private ScriptCommandSectionTreeItem _cursorItem;
+        private bool _clickedOnCommand = false;
         public event EventHandler RepositionCommand;
         public event EventHandler<DeleteItemEventArgs> DeleteCommand;
         public event EventHandler<CommandEventArgs> AddCommand;
@@ -175,6 +176,8 @@ namespace SerialLoops.Controls
             _treeView.Size = size;
             SetContents(topNodes, expanded);
 
+            _treeView.MouseDown += OnMouseDown;
+            _treeView.MouseUp += OnMouseUp;
             _treeView.MouseMove += OnMouseMove;
             _treeView.DragOver += OnDragOver;
             _treeView.DragDrop += OnDragDrop;
@@ -190,10 +193,23 @@ namespace SerialLoops.Controls
             };
         }
 
+        private void OnMouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Buttons != MouseButtons.Primary) return;
+            if (_treeView.GetCellAt(e.Location).Item is not ScriptCommandSectionTreeItem { Parent: ScriptCommandSectionTreeItem parent } item) return;
+            _clickedOnCommand = true;
+        }
+
+        private void OnMouseUp(object sender, MouseEventArgs e)
+        {
+            _clickedOnCommand = false;
+        }
+
         private void OnMouseMove(object sender, MouseEventArgs e)
         {
             if (e.Buttons != MouseButtons.Primary) return;
             if (_treeView.GetCellAt(e.Location).Item is not ScriptCommandSectionTreeItem {Parent: ScriptCommandSectionTreeItem parent} item) return;
+            if (!_clickedOnCommand) return;
             _cursorItem = item;
                 
             var data = new DataObject();

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -620,7 +620,7 @@ namespace SerialLoops
                         CharacterItem characterItem = (CharacterItem)item;
                         if (characterItem.NameplateProperties.Name != item.DisplayName[4..])
                         {
-                            Shared.RenameItem(OpenProject, ItemExplorer, EditorTabs, Log,
+                            Shared.RenameItem(characterItem, OpenProject, ItemExplorer, EditorTabs, Log,
                                 $"CHR_{characterItem.NameplateProperties.Name}");
                         }
 
@@ -648,7 +648,7 @@ namespace SerialLoops
                         PlaceItem placeItem = (PlaceItem)item;
                         if (placeItem.PlaceName != item.DisplayName[4..])
                         {
-                            Shared.RenameItem(OpenProject, ItemExplorer, EditorTabs, Log, $"PLC_{placeItem.PlaceName}");
+                            Shared.RenameItem(placeItem, OpenProject, ItemExplorer, EditorTabs, Log, $"PLC_{placeItem.PlaceName}");
                         }
 
                         MemoryStream placeStream = new();

--- a/src/SerialLoops/Utility/Shared.cs
+++ b/src/SerialLoops/Utility/Shared.cs
@@ -42,11 +42,20 @@ namespace SerialLoops.Utility
         public static void RenameItem(Project project, ItemExplorerPanel explorer, EditorTabsPanel tabs, ILogger log, string newName)
         {
             ItemDescription item = project.FindItem(explorer.Viewer.SelectedItem?.Text);
+            RenameItem(item, project, explorer, tabs, log, newName);
+        }
+        public static void RenameItem(ItemDescription item, Project project, ItemExplorerPanel explorer, EditorTabsPanel tabs, ILogger log, string newName)
+        {
             if (item is not null)
             {
+                string oldName = item.DisplayName;
                 DocumentPage openTab = tabs.Tabs.Pages.FirstOrDefault(p => p.Text == item.DisplayNameWithStatus);
                 item.Rename(newName);
-                explorer.Viewer.SelectedItem.Text = item.DisplayName;
+                if (explorer.Viewer.SelectedItem.Text.Equals(oldName))
+                {
+                    // Unfortunately, there doesn't seem to be a good way to ensure the item gets rename if we've selected a different item
+                    explorer.Viewer.SelectedItem.Text = item.DisplayName;
+                }
                 if (openTab is not null)
                 {
                     openTab.Text = item.DisplayNameWithStatus;


### PR DESCRIPTION
Fixes #223. Fixes #229.

The rename bug was caused by the simple fact that our rename function was built assuming someone was doing right click -> rename (or F2), and thus renamed the currently selected item. I've abstracted the function out to allow providing a rename of an arbitrary item with the caveat that I don't know how to ensure that its name is then changed in the item selector tree.

The other bug has been _mostly_ fixed. There are some edge cases (specifically, if you pick up a command and drag it out of the box and drop it, the bug can still occur), but the vast majority of cases have been fixed.