### PR TITLE
Improve stability with many bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@
 #### Installing Make or Docker
 To assemble ASM hacks you want to apply, you will need to decide whether to use Make or Docker.
 
+Currently, the Docker path is **only supported on Windows** due to operating system and framework limitations. It is possible to get Docker running
+just fine on Linux distros by running SerialLoops as root (e.g. `sudo SerialLoops`), but it's easier to just use Make. On macOS, there is no known
+way of getting the Docker path to work, so you will have to use Make.
+
 * [Make](https://www.gnu.org/software/make/) is the software used to assemble assembly hacks. Installing Make allows you to build the hacks
   directly on your system.
     - To install on Windows, you will have to use a terminal and a package manager. Your options are Winget (installed by default on Win10+) or
@@ -43,18 +47,17 @@ To assemble ASM hacks you want to apply, you will need to decide whether to use 
       for Winget or `choco install make` for Chocolatey. If using Winget, you will then have to go into system preferences and add Make to the path.
     - Installation on macOS can be done through Xcode or Homebrew. If using Xcode, open a terminal and type `xcode-select --install`. If you would
       rather use Homebrew, open a terminal after installing Homebrew and type `brew install make`.
-    - Make comes preinstalled on many Linux distributions. If it is not installed on yours, you will likely be able to install it with your package
-      as simply as `[packagemanger] install make` from a terminal.
+    - Make comes preinstalled on many Linux distributions, and if you're using the Debian or RPM package, it was definitely installed when you installed
+      Serial Loops. If you're using the tar.gz it is not installed on yours, you will likely be able to install it as simply as
+      `[packagemanger] install make` from a terminal.
   
   To test if make is installed properly, type `make --verison` into a terminal and see if it produces the version of make.
 * If you would rather not install Make, or if it is not working properly, you can instead run it through a Docker container. To do this, you should
   install [Docker Desktop](https://www.docker.com/products/docker-desktop/) or the Docker Engine. Ensure the Docker engine is running and make sure
   to check the "Use Docker for ASM Hacks" option in Preferences. You may want to occasionally clean up containers created by Serial Loops, as it will
   create many of them.
-    - On Windows, though, you will additionally need to install [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install).
+    - On Windows, you will additionally need to install [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install).
       From an admin PowerShell or Terminal window (Winkey + X + A), simply type `wsl --install` to install it.
-
-In general, Make is recommended, but it can be more difficult to get working on Windows systems sometimes. In this case, feel free to use Docker.
 
 #### Installing OpenAL (Linux)
 If you're running on Linux and _not using one of the package releases_ (the `.deb` or `.rpm`), you will also need to install OpenAL which is used for audio processing.

--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -37,14 +37,14 @@ namespace SerialLoops.Lib
         public bool RemoveMissingProjects { get; set; }
         public bool CheckForUpdates { get; set; }
         public bool PreReleaseChannel { get; set; }
-        public string UnixPath { get; set; }
+        public string MacOSPath { get; set; }
 
         public void Save(ILogger log)
         {
             IO.WriteStringFile(ConfigPath, JsonSerializer.Serialize(this), log);
         }
 
-        public static Config LoadConfig(bool isUnix, ILogger log)
+        public static Config LoadConfig(bool isMacOS, ILogger log)
         {
             string configDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SerialLoops");
             if (!Directory.Exists(configDirectory))
@@ -60,9 +60,9 @@ namespace SerialLoops.Lib
                 defaultConfig.ValidateConfig(log);
                 defaultConfig.ConfigDirectory = configDirectory;
                 defaultConfig.ConfigPath = configJson;
-                if (isUnix)
+                if (isMacOS)
                 {
-                    defaultConfig.InitializeUnixPath();
+                    defaultConfig.InitializeMacOSPath();
                 }
                 defaultConfig.InitializeHacks();
                 IO.WriteStringFile(configJson, JsonSerializer.Serialize(defaultConfig), log);
@@ -74,9 +74,9 @@ namespace SerialLoops.Lib
                 Config config = JsonSerializer.Deserialize<Config>(File.ReadAllText(configJson));
                 config.ValidateConfig(log);
                 config.ConfigPath = configJson;
-                if (isUnix && string.IsNullOrEmpty(config.UnixPath))
+                if (isMacOS && string.IsNullOrEmpty(config.MacOSPath))
                 {
-                    config.InitializeUnixPath();
+                    config.InitializeMacOSPath();
                 }
                 config.InitializeHacks();
                 return config;
@@ -132,7 +132,7 @@ namespace SerialLoops.Lib
             }
         }
 
-        private void InitializeUnixPath()
+        private void InitializeMacOSPath()
         {
             string unixPathFile = Path.Combine(ConfigDirectory, "unix-path.txt");
             ProcessStartInfo psi = new()
@@ -141,7 +141,7 @@ namespace SerialLoops.Lib
                 Arguments = $"echo \"$PATH\" > \"{unixPathFile}\"",
                 UseShellExecute = true,
             };
-            UnixPath = File.ReadAllText(unixPathFile).Trim();
+            MacOSPath = File.ReadAllText(unixPathFile).Trim();
         }
 
         private static Config GetDefault(ILogger log)

--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -14,8 +14,6 @@ namespace SerialLoops.Lib
     public class Config
     {
         [JsonIgnore]
-        public string ConfigDirectory { get; set; }
-        [JsonIgnore]
         public string ConfigPath { get; set; }
         public string UserDirectory { get; set; }
         [JsonIgnore]
@@ -45,19 +43,12 @@ namespace SerialLoops.Lib
 
         public static Config LoadConfig(ILogger log)
         {
-            string configDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SerialLoops");
-            if (!Directory.Exists(configDirectory))
-            {
-                Directory.CreateDirectory(configDirectory);
-            }
-
             string configJson = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
 
             if (!File.Exists(configJson))
             {
                 Config defaultConfig = GetDefault(log);
                 defaultConfig.ValidateConfig(log);
-                defaultConfig.ConfigDirectory = configDirectory;
                 defaultConfig.ConfigPath = configJson;
                 defaultConfig.InitializeHacks();
                 IO.WriteStringFile(configJson, JsonSerializer.Serialize(defaultConfig), log);

--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -37,14 +37,13 @@ namespace SerialLoops.Lib
         public bool RemoveMissingProjects { get; set; }
         public bool CheckForUpdates { get; set; }
         public bool PreReleaseChannel { get; set; }
-        public string MacOSPath { get; set; }
 
         public void Save(ILogger log)
         {
             IO.WriteStringFile(ConfigPath, JsonSerializer.Serialize(this), log);
         }
 
-        public static Config LoadConfig(bool isMacOS, ILogger log)
+        public static Config LoadConfig(ILogger log)
         {
             string configDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SerialLoops");
             if (!Directory.Exists(configDirectory))
@@ -60,10 +59,6 @@ namespace SerialLoops.Lib
                 defaultConfig.ValidateConfig(log);
                 defaultConfig.ConfigDirectory = configDirectory;
                 defaultConfig.ConfigPath = configJson;
-                if (isMacOS)
-                {
-                    defaultConfig.InitializeMacOSPath();
-                }
                 defaultConfig.InitializeHacks();
                 IO.WriteStringFile(configJson, JsonSerializer.Serialize(defaultConfig), log);
                 return defaultConfig;
@@ -74,10 +69,6 @@ namespace SerialLoops.Lib
                 Config config = JsonSerializer.Deserialize<Config>(File.ReadAllText(configJson));
                 config.ValidateConfig(log);
                 config.ConfigPath = configJson;
-                if (isMacOS && string.IsNullOrEmpty(config.MacOSPath))
-                {
-                    config.InitializeMacOSPath();
-                }
                 config.InitializeHacks();
                 return config;
             }
@@ -130,19 +121,6 @@ namespace SerialLoops.Lib
                 }
                 File.WriteAllText(Path.Combine(HacksDirectory, "hacks.json"), JsonSerializer.Serialize(Hacks));
             }
-        }
-
-        private void InitializeMacOSPath()
-        {
-            string unixPathFile = Path.Combine(ConfigDirectory, "unix-path.txt");
-            ProcessStartInfo psi = new()
-            {
-                FileName = "/bin/bash",
-                Arguments = $"-c \"echo $PATH > {unixPathFile}\"",
-                UseShellExecute = true,
-            };
-            Process.Start(psi).WaitForExit();
-            MacOSPath = File.ReadAllText(unixPathFile).Trim();
         }
 
         private static Config GetDefault(ILogger log)

