### PR TITLE
Improve chibi loading perf

### DIFF
--- a/src/SerialLoops.Lib/Items/ChibiItem.cs
+++ b/src/SerialLoops.Lib/Items/ChibiItem.cs
@@ -37,26 +37,7 @@ namespace SerialLoops.Lib.Items
             ChibiEntry entry = ChibiEntries.First(c => c.Name == entryName).Chibi;
             GraphicsFile animation = grp.Files.First(f => f.Index == entry.Animation);
 
-            IEnumerable<SKBitmap> rawFrames = animation.GetAnimationFrames(grp.Files.First(f => f.Index == entry.Texture)).Select(f => f.GetImage());
-            int maxWidth = rawFrames.Max(r => r.Width);
-            int maxHeight = rawFrames.Max(r => r.Height);
-            // Frames need to be resized to have a constant width/height
-            List<SKBitmap> frames = new();
-            if (rawFrames.Any(f => f.Width != maxWidth || f.Height != maxHeight))
-            {
-                foreach (SKBitmap rawFrame in rawFrames)
-                {
-                    SKBitmap frame = new(maxWidth, maxHeight);
-                    using SKCanvas canvas = new(frame);
-                    canvas.DrawBitmap(rawFrame, 0, 0);
-                    canvas.Flush();
-                    frames.Add(frame);
-                }
-            }
-            else
-            {
-                frames.AddRange(rawFrames);
-            }
+            IEnumerable<SKBitmap> frames = animation.GetAnimationFrames(grp.Files.First(f => f.Index == entry.Texture)).Select(f => f.GetImage());
             IEnumerable<int> timings = animation.AnimationEntries.Select(a => (int)((FrameAnimationEntry)a).Time);
 
             return frames.Zip(timings);

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="2.8.2.3" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.32.0" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.32.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NitroPacker.Core" Version="2.2.5" />
     <PackageReference Include="NLayer" Version="1.14.0" />


### PR DESCRIPTION
Fixes #269.

This fix takes an underlying bugfix in the lib and gets rid of the very slow hack I put in to get around that limitation. Super easy, works beautifully.