### PR TITLE
Fixup system texture tiling replacement

### DIFF
--- a/src/SerialLoops.Lib/Items/SystemTextureItem.cs
+++ b/src/SerialLoops.Lib/Items/SystemTextureItem.cs
@@ -84,8 +84,8 @@ namespace SerialLoops.Lib.Items
                 {
                     for (int x = 0; x < bitmap.Width; x += SysTex.TileWidth)
                     {
-                        SKRect crop = new(x, y, x + 64, y + 64);
-                        SKRect dest = new(0, currentTile * 64, 64, (currentTile + 1) * 64);
+                        SKRect crop = new(x, y, x + SysTex.TileWidth, y + SysTex.TileHeight);
+                        SKRect dest = new(0, currentTile * SysTex.TileHeight, SysTex.TileWidth, (currentTile + 1) * SysTex.TileHeight);
                         tileCanvas.DrawBitmap(bitmap, crop, dest);
                         currentTile++;
                     }


### PR DESCRIPTION
Fixes #256 

I stole the code for systex replacement from the BG replacement. BGs always tile 64x64, so that's hardcoded there; I thought I replaced it with the system texture TileWidth & TileHeight properties but apparently I did not. This prevents replacement from working fully as the tiles are too big.

Works now though. :)