--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -37,14 +37,13 @@ namespace SerialLoops.Lib
         public bool RemoveMissingProjects { get; set; }
         public bool CheckForUpdates { get; set; }
         public bool PreReleaseChannel { get; set; }
-        public string MacOSPath { get; set; }
 
         public void Save(ILogger log)
         {
             IO.WriteStringFile(ConfigPath, JsonSerializer.Serialize(this), log);
         }
 
-        public static Config LoadConfig(bool isMacOS, ILogger log)
+        public static Config LoadConfig(ILogger log)
         {
             string configDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SerialLoops");
             if (!Directory.Exists(configDirectory))
@@ -60,10 +59,6 @@ namespace SerialLoops.Lib
                 defaultConfig.ValidateConfig(log);
                 defaultConfig.ConfigDirectory = configDirectory;
                 defaultConfig.ConfigPath = configJson;
-                if (isMacOS)
-                {
-                    defaultConfig.InitializeMacOSPath();
-                }
                 defaultConfig.InitializeHacks();
                 IO.WriteStringFile(configJson, JsonSerializer.Serialize(defaultConfig), log);
                 return defaultConfig;
@@ -74,10 +69,6 @@ namespace SerialLoops.Lib
                 Config config = JsonSerializer.Deserialize<Config>(File.ReadAllText(configJson));
                 config.ValidateConfig(log);
                 config.ConfigPath = configJson;
-                if (isMacOS && string.IsNullOrEmpty(config.MacOSPath))
-                {
-                    config.InitializeMacOSPath();
-                }
                 config.InitializeHacks();
                 return config;
             }
@@ -130,18 +121,6 @@ namespace SerialLoops.Lib
                 }
                 File.WriteAllText(Path.Combine(HacksDirectory, "hacks.json"), JsonSerializer.Serialize(Hacks));
             }
-        }
-
-        private void InitializeMacOSPath()
-        {
-            string unixPathFile = Path.Combine(ConfigDirectory, "unix-path.txt");
-            ProcessStartInfo psi = new()
-            {
-                FileName = "/bin/bash",
-                Arguments = $"echo \"$PATH\" > \"{unixPathFile}\"",
-                UseShellExecute = true,
-            };
-            MacOSPath = File.ReadAllText(unixPathFile).Trim();
         }
 
         private static Config GetDefault(ILogger log)

--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -137,6 +137,10 @@ namespace SerialLoops.Lib
             {
                 emulatorPath = Path.Combine("/Applications", "melonDS.app");
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                emulatorPath = Path.Combine("/snap", "melonds", "current", "usr", "local", "bin", "melonDS");
+            }
             if (!Directory.Exists(emulatorPath))
             {
                 emulatorPath = "";

--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -159,7 +159,7 @@ namespace SerialLoops.Lib
                 EmulatorPath = emulatorPath,
                 UseDocker = false,
                 DevkitArmDockerTag = "latest",
-                AutoReopenLastProject = true,
+                AutoReopenLastProject = false,
                 RememberProjectWorkspace = true,
                 RemoveMissingProjects = false,
                 CheckForUpdates = true,

--- a/src/SerialLoops.Lib/Hacks/AsmHack.cs
+++ b/src/SerialLoops.Lib/Hacks/AsmHack.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Emit;
 using System.Text.Json.Serialization;
 
 namespace SerialLoops.Lib.Hacks

--- a/src/SerialLoops.Lib/Items/BackgroundMusicItem.cs
+++ b/src/SerialLoops.Lib/Items/BackgroundMusicItem.cs
@@ -55,18 +55,20 @@ namespace SerialLoops.Lib.Items
             // So we just convert to WAV AOT
             if (Path.GetExtension(audioFile).Equals(".mp3", StringComparison.OrdinalIgnoreCase))
             {
+                string mp3ConvertedFile = Path.Combine(Path.GetDirectoryName(bgmCachedFile), $"{Path.GetFileNameWithoutExtension(bgmCachedFile)}-converted.wav");
                 log.Log($"Converting {audioFile} to WAV...");
                 using Mp3FileReaderBase mp3Reader = new(audioFile, new Mp3FileReaderBase.FrameDecompressorBuilder(wf => new Mp3FrameDecompressor(wf)));
-                WaveFileWriter.CreateWaveFile(bgmCachedFile, mp3Reader.ToSampleProvider().ToWaveProvider16());
-                audioFile = bgmCachedFile;
+                WaveFileWriter.CreateWaveFile(mp3ConvertedFile, mp3Reader.ToSampleProvider().ToWaveProvider16());
+                audioFile = mp3ConvertedFile;
             }
             // Ditto the Vorbis decoder
             else if (Path.GetExtension(audioFile).Equals(".ogg", StringComparison.OrdinalIgnoreCase))
             {
+                string oggConvertedFile = Path.Combine(Path.GetDirectoryName(bgmCachedFile), $"{Path.GetFileNameWithoutExtension(bgmCachedFile)}-converted.wav");
                 log.Log($"Converting {audioFile} to WAV...");
                 using VorbisWaveReader vorbisReader = new(audioFile);
-                WaveFileWriter.CreateWaveFile(bgmCachedFile, vorbisReader.ToSampleProvider().ToWaveProvider16());
-                audioFile = bgmCachedFile;
+                WaveFileWriter.CreateWaveFile(oggConvertedFile, vorbisReader.ToSampleProvider().ToWaveProvider16());
+                audioFile = oggConvertedFile;
             }
             using WaveStream audio = Path.GetExtension(audioFile).ToLower() switch
             {

--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -142,7 +142,6 @@ namespace SerialLoops.Lib.Items
                         Event.LabelsSection.Objects.RemoveAt(i);
                         i--;
                     }
-                    Event.LabelsSection.Objects = Event.LabelsSection.Objects.DistinctBy(s => s.Name).ToList();
                 }
             }
         }

--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -23,6 +23,7 @@ namespace SerialLoops.Lib.Items
         {
             Event = evt;
 
+            PruneLabelsSection();
             Graph.AddVertexRange(Event.ScriptSections);
         }
 
