### PR TITLE
Remove the devkitARM version dependency

### DIFF
--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -150,16 +150,6 @@ namespace SerialLoops.Lib
                 IO.CopyFileToDirectories(this, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "Makefile_main"), Path.Combine("src", "Makefile"), log);
                 IO.CopyFileToDirectories(this, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "Makefile_overlay"), Path.Combine("src", "overlays", "Makefile"), log);
             }
-            if (!string.IsNullOrEmpty(config.DevkitArmPath))
-            {
-                string devkitARMVersionish = Path.GetFileNameWithoutExtension(Directory.GetDirectories(Path.Combine(config.DevkitArmPath, "lib", "gcc", "arm-none-eabi"))[0]);
-
-                log.Log($"DevkitARM version detected as {devkitARMVersionish}");
-                if (!makefile.Contains(devkitARMVersionish))
-                {
-                    log.LogError($"DevkitARM is most likely out of date! (Or, possibly, we are!) If you haven't installed devkitARM recently, consider upgrading.");
-                }
-            }
             if (Directory.GetFiles(Path.Combine(IterativeDirectory, "assets"), "*", SearchOption.AllDirectories).Length > 0)
             {
                 return new(LoadProjectState.LOOSELEAF_FILES);

--- a/src/SerialLoops.Lib/Sources/Makefile_main
+++ b/src/SerialLoops.Lib/Sources/Makefile_main
@@ -83,7 +83,7 @@ endif
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project (order is important)
 #---------------------------------------------------------------------------------
-LIBS    := -lnds9 -lc -lgcc
+LIBS    := -lnds9 -lc
  
  
 #---------------------------------------------------------------------------------
@@ -118,7 +118,7 @@ export INCLUDE    :=    $(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
+export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
  
 .PHONY: $(BUILD) clean

--- a/src/SerialLoops.Lib/Sources/Makefile_overlay
+++ b/src/SerialLoops.Lib/Sources/Makefile_overlay
@@ -83,7 +83,7 @@ endif
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project (order is important)
 #---------------------------------------------------------------------------------
-LIBS    := -lnds9 -lc -lgcc
+LIBS    := -lnds9 -lc
  
  
 #---------------------------------------------------------------------------------
@@ -118,7 +118,7 @@ export INCLUDE    :=    $(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
+export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
  
 .PHONY: $(BUILD) clean


### PR DESCRIPTION
Fixes #305. This just removes the check for this which removes the error and also removes the dependency on libgcc, which isn't necessary for building our hacks (it's leftover boilerplate from other projects that once required it). With the removal of the libgcc dependency, we no longer need to reference the version-specific devkitARM gcc directory which means we're fully version-independent for devkitARM.