### PR TITLE
Fixup corrupted audio

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -247,8 +247,7 @@ stages:
           Additionally, to test the game you will need to have a Nintendo DS emulator installed. We recommend [melonDS](https://melonds.kuribo64.net/) for its accuracy.
 
           ### Windows
-          There is currently no Windows installer; instead, you simply download the zip and run the application directly. Because our application contacts GitHub's servers to check for new releases on lauch, it is possible it will get flagged by
-          firewall software &ndash; please allow it through so it can function correctly.
+          There is currently no Windows installer; instead, you simply download the zip and run the application directly. Because our application contacts GitHub's servers to check for new releases on lauch, it is possible it will get flagged by firewall software &ndash; please allow it through so it can function correctly.
 
           ### macOS
           On macOS, after dragging the app from the dmg into Applications, please run `xattr -cr /Applications/SerialLoops.Mac.app` from the Terminal in order to be able to run the app. This is required because we currently don't codesign the application, meaning macOS will refuse to run it without explicit approval from you.

--- a/src/SerialLoops.Lib/Items/BackgroundMusicItem.cs
+++ b/src/SerialLoops.Lib/Items/BackgroundMusicItem.cs
@@ -192,7 +192,8 @@ namespace SerialLoops.Lib.Items
             }
             try
             {
-                AdxDecoder decoder = new(adxBytes, log) { DoLoop = loop };
+                AdxDecoder decoder = new(adxBytes, log);
+                decoder.DoLoop = decoder.DoLoop && loop; // We manually handle looping here so that we can disable it when trying to export WAV files
                 return new AdxWaveProvider(decoder, decoder.Header.LoopInfo.EnabledInt == 1, decoder.LoopInfo.StartSample, decoder.LoopInfo.EndSample);
             }
             catch (Exception ex)
@@ -211,7 +212,8 @@ namespace SerialLoops.Lib.Items
                 }
                 try
                 {
-                    AdxDecoder decoder = new(adxBytes, log) { DoLoop = loop };
+                    AdxDecoder decoder = new(adxBytes, log);
+                    decoder.DoLoop = decoder.DoLoop && loop;
                     return new AdxWaveProvider(decoder, decoder.Header.LoopInfo.EnabledInt == 1, decoder.LoopInfo.StartSample, decoder.LoopInfo.EndSample);
                 }
                 catch (Exception nestedException)


### PR DESCRIPTION
Fixes #268.

This was my fault! I made it so we manually turn off looping in BGM audio to make it so we can export wavs, but it ironically also manually turned _on_ looping in ADX audio without loops, corrupting playback. This fixes that oversight.