@@ -122,6 +123,26 @@ namespace SerialLoops.Lib.Items
                 if (section != commandTree.Keys.Last())
                 {
                     Graph.AddEdge(new() { Source = section, Target = commandTree.Keys.ElementAt(commandTree.Keys.ToList().IndexOf(section) + 1) });
+                }
+            }
+        }
+
+        public void PruneLabelsSection()
+        {
+            if (Event.LabelsSection.Objects.Count - 1 > Event.ScriptSections.Count)
+            {
+                for (int i = 0; i < Event.LabelsSection.Objects.Count; i++)
+                {
+                    if (Event.LabelsSection.Objects[i].Id == 0)
+                    {
+                        continue;
+                    }
+                    if (!Event.ScriptSections.Select(s => s.Name).Contains(Event.LabelsSection.Objects[i].Name.Replace("/", "")))
+                    {
+                        Event.LabelsSection.Objects.RemoveAt(i);
+                        i--;
+                    }
+                    Event.LabelsSection.Objects = Event.LabelsSection.Objects.DistinctBy(s => s.Name).ToList();
                 }
             }
         }

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -108,7 +108,6 @@ namespace SerialLoops.Lib
             SUCCESS,
             LOOSELEAF_FILES,
             CORRUPTED_FILE,
-            DEVKITARM_OUTOFDATE,
             NOT_FOUND,
             FAILED,
         }
@@ -148,14 +147,10 @@ namespace SerialLoops.Lib
             {
                 string devkitARMVersionish = Path.GetFileNameWithoutExtension(Directory.GetDirectories(Path.Combine(config.DevkitArmPath, "lib", "gcc", "arm-none-eabi"))[0]);
 
+                log.Log($"DevkitARM version detected as {devkitARMVersionish}");
                 if (!makefile.Contains(devkitARMVersionish))
                 {
                     log.LogError($"DevkitARM is most likely out of date! (Or, possibly, we are!) If you haven't installed devkitARM recently, consider upgrading.");
-                    return new(LoadProjectState.DEVKITARM_OUTOFDATE);
-                }
-                else
-                {
-                    log.Log($"DevkitARM version detected as {devkitARMVersionish}");
                 }
             }
             if (Directory.GetFiles(Path.Combine(IterativeDirectory, "assets"), "*", SearchOption.AllDirectories).Length > 0)

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -488,7 +488,6 @@ namespace SerialLoops.Lib
         {
             if (Directory.Exists(cachesDirectory))
             {
-                IO.DeleteFilesKeepDirectories(cachesDirectory);
                 Directory.Delete(cachesDirectory, true);
             }
 

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -488,6 +488,7 @@ namespace SerialLoops.Lib
         {
             if (Directory.Exists(cachesDirectory))
             {
+                IO.DeleteFilesKeepDirectories(cachesDirectory);
                 Directory.Delete(cachesDirectory, true);
             }
 

--- a/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
@@ -169,7 +169,9 @@ namespace SerialLoops.Lib.Script
                     case CommandVerb.BG_DISP2:
                         if (i == 0)
                         {
-                            parameters.Add(new BgScriptParameter("Background", (BackgroundItem)project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter), kinetic: false));
+                            ItemDescription bgItem = project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter)
+                                ?? project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType == HaruhiChokuretsuLib.Archive.Data.BgType.TEX_BG);
+                            parameters.Add(new BgScriptParameter("Background", (BackgroundItem)bgItem, kinetic: false));
                         }
                         break;
                     case CommandVerb.SCREEN_FADEIN:
@@ -659,7 +661,10 @@ namespace SerialLoops.Lib.Script
                         switch (i)
                         {
                             case 0:
-                                parameters.Add(new BgScriptParameter("Background", (BackgroundItem)project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter), kinetic: false));
+                                ItemDescription cgItem = project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter)
+                                    ?? project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType == HaruhiChokuretsuLib.Archive.Data.BgType.TEX_CG);
+
+                                parameters.Add(new BgScriptParameter("Background", (BackgroundItem)cgItem, kinetic: false));
                                 break;
                             case 1:
                                 parameters.Add(new BoolScriptParameter("Display from Bottom", parameter == 1));

--- a/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
@@ -169,7 +169,7 @@ namespace SerialLoops.Lib.Script
                     case CommandVerb.BG_DISP2:
                         if (i == 0)
                         {
-                            ItemDescription bgItem = project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter)
+                            ItemDescription bgItem = project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter)
                                 ?? project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType == HaruhiChokuretsuLib.Archive.Data.BgType.TEX_BG);
                             parameters.Add(new BgScriptParameter("Background", (BackgroundItem)bgItem, kinetic: false));
                         }
@@ -661,7 +661,7 @@ namespace SerialLoops.Lib.Script
                         switch (i)
                         {
                             case 0:
-                                ItemDescription cgItem = project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter)
+                                ItemDescription cgItem = project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).Id == parameter)
                                     ?? project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType == HaruhiChokuretsuLib.Archive.Data.BgType.TEX_CG);
 
                                 parameters.Add(new BgScriptParameter("Background", (BackgroundItem)cgItem, kinetic: false));

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="2.8.2.3" />
     <PackageReference Include="HaruhiChokuretsuLib" Version="0.29.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.2.4" />
+    <PackageReference Include="NitroPacker.Core" Version="2.2.5" />
     <PackageReference Include="NLayer" Version="1.14.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.3.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="2.8.2.3" />
     <PackageReference Include="HaruhiChokuretsuLib" Version="0.29.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.2.3" />
+    <PackageReference Include="NitroPacker.Core" Version="2.2.4" />
     <PackageReference Include="NLayer" Version="1.14.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.3.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="2.8.2.3" />
     <PackageReference Include="HaruhiChokuretsuLib" Version="0.29.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.2.1" />
+    <PackageReference Include="NitroPacker.Core" Version="2.2.3" />
     <PackageReference Include="NLayer" Version="1.14.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.3.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />

--- a/src/SerialLoops.Lib/Sources/hacks.json
+++ b/src/SerialLoops.Lib/Sources/hacks.json
@@ -19,8 +19,8 @@
                 "Symbols": []
             },
             {
-                "File": "nullifyAttractSequenceTimer_asm.s",
-                "Destination": "overlays/main_0002/source/nullifyAttractSequenceTimer_asm.s",
+                "File": "disableAttractSequenceTimer_asm.s",
+                "Destination": "overlays/main_0002/source/disableAttractSequenceTimer_asm.s",
                 "Symbols": []
             }
         ]

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -152,34 +152,6 @@ namespace SerialLoops.Dialogs
                     paths = pathVariable.Split(':');
                 }
 
-                string makeExe = Platform.IsWpf ? "make.exe" : "make";
-                string dockerExe = Platform.IsWpf ? "docker.exe" : "docker";
-                foreach (string path in paths)
-                {
-                    if (File.Exists(Path.Combine(path, makeExe)))
-                    {
-                        makePath = Path.Combine(path, makeExe);
-                    }
-                    if (File.Exists(Path.Combine(path, dockerExe)))
-                    {
-                        dockerPath = Path.Combine(path, dockerExe);
-                    }
-                    if (!string.IsNullOrEmpty(makePath) && !string.IsNullOrEmpty(dockerPath))
-                    {
-                        break;
-                    }
-                }
-                if (string.IsNullOrEmpty(makePath))
-                {
-                    log.LogWarning("Failed to find make executable on path; defaulting to 'make'...");
-                    makePath = makeExe;
-                }
-                if (string.IsNullOrEmpty(dockerPath))
-                {
-                    log.LogWarning("Failed to find docker executable on path; defaulting to 'docker'...");
-                    dockerPath = dockerExe;
-                }
-
                 // Build and insert ARM9 hacks
                 if (appliedHacks.Any(h => h.Files.Any(f => !f.Destination.Contains("overlays", StringComparison.OrdinalIgnoreCase))))
                 {
@@ -199,8 +171,7 @@ namespace SerialLoops.Dialogs
                     {
                         ARM9AsmHack.Insert(Path.Combine(project.BaseDirectory, "src"), arm9, 0x02005ECC, config.UseDocker ? config.DevkitArmDockerTag : string.Empty,
                             (object sender, DataReceivedEventArgs e) => log.Log(e.Data),
-                            (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data),
-                            makePath, dockerPath);
+                            (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data));
                     }
                     catch (Exception ex)
                     {
@@ -256,8 +227,7 @@ namespace SerialLoops.Dialogs
                             {
                                 OverlayAsmHack.Insert(overlaySourceDir, overlays[i], newRomInfoPath, config.UseDocker ? config.DevkitArmDockerTag : string.Empty,
                                     (object sender, DataReceivedEventArgs e) => log.Log(e.Data),
-                                    (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data),
-                                    makePath, dockerPath);
+                                    (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data));
                             }
                             catch (Exception ex)
                             {

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -158,7 +158,8 @@ namespace SerialLoops.Dialogs
                     {
                         ARM9AsmHack.Insert(Path.Combine(project.BaseDirectory, "src"), arm9, 0x02005ECC, config.UseDocker ? config.DevkitArmDockerTag : string.Empty,
                             (object sender, DataReceivedEventArgs e) => log.Log(e.Data),
-                            (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data));
+                            (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data),
+                            devkitArmPath: config.DevkitArmPath);
                     }
                     catch (Exception ex)
                     {
@@ -214,7 +215,8 @@ namespace SerialLoops.Dialogs
                             {
                                 OverlayAsmHack.Insert(overlaySourceDir, overlays[i], newRomInfoPath, config.UseDocker ? config.DevkitArmDockerTag : string.Empty,
                                     (object sender, DataReceivedEventArgs e) => log.Log(e.Data),
-                                    (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data));
+                                    (object sender, DataReceivedEventArgs e) => log.LogWarning(e.Data),
+                                    devkitArmPath: config.DevkitArmPath);
                             }
                             catch (Exception ex)
                             {

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -139,19 +139,6 @@ namespace SerialLoops.Dialogs
                     }
                 }
 
-                // Get make and docker paths
-                string makePath = string.Empty, dockerPath = string.Empty;
-                string pathVariable = Environment.GetEnvironmentVariable("PATH") ?? "";
-                string[] paths;
-                if (Platform.IsWpf)
-                {
-                    paths = pathVariable.Split(';');
-                }
-                else
-                {
-                    paths = pathVariable.Split(':');
-                }
-
                 // Build and insert ARM9 hacks
                 if (appliedHacks.Any(h => h.Files.Any(f => !f.Destination.Contains("overlays", StringComparison.OrdinalIgnoreCase))))
                 {

--- a/src/SerialLoops/Dialogs/PreferencesDialog.cs
+++ b/src/SerialLoops/Dialogs/PreferencesDialog.cs
@@ -75,13 +75,15 @@ namespace SerialLoops.Dialogs
                             {
                                 Name = "Use Docker for ASM Hacks",
                                 Value = Configuration.UseDocker,
-                                OnChange = (value) => Configuration.UseDocker = value
+                                OnChange = (value) => Configuration.UseDocker = value,
+                                Enabled = !Platform.IsMac,
                             },
                             new TextOption
                             {
                                 Name = "DevkitARM Docker Tag",
                                 Value = Configuration.DevkitArmDockerTag,
-                                OnChange = (value) => Configuration.DevkitArmDockerTag = value
+                                OnChange = (value) => Configuration.DevkitArmDockerTag = value,
+                                Enabled = !Platform.IsMac,
                             },
                         }
                     ),

--- a/src/SerialLoops/Editors/CharacterEditor.cs
+++ b/src/SerialLoops/Editors/CharacterEditor.cs
@@ -138,8 +138,8 @@ namespace SerialLoops.Editors
                         }
                     }),
                     nameplatePreviewLayout,
-                    ControlGenerator.GetControlWithLabel("Voice Font", new NumericStepper { Value = _character.MessageInfo.VoiceFont }),
-                    ControlGenerator.GetControlWithLabel("Text Timer", new NumericStepper { Value = _character.MessageInfo.TextTimer }),
+                    ControlGenerator.GetControlWithLabel("Voice Font", new NumericStepper { Value = _character.MessageInfo.VoiceFont, Enabled = false }),
+                    ControlGenerator.GetControlWithLabel("Text Timer", new NumericStepper { Value = _character.MessageInfo.TextTimer, Enabled = false }),
                 },
             };
         }

--- a/src/SerialLoops/Editors/PlaceEditor.cs
+++ b/src/SerialLoops/Editors/PlaceEditor.cs
@@ -4,10 +4,8 @@ using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Utility;
 using SkiaSharp;
-using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using Topten.RichTextKit;
 
 namespace SerialLoops.Editors
 {

--- a/src/SerialLoops/Editors/PuzzleEditor.cs
+++ b/src/SerialLoops/Editors/PuzzleEditor.cs
@@ -62,13 +62,13 @@ namespace SerialLoops.Editors
             
             mainLayout.Items.Add(panel1);
             
-            DropDown accompanyingCharacterDropdown = new();
+            DropDown accompanyingCharacterDropdown = new() { Enabled = false };
             accompanyingCharacterDropdown.Items.AddRange(PuzzleItem.Characters.Select(c => new ListItem() { Text = c, Key = c }));
             accompanyingCharacterDropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.AccompanyingCharacter);
-            DropDown powerCharacter1Dropdown = new();
+            DropDown powerCharacter1Dropdown = new() { Enabled = false };
             powerCharacter1Dropdown.Items.AddRange(PuzzleItem.Characters.Select(c => new ListItem() { Text = c, Key = c }));
             powerCharacter1Dropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.PowerCharacter1);
-            DropDown powerCharacter2Dropdown = new();
+            DropDown powerCharacter2Dropdown = new() { Enabled = false };
             powerCharacter2Dropdown.Items.AddRange(PuzzleItem.Characters.Select(c => new ListItem() { Text = c, Key = c }));
             powerCharacter2Dropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.PowerCharacter2);
 
@@ -90,19 +90,19 @@ namespace SerialLoops.Editors
                             Items =
                             {
                                 ControlGenerator.GetControlWithLabel("Map", ControlGenerator.GetFileLink(map, _tabs, _log)),
-                                ControlGenerator.GetControlWithLabel("Base Time", new TextBox { Text = _puzzle.Puzzle.Settings.BaseTime.ToString() }),
-                                ControlGenerator.GetControlWithLabel("Number of Singularities", new TextBox { Text = _puzzle.Puzzle.Settings.NumSingularities.ToString() }),
-                                ControlGenerator.GetControlWithLabel("Unknown 04", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown04.ToString() }),
-                                ControlGenerator.GetControlWithLabel("Target Number", new TextBox { Text = _puzzle.Puzzle.Settings.TargetNumber.ToString() }),
-                                ControlGenerator.GetControlWithLabel("Continue on Failure", new CheckBox { Checked = _puzzle.Puzzle.Settings.ContinueOnFailure }),
+                                ControlGenerator.GetControlWithLabel("Base Time", new TextBox { Text = _puzzle.Puzzle.Settings.BaseTime.ToString(), Enabled = false }),
+                                ControlGenerator.GetControlWithLabel("Number of Singularities", new TextBox { Text = _puzzle.Puzzle.Settings.NumSingularities.ToString(), Enabled = false }),
+                                ControlGenerator.GetControlWithLabel("Unknown 04", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown04.ToString(), Enabled = false }),
+                                ControlGenerator.GetControlWithLabel("Target Number", new TextBox { Text = _puzzle.Puzzle.Settings.TargetNumber.ToString(), Enabled = false }),
+                                ControlGenerator.GetControlWithLabel("Continue on Failure", new CheckBox { Checked = _puzzle.Puzzle.Settings.ContinueOnFailure, Enabled = false }),
                                 ControlGenerator.GetControlWithLabel("Accompanying Character", accompanyingCharacterDropdown),
                                 ControlGenerator.GetControlWithLabel("Power Character 1", powerCharacter1Dropdown),
                                 ControlGenerator.GetControlWithLabel("Power Character 2", powerCharacter2Dropdown),
                                 ControlGenerator.GetControlWithLabel("Singularity", new SKGuiImage(_puzzle.SingularityImage)),
-                                ControlGenerator.GetControlWithLabel("Topic Set", new TextBox { Text = _puzzle.Puzzle.Settings.TopicSet.ToString() }),
-                                ControlGenerator.GetControlWithLabel("Unknown 15", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown15.ToString() }),
-                                ControlGenerator.GetControlWithLabel("Unknown 16", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown16.ToString() }),
-                                ControlGenerator.GetControlWithLabel("Unknown 17", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown17.ToString() }),
+                                ControlGenerator.GetControlWithLabel("Topic Set", new TextBox { Text = _puzzle.Puzzle.Settings.TopicSet.ToString(), Enabled = false }),
+                                ControlGenerator.GetControlWithLabel("Unknown 15", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown15.ToString(), Enabled = false }),
+                                ControlGenerator.GetControlWithLabel("Unknown 16", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown16.ToString(), Enabled = false }),
+                                ControlGenerator.GetControlWithLabel("Unknown 17", new TextBox { Text = _puzzle.Puzzle.Settings.Unknown17.ToString(), Enabled = false }),
                             },
                         },
                     },

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -992,8 +992,8 @@ namespace SerialLoops.Editors
                         StackLayout bgmLink = ControlGenerator.GetFileLink(bgmParam.Bgm, _tabs, _log);
 
                         ScriptCommandDropDown bgmDropDown = new() { Command = command, ParameterIndex = i, Link = (ClearableLinkButton)bgmLink.Items[1].Control };
-                        bgmDropDown.Items.AddRange(_project.Items.Where(i => i.Type == ItemDescription.ItemType.BGM).Select(i => new ListItem { Text = i.Name, Key = i.Name }));
-                        bgmDropDown.SelectedKey = bgmParam.Bgm.Name;
+                        bgmDropDown.Items.AddRange(_project.Items.Where(i => i.Type == ItemDescription.ItemType.BGM).Select(i => new ListItem { Text = i.DisplayName, Key = i.DisplayName }));
+                        bgmDropDown.SelectedKey = bgmParam.Bgm.DisplayName;
                         bgmDropDown.SelectedKeyChanged += BgmDropDown_SelectedKeyChanged;
 
                         StackLayout bgmLayout = new()
@@ -2057,11 +2057,11 @@ namespace SerialLoops.Editors
         {
             ScriptCommandDropDown dropDown = (ScriptCommandDropDown)sender;
             _log.Log($"Attempting to modify parameter {dropDown.ParameterIndex} to BGM {dropDown.SelectedKey} in {dropDown.Command.Index} in file {_script.Name}...");
-            BackgroundMusicItem bgm = (BackgroundMusicItem)_project.Items.FirstOrDefault(i => i.Name == dropDown.SelectedKey);
+            BackgroundMusicItem bgm = (BackgroundMusicItem)_project.Items.FirstOrDefault(i => i.DisplayName == dropDown.SelectedKey);
             ((BgmScriptParameter)dropDown.Command.Parameters[dropDown.ParameterIndex]).Bgm = bgm;
             _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(dropDown.Command.Section)]
                 .Objects[dropDown.Command.Index].Parameters[dropDown.ParameterIndex] =
-                (short)((BackgroundMusicItem)_project.Items.First(i => i.Name == dropDown.SelectedKey)).Index;
+                (short)((BackgroundMusicItem)_project.Items.First(i => i.DisplayName == dropDown.SelectedKey)).Index;
 
             dropDown.Link.Text = bgm.DisplayName;
             dropDown.Link.RemoveAllClickEvents();
@@ -2488,7 +2488,7 @@ namespace SerialLoops.Editors
 
             dropDown.Link.Text = dropDown.SelectedKey;
             dropDown.Link.RemoveAllClickEvents();
-            dropDown.Link.ClickUnique += (s, e) => { _tabs.OpenTab(_project.Items.FirstOrDefault(i => i.Name == dropDown.SelectedKey), _log); };
+            dropDown.Link.ClickUnique += (s, e) => { _tabs.OpenTab(_project.Items.FirstOrDefault(i => i.DisplayName == dropDown.SelectedKey), _log); };
 
             UpdateTabTitle(false, dropDown);
         }

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -2065,7 +2065,7 @@ namespace SerialLoops.Editors
 
             dropDown.Link.Text = bgm.DisplayName;
             dropDown.Link.RemoveAllClickEvents();
-            dropDown.Link.ClickUnique += (s, e) => { _tabs.OpenTab(_project.Items.FirstOrDefault(i => i.Name == dropDown.SelectedKey), _log); };
+            dropDown.Link.ClickUnique += (s, e) => { _tabs.OpenTab(_project.Items.FirstOrDefault(i => i.DisplayName == dropDown.SelectedKey), _log); };
 
             UpdateTabTitle(false, dropDown);
         }
@@ -2541,14 +2541,14 @@ namespace SerialLoops.Editors
             else
             {
                 ((VoicedLineScriptParameter)dropDown.Command.Parameters[dropDown.ParameterIndex]).VoiceLine =
-                    (VoicedLineItem)_project.Items.FirstOrDefault(i => i.Name == dropDown.SelectedKey);
+                    (VoicedLineItem)_project.Items.FirstOrDefault(i => i.DisplayName == dropDown.SelectedKey);
                 _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(dropDown.Command.Section)]
                     .Objects[dropDown.Command.Index].Parameters[dropDown.ParameterIndex] =
-                    (short)((VoicedLineItem)_project.Items.First(i => i.Name == dropDown.SelectedKey)).Index;
+                    (short)((VoicedLineItem)_project.Items.First(i => i.DisplayName == dropDown.SelectedKey)).Index;
             }
             dropDown.Link.Text = dropDown.SelectedKey;
             dropDown.Link.RemoveAllClickEvents();
-            dropDown.Link.ClickUnique += (s, e) => { _tabs.OpenTab(_project.Items.FirstOrDefault(i => i.Name == dropDown.SelectedKey), _log); };
+            dropDown.Link.ClickUnique += (s, e) => { _tabs.OpenTab(_project.Items.FirstOrDefault(i => i.DisplayName == dropDown.SelectedKey), _log); };
 
             UpdateTabTitle(false, dropDown);
         }

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1264,7 +1264,7 @@ namespace SerialLoops.Editors
                         {
                             Command = command,
                             ParameterIndex = i,
-                            CurrentShort = i
+                            CurrentShort = currentShort,
                         };
                         screenSelector.ScreenChanged += ScreenSelector_ScreenChanged;
 

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -931,12 +931,12 @@ namespace SerialLoops.Editors
                             ParameterIndex = i,
                             Project = _project,
                         };
-                        bgSelectionButton.Items.Add(NonePreviewableGraphic.BACKGROUND);
 
                         // BGDISPTEMP is able to display a lot more kinds of backgrounds properly than the other BG commands
                         // Hence, this switch to make sure you don't accidentally crash the game
                         if (command.Verb == CommandVerb.BG_FADE)
                         {
+                            bgSelectionButton.Items.Add(NonePreviewableGraphic.BACKGROUND);
                             switch (i)
                             {
                                 case 0:

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1034,7 +1034,7 @@ namespace SerialLoops.Editors
                     case ScriptParameter.ParameterType.CHARACTER:
                         ScriptCommandDropDown dialoguePropertyDropDown = new() { Command = command, ParameterIndex = i };
                         dialoguePropertyDropDown.Items.AddRange(_project.Items.Where(i => i.Type == ItemDescription.ItemType.Character)
-                            .Select(c => new ListItem { Key = c.Name, Text = c.Name[4..] }));
+                            .Select(c => new ListItem { Key = c.DisplayName, Text = c.DisplayName[4..] }));
                         dialoguePropertyDropDown.SelectedKey = ((DialoguePropertyScriptParameter)parameter).Character.Name;
                         dialoguePropertyDropDown.SelectedKeyChanged += DialoguePropertyDropDown_SelectedKeyChanged;
                         _currentSpeakerDropDown.OtherDropDowns.Add(dialoguePropertyDropDown);
@@ -2256,7 +2256,7 @@ namespace SerialLoops.Editors
         private void DialoguePropertyDropDown_SelectedKeyChanged(object sender, EventArgs e)
         {
             ScriptCommandDropDown dropDown = (ScriptCommandDropDown)sender;
-            CharacterItem character = (CharacterItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Character && i.Name == dropDown.SelectedKey);
+            CharacterItem character = (CharacterItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Character && i.DisplayName.Equals(dropDown.SelectedKey));
             _log.Log($"Attempting to modify dialogue property in parameter {dropDown.ParameterIndex} to dialogue {dropDown.SelectedKey} in {dropDown.Command.Index} in file {_script.Name}...");
             ((DialoguePropertyScriptParameter)dropDown.Command.Parameters[dropDown.ParameterIndex]).Character = character;
             _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(dropDown.Command.Section)].Objects[dropDown.Command.Index]

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1788,7 +1788,7 @@ namespace SerialLoops.Editors
                                 case SpriteExitScriptParameter.SpriteExitTransition.SLIDE_FROM_CENTER_TO_RIGHT_FADE_OUT:
                                 case SpriteExitScriptParameter.SpriteExitTransition.FADE_OUT_CENTER:
                                 case SpriteExitScriptParameter.SpriteExitTransition.FADE_OUT_LEFT:
-                                    if (sprites.ContainsKey(prevCharacter) && previousSprites.ContainsKey(prevCharacter) && (sprites[prevCharacter].Sprite == previousSprites[prevCharacter].Sprite || ((SpriteEntranceScriptParameter)previousCommand.Parameters[2]).EntranceTransition != SpriteEntranceScriptParameter.SpriteEntranceTransition.NO_TRANSITION))
+                                    if (sprites.ContainsKey(prevCharacter) && previousSprites.ContainsKey(prevCharacter))
                                     {
                                         sprites.Remove(prevCharacter);
                                         previousSprites.Remove(prevCharacter);
@@ -2203,7 +2203,7 @@ namespace SerialLoops.Editors
             int currentCaretIndex = textArea.CaretIndex;
             textArea.FireTextChanged = false;
             textArea.Text = Regex.Replace(textArea.Text, @"^""", "“");
-            textArea.Text = Regex.Replace(textArea.Text, @"\s""", "“");
+            textArea.Text = Regex.Replace(textArea.Text, @"(\s)""", "$1“");
             textArea.Text = textArea.Text.Replace('"', '”');
             textArea.FireTextChanged = true;
             textArea.CaretIndex = currentCaretIndex;

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1791,7 +1791,7 @@ namespace SerialLoops.Editors
                                 case SpriteExitScriptParameter.SpriteExitTransition.SLIDE_FROM_CENTER_TO_RIGHT_FADE_OUT:
                                 case SpriteExitScriptParameter.SpriteExitTransition.FADE_OUT_CENTER:
                                 case SpriteExitScriptParameter.SpriteExitTransition.FADE_OUT_LEFT:
-                                    if (sprites.ContainsKey(prevCharacter) && previousSprites.ContainsKey(prevCharacter) && previousSprites[prevCharacter].Sprite.Sprite.Character == prevCharacter.MessageInfo.Character)
+                                    if (sprites.ContainsKey(prevCharacter) && previousSprites.ContainsKey(prevCharacter) && ((SpriteScriptParameter)previousCommand.Parameters[1]).Sprite?.Sprite?.Character == prevCharacter.MessageInfo.Character)
                                     {
                                         sprites.Remove(prevCharacter);
                                         previousSprites.Remove(prevCharacter);

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1788,7 +1788,7 @@ namespace SerialLoops.Editors
                                 case SpriteExitScriptParameter.SpriteExitTransition.SLIDE_FROM_CENTER_TO_RIGHT_FADE_OUT:
                                 case SpriteExitScriptParameter.SpriteExitTransition.FADE_OUT_CENTER:
                                 case SpriteExitScriptParameter.SpriteExitTransition.FADE_OUT_LEFT:
-                                    if (sprites.ContainsKey(prevCharacter) && previousSprites.ContainsKey(prevCharacter))
+                                    if (sprites.ContainsKey(prevCharacter) && previousSprites.ContainsKey(prevCharacter) && previousSprites[prevCharacter].Sprite.Sprite.Character == prevCharacter.MessageInfo.Character)
                                     {
                                         sprites.Remove(prevCharacter);
                                         previousSprites.Remove(prevCharacter);

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -216,7 +216,7 @@ namespace SerialLoops.Editors
                                     break;
 
                                 case CommandVerb.BG_DISPCG:
-                                    invocation.Parameters[0] = (short)((BackgroundItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType != BgType.KINETIC_SCREEN && ((BackgroundItem)i).BackgroundType != BgType.TEX_BG).Id;
+                                    invocation.Parameters[0] = (short)((BackgroundItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType != BgType.KINETIC_SCREEN && ((BackgroundItem)i).BackgroundType != BgType.TEX_BG)).Id;
                                     break;
 
                                 case CommandVerb.BG_SCROLL:

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -212,8 +212,11 @@ namespace SerialLoops.Editors
                             {
                                 case CommandVerb.BG_DISP:
                                 case CommandVerb.BG_DISP2:
+                                    invocation.Parameters[0] = (short)((BackgroundItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType == BgType.TEX_BG)).Id;
+                                    break;
+
                                 case CommandVerb.BG_DISPCG:
-                                    invocation.Parameters[0] = (short)((BackgroundItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType != BgType.KINETIC_SCREEN)).Id;
+                                    invocation.Parameters[0] = (short)((BackgroundItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Background && ((BackgroundItem)i).BackgroundType != BgType.KINETIC_SCREEN && ((BackgroundItem)i).BackgroundType != BgType.TEX_BG).Id;
                                     break;
 
                                 case CommandVerb.BG_SCROLL:

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -519,10 +519,6 @@ namespace SerialLoops
             LoopyProgressTracker tracker = new();
             _ = new ProgressDialog(() => (OpenProject, result) = Project.OpenProject(path, CurrentConfig, Log, tracker),
                 () => { }, tracker, "Loading Project");
-            if (result.State == Project.LoadProjectState.DEVKITARM_OUTOFDATE)
-            {
-                OpenProject = null;
-            }
             if (OpenProject is not null && result.State == Project.LoadProjectState.LOOSELEAF_FILES)
             {
                 if (MessageBox.Show("Saved but unbuilt files were detected in the project directory. " +

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -415,11 +415,7 @@ namespace SerialLoops
         {
             base.OnLoad(e);
             Log = new();
-            CurrentConfig = Config.LoadConfig(Platform.IsMac, Log);
-            if (Platform.IsMac)
-            {
-                Environment.SetEnvironmentVariable("PATH", CurrentConfig.MacOSPath);
-            }
+            CurrentConfig = Config.LoadConfig(Log);
             Log.Initialize(CurrentConfig);
             ProjectsCache = ProjectsCache.LoadCache(CurrentConfig, Log);
             UpdateRecentProjects();

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -415,7 +415,11 @@ namespace SerialLoops
         {
             base.OnLoad(e);
             Log = new();
-            CurrentConfig = Config.LoadConfig(Log);
+            CurrentConfig = Config.LoadConfig(!Platform.IsWpf, Log);
+            if (!Platform.IsWpf)
+            {
+                Environment.SetEnvironmentVariable("PATH", CurrentConfig.UnixPath);
+            }
             Log.Initialize(CurrentConfig);
             ProjectsCache = ProjectsCache.LoadCache(CurrentConfig, Log);
             UpdateRecentProjects();

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -415,7 +415,11 @@ namespace SerialLoops
         {
             base.OnLoad(e);
             Log = new();
-            CurrentConfig = Config.LoadConfig(Log);
+            CurrentConfig = Config.LoadConfig(Platform.IsMac, Log);
+            if (Platform.IsMac)
+            {
+                Environment.SetEnvironmentVariable("PATH", CurrentConfig.MacOSPath);
+            }
             Log.Initialize(CurrentConfig);
             ProjectsCache = ProjectsCache.LoadCache(CurrentConfig, Log);
             UpdateRecentProjects();

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -415,10 +415,10 @@ namespace SerialLoops
         {
             base.OnLoad(e);
             Log = new();
-            CurrentConfig = Config.LoadConfig(!Platform.IsWpf, Log);
-            if (!Platform.IsWpf)
+            CurrentConfig = Config.LoadConfig(Platform.IsMac, Log);
+            if (Platform.IsMac)
             {
-                Environment.SetEnvironmentVariable("PATH", CurrentConfig.UnixPath);
+                Environment.SetEnvironmentVariable("PATH", CurrentConfig.MacOSPath);
             }
             Log.Initialize(CurrentConfig);
             ProjectsCache = ProjectsCache.LoadCache(CurrentConfig, Log);

--- a/src/SerialLoops/Utility/OptionPanels.cs
+++ b/src/SerialLoops/Utility/OptionPanels.cs
@@ -36,6 +36,8 @@ namespace SerialLoops.Utility
     {
         public string Name { get; set; }
 
+        public bool Enabled { get; set; }
+
         protected abstract Control GetControl();
 
         protected virtual Control GetLabel()
@@ -74,7 +76,8 @@ namespace SerialLoops.Utility
                 Spacing = 5,
                 Orientation = Orientation.Horizontal,
                 VerticalContentAlignment = VerticalAlignment.Center,
-                Items = { _textBox }
+                Items = { _textBox },
+                Enabled = Enabled,
             };
         }
     }
@@ -105,6 +108,7 @@ namespace SerialLoops.Utility
                 Items = { _checkBox },
                 Orientation = Orientation.Horizontal,
                 VerticalContentAlignment = VerticalAlignment.Center,
+                Enabled = Enabled,
             };
         }
     }
@@ -139,7 +143,7 @@ namespace SerialLoops.Utility
 
         public BooleanToggleOption(List<Option> options)
         {
-            ToggleButton = new LinkButton { Text = _buttonText };
+            ToggleButton = new LinkButton { Text = _buttonText, Enabled = Enabled };
             ToggleButton.Click += (sender, args) =>
             {
                 options.OfType<BooleanOption>().ToList().ForEach(option => option.Value = Value);
@@ -186,8 +190,9 @@ namespace SerialLoops.Utility
         {
             _pathBox = new TextBox { Text = "", Width = 225 };
             _pathBox.TextChanged += (sender, args) => { OnChange?.Invoke(Path); };
+            _pathBox.Enabled = Enabled;
 
-            _pickerButton = new Button() { Text = "Select..." };
+            _pickerButton = new Button() { Text = "Select...", Enabled = Enabled };
             _pickerButton.Click += SelectButton_OnClick;
         }
 

--- a/src/SerialLoops/Utility/OptionPanels.cs
+++ b/src/SerialLoops/Utility/OptionPanels.cs
@@ -36,7 +36,7 @@ namespace SerialLoops.Utility
     {
         public string Name { get; set; }
 
-        public bool Enabled { get; set; }
+        public bool Enabled { get; set; } = true;
 
         protected abstract Control GetControl();
 

--- a/src/SerialLoops/Utility/Shared.cs
+++ b/src/SerialLoops/Utility/Shared.cs
@@ -51,7 +51,7 @@ namespace SerialLoops.Utility
                 string oldName = item.DisplayName;
                 DocumentPage openTab = tabs.Tabs.Pages.FirstOrDefault(p => p.Text == item.DisplayNameWithStatus);
                 item.Rename(newName);
-                if (explorer.Viewer.SelectedItem.Text.Equals(oldName))
+                if (explorer.Viewer.SelectedItem?.Text.Equals(oldName) ?? false)
                 {
                     // Unfortunately, there doesn't seem to be a good way to ensure the item gets rename if we've selected a different item
                     explorer.Viewer.SelectedItem.Text = item.DisplayName;

--- a/test/SerialLoops.Tests/CoreTests.cs
+++ b/test/SerialLoops.Tests/CoreTests.cs
@@ -46,7 +46,7 @@ namespace SerialLoops.Tests
 
             // Create a project using the extracted data
             _log.Log("Creating project...");
-            _config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
+            _config = Config.LoadConfig(_log);
             _project = new("Tester", "en", _config, _log);
             
             string archivesDir = Path.Combine("original", "archives");

--- a/test/SerialLoops.Tests/CoreTests.cs
+++ b/test/SerialLoops.Tests/CoreTests.cs
@@ -46,7 +46,7 @@ namespace SerialLoops.Tests
 
             // Create a project using the extracted data
             _log.Log("Creating project...");
-            _config = Config.LoadConfig(_log);
+            _config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             _project = new("Tester", "en", _config, _log);
             
             string archivesDir = Path.Combine("original", "archives");

--- a/test/SerialLoops.Tests/CoreTests.cs
+++ b/test/SerialLoops.Tests/CoreTests.cs
@@ -1,6 +1,5 @@
-﻿using HaruhiChokuretsuLib.Audio;
-using NAudio.Wave;
-using NUnit.Framework;
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Script;
@@ -47,7 +46,7 @@ namespace SerialLoops.Tests
 
             // Create a project using the extracted data
             _log.Log("Creating project...");
-            _config = Config.LoadConfig(_log);
+            _config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             _project = new("Tester", "en", _config, _log);
             
             string archivesDir = Path.Combine("original", "archives");

--- a/test/SerialLoops.Tests/StartUpTests.cs
+++ b/test/SerialLoops.Tests/StartUpTests.cs
@@ -1,5 +1,6 @@
 using HaruhiChokuretsuLib.Util;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using SerialLoops.Lib;
 using System.IO;
 using System.Net.Http;
@@ -19,7 +20,7 @@ namespace SerialLoops.Tests
 
         private async Task<Project> DownloadTestRom()
         {
-            Config config = Config.LoadConfig(_log);
+            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Project project = new("Test", "en", config, _log);
 
             string romPath = Path.Combine(project.MainDirectory, "bcsds.nds");
@@ -35,7 +36,7 @@ namespace SerialLoops.Tests
         public void ConfigCreationTest()
         {
             // Create default config
-            Config config = Config.LoadConfig(_log);
+            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Assert.Multiple(() =>
             {
                 Assert.That(File.Exists(config.ConfigPath), $"Config file not found at '{config.ConfigPath}'");
@@ -48,7 +49,7 @@ namespace SerialLoops.Tests
             config.Save(_log);
 
             // Load config from disk
-            Config newConfig = Config.LoadConfig(_log);
+            Config newConfig = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Assert.That(newConfig.UserDirectory, Is.EqualTo(config.UserDirectory));
 
             File.Delete(config.ConfigPath);
@@ -57,7 +58,7 @@ namespace SerialLoops.Tests
         [Test]
         public void ProjectCreationTest()
         {
-            Config config = Config.LoadConfig(_log);
+            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Project project = new("Test", "en", config, _log);
 
             Assert.Multiple(() =>

--- a/test/SerialLoops.Tests/StartUpTests.cs
+++ b/test/SerialLoops.Tests/StartUpTests.cs
@@ -20,7 +20,7 @@ namespace SerialLoops.Tests
 
         private async Task<Project> DownloadTestRom()
         {
-            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
+            Config config = Config.LoadConfig(_log);
             Project project = new("Test", "en", config, _log);
 
             string romPath = Path.Combine(project.MainDirectory, "bcsds.nds");
@@ -36,7 +36,7 @@ namespace SerialLoops.Tests
         public void ConfigCreationTest()
         {
             // Create default config
-            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
+            Config config = Config.LoadConfig(_log);
             Assert.Multiple(() =>
             {
                 Assert.That(File.Exists(config.ConfigPath), $"Config file not found at '{config.ConfigPath}'");
@@ -49,7 +49,7 @@ namespace SerialLoops.Tests
             config.Save(_log);
 
             // Load config from disk
-            Config newConfig = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
+            Config newConfig = Config.LoadConfig(_log);
             Assert.That(newConfig.UserDirectory, Is.EqualTo(config.UserDirectory));
 
             File.Delete(config.ConfigPath);
@@ -58,7 +58,7 @@ namespace SerialLoops.Tests
         [Test]
         public void ProjectCreationTest()
         {
-            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
+            Config config = Config.LoadConfig(_log);
             Project project = new("Test", "en", config, _log);
 
             Assert.Multiple(() =>

--- a/test/SerialLoops.Tests/StartUpTests.cs
+++ b/test/SerialLoops.Tests/StartUpTests.cs
@@ -20,7 +20,7 @@ namespace SerialLoops.Tests
 
         private async Task<Project> DownloadTestRom()
         {
-            Config config = Config.LoadConfig(_log);
+            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Project project = new("Test", "en", config, _log);
 
             string romPath = Path.Combine(project.MainDirectory, "bcsds.nds");
@@ -36,7 +36,7 @@ namespace SerialLoops.Tests
         public void ConfigCreationTest()
         {
             // Create default config
-            Config config = Config.LoadConfig(_log);
+            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Assert.Multiple(() =>
             {
                 Assert.That(File.Exists(config.ConfigPath), $"Config file not found at '{config.ConfigPath}'");
@@ -49,7 +49,7 @@ namespace SerialLoops.Tests
             config.Save(_log);
 
             // Load config from disk
-            Config newConfig = Config.LoadConfig(_log);
+            Config newConfig = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Assert.That(newConfig.UserDirectory, Is.EqualTo(config.UserDirectory));
 
             File.Delete(config.ConfigPath);
@@ -58,7 +58,7 @@ namespace SerialLoops.Tests
         [Test]
         public void ProjectCreationTest()
         {
-            Config config = Config.LoadConfig(_log);
+            Config config = Config.LoadConfig(OSPlatform.CurrentPlatform.Platform == OSPlatform.MacOSXPlatformID || OSPlatform.CurrentPlatform.Platform == OSPlatform.UnixPlatformID_Microsoft, _log);
             Project project = new("Test", "en", config, _log);
 
             Assert.Multiple(() =>


### PR DESCRIPTION
Just a grab bag of bugs fixed through testing.

* Fixes quite a few errors with the script preview, most notably how sprites entrances/exits are handled (matches what the game does better)
* Uses display name for BGM selector in the script editor
* Topic links would cause crashes when clicking them before, this fixes that
* Fixes a crash on macOS when renaming without a selected command
* Fixes #236 by now pruning the labels section on load, preventing an issue where scripts would have lots of extraneous section references
* The BG_DISPCG command was initialized with a TEX_BG before; this has been fixed
* Fixes #243 where trying to replace a BGM with a file that needed AOT conversion caused crashes due to me doing a bad job copying them
* Some more character rename bugs were fixed
* Disable fields in the puzzle and character editors that can't currently be edited
* Fixes some errors with the Skip OP hack
* During investigation, I found that Docker does not work on macOS at all and requires elevation on Linux. I've updated the readme and disabled those options on macOS as a result
* We now allow loading projects even if your devkitARM installation is out of date bc that's fine as long as you're not trying to apply hacks
* Added melonDS snap location as a preset on Linux
* Fixed some underlying issues with NitroPacker
* Fixed a crash related to BG_DISP being set to NONE and prevented the user from selecting none for BG_DISP and BG_DISPCG