### PR TITLE
ASM hack QoL changes & upgrade to .NET 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Please file bugs in the Issues tab in this repository. Please include the follow
 Serial Loops is licensed under the GPLv3. See [LICENSE](LICENSE) for more information.
 
 ### Building
-Serial Loops requires the .NET 6.0 SDK to build. You can download it [here](https://dotnet.microsoft.com/download/dotnet/6.0). To build Serial Loops for your platform, run:
+Serial Loops requires the .NET 8.0 SDK to build. You can download it [here](https://dotnet.microsoft.com/download/dotnet/8.0). To build Serial Loops for your platform, run:
 
 ```bash
 dotnet build src/PLATFORM
@@ -97,4 +97,4 @@ Remember to replace `PLATFORM` with the platform you're on:
 * `SerialLoops.Mac` for macOS
 * `SerialLoops.Wpf` for Windows
 
-We recommend Visual Studio 2022 for development. If you'd like to contribute new features or fixes, we recommend [getting in touch on Discord first](https://discord.gg/nesRSbpeFM) before submitting a Pull Request!
+We recommend [Visual Studio 2022](https://visualstudio.microsoft.com/) on Windows or [Rider](https://www.jetbrains.com/rider/) on Linux/Mac for development. If you'd like to contribute new features or fixes, we recommend [getting in touch on Discord first](https://discord.gg/nesRSbpeFM) before submitting a pull request!

--- a/src/SerialLoops.Gtk/SerialLoops.Gtk.csproj
+++ b/src/SerialLoops.Gtk/SerialLoops.Gtk.csproj
@@ -2,7 +2,7 @@
 	
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Version>$(SLAssemblyVersion)</Version>
     <InformationalVersion>$(SLVersion)</InformationalVersion>

--- a/src/SerialLoops.Lib/Items/BackgroundItem.cs
+++ b/src/SerialLoops.Lib/Items/BackgroundItem.cs
@@ -31,7 +31,7 @@ namespace SerialLoops.Lib.Items
             BackgroundType = entry.Type;
             Graphic1 = project.Grp.Files.First(g => g.Index == entry.BgIndex1);
             Graphic2 = project.Grp.Files.FirstOrDefault(g => g.Index == entry.BgIndex2); // can be null if type is SINGLE_TEX
-            CgStruct cgEntry = project.Extra.Cgs.FirstOrDefault(c => c.BgId == Id);
+            CgExtraData cgEntry = project.Extra.Cgs.FirstOrDefault(c => c.BgId == Id);
             if (cgEntry is not null)
             {
                 CgName = cgEntry?.Name?.GetSubstitutedString(project);

--- a/src/SerialLoops.Lib/Items/GroupSelectionItem.cs
+++ b/src/SerialLoops.Lib/Items/GroupSelectionItem.cs
@@ -5,10 +5,10 @@ namespace SerialLoops.Lib.Items
 {
     public class GroupSelectionItem : Item
     {
-        public ScenarioSelectionStruct Selection { get; set; }
+        public ScenarioSelection Selection { get; set; }
         public int Index { get; set; }
 
-        public GroupSelectionItem(ScenarioSelectionStruct selection, int index, Project project) : base($"Selection {index}", ItemType.Group_Selection)
+        public GroupSelectionItem(ScenarioSelection selection, int index, Project project) : base($"Selection {index}", ItemType.Group_Selection)
         {
             Selection = selection;
             Index = index;

--- a/src/SerialLoops.Lib/Items/ItemDescription.cs
+++ b/src/SerialLoops.Lib/Items/ItemDescription.cs
@@ -108,7 +108,7 @@ namespace SerialLoops.Lib.Items
                     {
                         references.Add(scenario);
                     }
-                    references.AddRange(project.Items.Where(i => i.Type == ItemType.Group_Selection && ((GroupSelectionItem)i).Selection.RouteSelections.Where(s => s is not null).Any(s => s.Routes.Any(r => r.ScriptIndex == script.Event.Index))));
+                    references.AddRange(project.Items.Where(i => i.Type == ItemType.Group_Selection && ((GroupSelectionItem)i).Selection.Activities.Where(s => s is not null).Any(s => s.Routes.Any(r => r.ScriptIndex == script.Event.Index))));
                     references.AddRange(project.Items.Where(i => i.Type == ItemType.Topic &&
                         (((TopicItem)i).Topic.CardType != TopicCardType.Main && ((TopicItem)i).Topic.EventIndex == script.Event.Index ||
                         (((TopicItem)i).HiddenMainTopic?.EventIndex ?? -1) == script.Event.Index)));

--- a/src/SerialLoops.Lib/Items/ItemDescription.cs
+++ b/src/SerialLoops.Lib/Items/ItemDescription.cs
@@ -110,7 +110,7 @@ namespace SerialLoops.Lib.Items
                     }
                     references.AddRange(project.Items.Where(i => i.Type == ItemType.Group_Selection && ((GroupSelectionItem)i).Selection.Activities.Where(s => s is not null).Any(s => s.Routes.Any(r => r.ScriptIndex == script.Event.Index))));
                     references.AddRange(project.Items.Where(i => i.Type == ItemType.Topic &&
-                        (((TopicItem)i).Topic.CardType != TopicCardType.Main && ((TopicItem)i).Topic.EventIndex == script.Event.Index ||
+                        (((TopicItem)i).TopicEntry.CardType != TopicCardType.Main && ((TopicItem)i).TopicEntry.EventIndex == script.Event.Index ||
                         (((TopicItem)i).HiddenMainTopic?.EventIndex ?? -1) == script.Event.Index)));
                     references.AddRange(project.Items.Where(i => i.Type == ItemType.Script && ((ScriptItem)i).Event.ConditionalsSection.Objects.Contains(Name)));
                     return references;

--- a/src/SerialLoops.Lib/Items/PuzzleItem.cs
+++ b/src/SerialLoops.Lib/Items/PuzzleItem.cs
@@ -23,15 +23,15 @@ namespace SerialLoops.Lib.Items
             GraphicsFile singularityLayout = project.Grp.Files.First(f => f.Index == Puzzle.Settings.SingularityLayout);
             GraphicsFile singularityTexture = project.Grp.Files.First(f => f.Index == Puzzle.Settings.SingularityTexture);
             SingularityImage = singularityLayout.GetLayout(
-                    new List<GraphicsFile>() { singularityTexture },
+                    [singularityTexture],
                     0,
                     singularityLayout.LayoutEntries.Count,
                     false,
                     true).bitmap;
         }
 
-        public static readonly List<string> Characters = new()
-        {
+        public static readonly List<string> Characters =
+        [
             "UNKNOWN (0)",
             "KYON",
             "HARUHI",
@@ -39,6 +39,6 @@ namespace SerialLoops.Lib.Items
             "NAGATO",
             "KOIZUMI",
             "ANY",
-        };
+        ];
     }
 }

--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -31,10 +31,10 @@ namespace SerialLoops.Lib.Items
         {
             try
             {
-                Dictionary<ScriptSection, List<ScriptItemCommand>> commands = new();
+                Dictionary<ScriptSection, List<ScriptItemCommand>> commands = [];
                 foreach (ScriptSection section in Event.ScriptSections)
                 {
-                    commands.Add(section, new());
+                    commands.Add(section, []);
                     foreach (ScriptCommandInvocation command in section.Objects)
                     {
                         commands[section].Add(ScriptItemCommand.FromInvocation(command, section, commands[section].Count, Event, project, log));

--- a/src/SerialLoops.Lib/Items/TopicItem.cs
+++ b/src/SerialLoops.Lib/Items/TopicItem.cs
@@ -7,15 +7,15 @@ namespace SerialLoops.Lib.Items
 {
     public class TopicItem : Item
     {
-        public TopicStruct Topic { get; set; }
-        public TopicStruct HiddenMainTopic { get; set; }
+        public Topic Topic { get; set; }
+        public Topic HiddenMainTopic { get; set; }
         public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
-        public TopicItem(TopicStruct topicStruct, Project project) : base($"{topicStruct.Id}", ItemType.Topic)
+        public TopicItem(Topic Topic, Project project) : base($"{Topic.Id}", ItemType.Topic)
         {
-            DisplayName = $"{topicStruct.Id} - {topicStruct.Title.GetSubstitutedString(project)}";
+            DisplayName = $"{Topic.Id} - {Topic.Title.GetSubstitutedString(project)}";
             CanRename = false;
-            Topic = topicStruct;
+            Topic = Topic;
             PopulateScriptUses(project);
         }
 

--- a/src/SerialLoops.Lib/Items/TopicItem.cs
+++ b/src/SerialLoops.Lib/Items/TopicItem.cs
@@ -7,15 +7,15 @@ namespace SerialLoops.Lib.Items
 {
     public class TopicItem : Item
     {
-        public Topic Topic { get; set; }
+        public Topic TopicEntry { get; set; }
         public Topic HiddenMainTopic { get; set; }
         public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
-        public TopicItem(Topic Topic, Project project) : base($"{Topic.Id}", ItemType.Topic)
+        public TopicItem(Topic topic, Project project) : base($"{topic.Id}", ItemType.Topic)
         {
-            DisplayName = $"{Topic.Id} - {Topic.Title.GetSubstitutedString(project)}";
+            DisplayName = $"{topic.Id} - {topic.Title.GetSubstitutedString(project)}";
             CanRename = false;
-            Topic = Topic;
+            TopicEntry = topic;
             PopulateScriptUses(project);
         }
 
@@ -29,7 +29,7 @@ namespace SerialLoops.Lib.Items
             ScriptUses = project.Evt.Files.SelectMany(e =>
                 e.ScriptSections.SelectMany(sec =>
                     sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.TOPIC_GET.ToString()).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == Topic.Id).ToArray();
+                .Where(t => t.c.Parameters[0] == TopicEntry.Id).ToArray();
         }
     }
 }

--- a/src/SerialLoops.Lib/Items/VoicedLineItem.cs
+++ b/src/SerialLoops.Lib/Items/VoicedLineItem.cs
@@ -14,7 +14,7 @@ namespace SerialLoops.Lib.Items
 {
     public class VoicedLineItem : Item, ISoundItem
     {
-        private string _vceFile;
+        private readonly string _vceFile;
 
         public string VoiceFile { get; set; }
         public int Index { get; set; }
@@ -31,7 +31,7 @@ namespace SerialLoops.Lib.Items
         
         public IWaveProvider GetWaveProvider(ILogger log, bool loop = false)
         {
-            byte[] adxBytes = Array.Empty<byte>();
+            byte[] adxBytes = [];
             try
             {
                 adxBytes = File.ReadAllBytes(_vceFile);

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -609,8 +609,8 @@ namespace SerialLoops.Lib
             {
                 Evt.Files.First(f => f.Name == "TOPICS").InitializeTopicFile();
                 TopicFile = Evt.Files.First(f => f.Name == "TOPICS");
-                tracker.Focus("Topics", TopicFile.TopicStructs.Count);
-                foreach (TopicStruct topic in TopicFile.TopicStructs)
+                tracker.Focus("Topics", TopicFile.Topics.Count);
+                foreach (Topic topic in TopicFile.Topics)
                 {
                     // Main topics have shadow topics that are located at ID + 40 (this is actually how the game finds them)
                     // So if we're a main topic and we see another topic 40 back, we know we're one of these shadow topics and should really be

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -150,16 +150,6 @@ namespace SerialLoops.Lib
                 IO.CopyFileToDirectories(this, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "Makefile_main"), Path.Combine("src", "Makefile"), log);
                 IO.CopyFileToDirectories(this, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "Makefile_overlay"), Path.Combine("src", "overlays", "Makefile"), log);
             }
-            if (!string.IsNullOrEmpty(config.DevkitArmPath))
-            {
-                string devkitARMVersionish = Path.GetFileNameWithoutExtension(Directory.GetDirectories(Path.Combine(config.DevkitArmPath, "lib", "gcc", "arm-none-eabi"))[0]);
-
-                log.Log($"DevkitARM version detected as {devkitARMVersionish}");
-                if (!makefile.Contains(devkitARMVersionish))
-                {
-                    log.LogError($"DevkitARM is most likely out of date! (Or, possibly, we are!) If you haven't installed devkitARM recently, consider upgrading.");
-                }
-            }
             if (Directory.GetFiles(Path.Combine(IterativeDirectory, "assets"), "*", SearchOption.AllDirectories).Length > 0)
             {
                 return new(LoadProjectState.LOOSELEAF_FILES);

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -615,9 +615,9 @@ namespace SerialLoops.Lib
                     // Main topics have shadow topics that are located at ID + 40 (this is actually how the game finds them)
                     // So if we're a main topic and we see another topic 40 back, we know we're one of these shadow topics and should really be
                     // rolled into the original main topic
-                    if (topic.Type == TopicType.Main && Items.Any(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).Topic.Id == topic.Id - 40))
+                    if (topic.Type == TopicType.Main && Items.Any(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == topic.Id - 40))
                     {
-                        ((TopicItem)Items.First(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).Topic.Id == topic.Id - 40)).HiddenMainTopic = topic;
+                        ((TopicItem)Items.First(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == topic.Id - 40)).HiddenMainTopic = topic;
                     }
                     else
                     {

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <Version>$(SLAssemblyVersion)</Version>
@@ -10,15 +10,15 @@
 
   <ItemGroup>
     <PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="2.8.2.3" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.34.7" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.35.2" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.2.5" />
-    <PackageReference Include="NLayer" Version="1.14.0" />
-    <PackageReference Include="NLayer.NAudioSupport" Version="1.3.0" />
+    <PackageReference Include="NitroPacker.Core" Version="2.4.0" />
+    <PackageReference Include="NLayer" Version="1.15.0" />
+    <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />
-    <PackageReference Include="Topten.RichTextKit" Version="0.4.165" />
+    <PackageReference Include="Topten.RichTextKit" Version="0.4.166" />
     <PackageReference Include="VCDiff" Version="4.0.1" />
   </ItemGroup>
 

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0" />
     <PackageReference Include="HaruhiChokuretsuLib" Version="0.35.2" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.4.0" />
+    <PackageReference Include="NitroPacker.Core" Version="2.4.3" />
     <PackageReference Include="NLayer" Version="1.15.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />

--- a/src/SerialLoops.Lib/Sources/Makefile_main
+++ b/src/SerialLoops.Lib/Sources/Makefile_main
@@ -83,7 +83,7 @@ endif
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project (order is important)
 #---------------------------------------------------------------------------------
-LIBS    := -lnds9 -lc -lgcc
+LIBS    := -lnds9 -lc
  
  
 #---------------------------------------------------------------------------------
@@ -118,7 +118,7 @@ export INCLUDE    :=    $(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
+export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
  
 .PHONY: $(BUILD) clean

--- a/src/SerialLoops.Lib/Sources/Makefile_overlay
+++ b/src/SerialLoops.Lib/Sources/Makefile_overlay
@@ -83,7 +83,7 @@ endif
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project (order is important)
 #---------------------------------------------------------------------------------
-LIBS    := -lnds9 -lc -lgcc
+LIBS    := -lnds9 -lc
  
  
 #---------------------------------------------------------------------------------
@@ -118,7 +118,7 @@ export INCLUDE    :=    $(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
+export LIBPATHS    :=    $(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
  
 .PHONY: $(BUILD) clean

--- a/src/SerialLoops.Mac/SerialLoops.Mac.csproj
+++ b/src/SerialLoops.Mac/SerialLoops.Mac.csproj
@@ -2,7 +2,7 @@
 	
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Version>$(SLAssemblyVersion)</Version>

--- a/src/SerialLoops.Wpf/SerialLoops.Wpf.csproj
+++ b/src/SerialLoops.Wpf/SerialLoops.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ApplicationIcon>WindowsIcon.ico</ApplicationIcon>
     <Version>$(SLAssemblyVersion)</Version>
     <InformationalVersion>$(SLVersion)</InformationalVersion>

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -325,16 +325,14 @@ namespace SerialLoops.Dialogs
 
                 if (config.UseDocker)
                 {
-                    ProcessStartInfo dockerRmProcess = new()
+                    Process.Start(new ProcessStartInfo
                     {
                         FileName = "docker",
+                        Arguments = $"rm {string.Join(' ', dockerContainerNames)}",
                         UseShellExecute = false,
                         RedirectStandardError = true,
                         RedirectStandardOutput = true,
-                    };
-                    dockerRmProcess.ArgumentList.Add("rm");
-                    dockerRmProcess.ArgumentList.Concat(dockerContainerNames);
-                    Process.Start(dockerRmProcess);
+                    });
                 }
 
                 Close();

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -291,7 +291,22 @@ namespace SerialLoops.Dialogs
                 IEnumerable<string> failedHackNames = appliedHacks.Where(h => !h.Applied(project)).Select(h => h.Name);
                 if (failedHackNames.Any())
                 {
-                    log.LogError($"Failed to apply the following hacks to the ROM:\n{string.Join(", ", failedHackNames)}\n\nPlease check the log file for more information.");
+                    log.LogError($"Failed to apply the following hacks to the ROM:\n{string.Join(", ", failedHackNames)}\n\nPlease check the log file for more information.\n\nIn order to preserve state, no hacks were applied.");
+                    foreach (AsmHack hack in appliedHacks)
+                    {
+                        hack.Revert(project, log);
+                    }
+                    IEnumerable<string> dirsToDelete = Directory.GetDirectories(Path.Combine(project.BaseDirectory, "src"), "-p", SearchOption.AllDirectories)
+                        .Concat(Directory.GetDirectories(Path.Combine(project.BaseDirectory, "src"), "build", SearchOption.AllDirectories));
+                    foreach (string dir in dirsToDelete)
+                    {
+                        Directory.Delete(dir, recursive: true);
+                    }
+                    string[] filesToDelete = Directory.GetFiles(Path.Combine(project.BaseDirectory, "src"), "arm9_newcode.x", SearchOption.AllDirectories);
+                    foreach (string file in filesToDelete)
+                    {
+                        File.Delete(file);
+                    }
                 }
                 else
                 {

--- a/src/SerialLoops/Dialogs/AsmHacksDialog.cs
+++ b/src/SerialLoops/Dialogs/AsmHacksDialog.cs
@@ -320,6 +320,11 @@ namespace SerialLoops.Dialogs
                     }
                 }
 
+                if (config.UseDocker)
+                {
+
+                }
+
                 Close();
             };
 

--- a/src/SerialLoops/Editors/BackgroundEditor.cs
+++ b/src/SerialLoops/Editors/BackgroundEditor.cs
@@ -12,13 +12,9 @@ using System.Linq;
 
 namespace SerialLoops.Editors
 {
-    public class BackgroundEditor : Editor
+    public class BackgroundEditor(BackgroundItem item, Project project, ILogger log) : Editor(item, log, project)
     {
         private BackgroundItem _bg;
-
-        public BackgroundEditor(BackgroundItem item, Project project, ILogger log) : base(item, log, project)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/BackgroundMusicEditor.cs
+++ b/src/SerialLoops/Editors/BackgroundMusicEditor.cs
@@ -22,7 +22,7 @@ namespace SerialLoops.Editors
 
         public SoundPlayerPanel BgmPlayer { get; set; }
 
-        private string _bgmCachedFile;
+        private readonly string _bgmCachedFile;
 
         public BackgroundMusicEditor(BackgroundMusicItem item, Project project, ILogger log) : base(item, log, project)
         {
@@ -127,7 +127,7 @@ namespace SerialLoops.Editors
             extractButton.Click += (obj, args) =>
             {
                 SaveFileDialog saveFileDialog = new() { Title = "Save BGM as WAV" };
-                saveFileDialog.Filters.Add(new() { Name = "WAV File", Extensions = new string[] { ".wav" } });
+                saveFileDialog.Filters.Add(new() { Name = "WAV File", Extensions = [".wav"] });
                 if (saveFileDialog.ShowAndReportIfFileSelected(this))
                 {
                     LoopyProgressTracker tracker = new();
@@ -140,11 +140,11 @@ namespace SerialLoops.Editors
             replaceButton.Click += (obj, args) =>
             {
                 OpenFileDialog openFileDialog = new() { Title = "Replace BGM" };
-                openFileDialog.Filters.Add(new() { Name = "Supported Audio Files", Extensions = new string[] { ".wav", ".flac", ".mp3", ".ogg" } });
-                openFileDialog.Filters.Add(new() { Name = "WAV files", Extensions = new string[] { ".wav" } });
-                openFileDialog.Filters.Add(new() { Name = "FLAC files", Extensions = new string[] { ".flac" } });
-                openFileDialog.Filters.Add(new() { Name = "MP3 files", Extensions = new string[] { ".mp3" } });
-                openFileDialog.Filters.Add(new() { Name = "Vorbis files", Extensions = new string[] { ".ogg" } });
+                openFileDialog.Filters.Add(new() { Name = "Supported Audio Files", Extensions = [".wav", ".flac", ".mp3", ".ogg"] });
+                openFileDialog.Filters.Add(new() { Name = "WAV files", Extensions = [".wav"] });
+                openFileDialog.Filters.Add(new() { Name = "FLAC files", Extensions = [".flac"] });
+                openFileDialog.Filters.Add(new() { Name = "MP3 files", Extensions = [".mp3"] });
+                openFileDialog.Filters.Add(new() { Name = "Vorbis files", Extensions = [".ogg"] });
                 if (openFileDialog.ShowAndReportIfFileSelected(this))
                 {
                     LoopyProgressTracker tracker = new("Replacing BGM");

--- a/src/SerialLoops/Editors/CharacterEditor.cs
+++ b/src/SerialLoops/Editors/CharacterEditor.cs
@@ -11,13 +11,9 @@ using System.Reflection;
 
 namespace SerialLoops.Editors
 {
-    public class CharacterEditor : Editor
+    public class CharacterEditor(CharacterItem dialogueConfig, Project project, EditorTabsPanel tabs, ILogger log) : Editor(dialogueConfig, log, project, tabs)
     {
         private CharacterItem _character;
-
-        public CharacterEditor(CharacterItem dialogueConfig, Project project, EditorTabsPanel tabs, ILogger log) : base(dialogueConfig, log, project, tabs)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/CharacterSpriteEditor.cs
+++ b/src/SerialLoops/Editors/CharacterSpriteEditor.cs
@@ -11,14 +11,10 @@ using System.IO;
 
 namespace SerialLoops.Editors
 {
-    public class CharacterSpriteEditor : Editor
+    public class CharacterSpriteEditor(CharacterSpriteItem item, Project project, ILogger log) : Editor(item, log, project)
     {
         private CharacterSpriteItem _sprite;
         private AnimatedImage _animatedImage;
-
-        public CharacterSpriteEditor(CharacterSpriteItem item, Project project, ILogger log) : base(item, log, project)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/ChibiEditor.cs
+++ b/src/SerialLoops/Editors/ChibiEditor.cs
@@ -15,7 +15,7 @@ using System.Timers;
 
 namespace SerialLoops.Editors
 {
-    public class ChibiEditor : Editor
+    public class ChibiEditor(ChibiItem chibi, Project project, ILogger log) : Editor(chibi, log, project)
     {
         private ChibiItem _chibi;
         private DropDown _animationSelection;
@@ -24,10 +24,6 @@ namespace SerialLoops.Editors
 
         private AnimatedImage _animatedImage;
         private StackLayout _framesStack;
-
-        public ChibiEditor(ChibiItem chibi, Project project, ILogger log) : base(chibi, log, project)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/GroupSelectionEditor.cs
+++ b/src/SerialLoops/Editors/GroupSelectionEditor.cs
@@ -67,7 +67,7 @@ namespace SerialLoops.Editors
                 {
                     GroupBox routeBox = new() { Text = route.Title.GetSubstitutedString(_project) };
                     IEnumerable<TopicItem> kyonlessTopics = route.KyonlessTopics.Select(t => (TopicItem)_project.Items
-                        .FirstOrDefault(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).Topic.Id == t));
+                        .FirstOrDefault(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == t));
                     StackLayout kyonlessTopicsLayout = new();
                     foreach (TopicItem topicItem in kyonlessTopics)
                     {

--- a/src/SerialLoops/Editors/GroupSelectionEditor.cs
+++ b/src/SerialLoops/Editors/GroupSelectionEditor.cs
@@ -23,15 +23,15 @@ namespace SerialLoops.Editors
         {
             _selection = (GroupSelectionItem)Description;
 
-            List<GroupBox> groups = new();
-            foreach (ScenarioRouteSelectionStruct routeSelection in _selection.Selection.RouteSelections)
+            List<GroupBox> groups = [];
+            foreach (ScenarioActivity scenarioActivity in _selection.Selection.Activities)
             {
-                if (routeSelection is null)
+                if (scenarioActivity is null)
                 {
                     continue;
                 }
 
-                GroupBox selectionBox = new() { Text = routeSelection.Title.GetSubstitutedString(_project) };
+                GroupBox selectionBox = new() { Text = scenarioActivity.Title.GetSubstitutedString(_project) };
 
                 GroupBox optimalGroupBox = new() { Text = "Optimal Group" };
                 StackLayout optimalGroupLayout = new()
@@ -40,9 +40,9 @@ namespace SerialLoops.Editors
                     Spacing = 10,
                     Items =
                     {
-                        routeSelection.OptimalGroup.Item1.ToString(),
-                        routeSelection.OptimalGroup.Item2.ToString(),
-                        routeSelection.OptimalGroup.Item3.ToString(),
+                        scenarioActivity.OptimalGroup.Item1.ToString(),
+                        scenarioActivity.OptimalGroup.Item2.ToString(),
+                        scenarioActivity.OptimalGroup.Item3.ToString(),
                     }
                 };
                 optimalGroupBox.Content = optimalGroupLayout;
@@ -54,16 +54,16 @@ namespace SerialLoops.Editors
                     Spacing = 10,
                     Items =
                     {
-                        routeSelection.WorstGroup.Item1.ToString(),
-                        routeSelection.WorstGroup.Item2.ToString(),
-                        routeSelection.WorstGroup.Item3.ToString(),
+                        scenarioActivity.WorstGroup.Item1.ToString(),
+                        scenarioActivity.WorstGroup.Item2.ToString(),
+                        scenarioActivity.WorstGroup.Item3.ToString(),
                     }
                 };
                 worstGroupBox.Content = worstGroupLayout;
 
                 GroupBox routesBox = new() { Text = "Routes" };
                 StackLayout routesLayout = new() { Orientation = Orientation.Vertical, Spacing = 2 };
-                foreach (ScenarioRouteStruct route in routeSelection.Routes)
+                foreach (ScenarioRoute route in scenarioActivity.Routes)
                 {
                     GroupBox routeBox = new() { Text = route.Title.GetSubstitutedString(_project) };
                     IEnumerable<TopicItem> kyonlessTopics = route.KyonlessTopics.Select(t => (TopicItem)_project.Items
@@ -99,10 +99,10 @@ namespace SerialLoops.Editors
                     Spacing = 3,
                     Items =
                     {
-                        ControlGenerator.GetControlWithLabel("Haruhi Present", new CheckBox { Checked = routeSelection.HaruhiPresent }),
-                        ControlGenerator.GetControlWithLabel("Required Brigade Member", new Label { Text = routeSelection.RequiredBrigadeMember.ToString() }),
-                        ControlGenerator.GetControlWithLabel("Future Description", new TextBox { Text = routeSelection.FutureDesc.GetSubstitutedString(_project), Width = 400 }),
-                        ControlGenerator.GetControlWithLabel("Past Description", new TextBox { Text = routeSelection.PastDesc.GetSubstitutedString(_project), Width = 400 }),
+                        ControlGenerator.GetControlWithLabel("Haruhi Present", new CheckBox { Checked = scenarioActivity.HaruhiPresent }),
+                        ControlGenerator.GetControlWithLabel("Required Brigade Member", new Label { Text = scenarioActivity.RequiredBrigadeMember.ToString() }),
+                        ControlGenerator.GetControlWithLabel("Future Description", new TextBox { Text = scenarioActivity.FutureDesc.GetSubstitutedString(_project), Width = 400 }),
+                        ControlGenerator.GetControlWithLabel("Past Description", new TextBox { Text = scenarioActivity.PastDesc.GetSubstitutedString(_project), Width = 400 }),
                         optimalGroupBox,
                         worstGroupBox,
                         routesBox,

--- a/src/SerialLoops/Editors/MapEditor.cs
+++ b/src/SerialLoops/Editors/MapEditor.cs
@@ -7,13 +7,9 @@ using System;
 
 namespace SerialLoops.Editors
 {
-    public class MapEditor : Editor
+    public class MapEditor(MapItem map, Project project, ILogger log) : Editor(map, log, project)
     {
         private MapItem _map;
-
-        public MapEditor(MapItem map, Project project, ILogger log) : base(map, log, project)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/PlaceEditor.cs
+++ b/src/SerialLoops/Editors/PlaceEditor.cs
@@ -9,13 +9,9 @@ using System.Reflection;
 
 namespace SerialLoops.Editors
 {
-    public class PlaceEditor : Editor
+    public class PlaceEditor(PlaceItem placeItem, Project project, ILogger log) : Editor(placeItem, log, project)
     {
         private PlaceItem _place;
-
-        public PlaceEditor(PlaceItem placeItem, Project project, ILogger log) : base(placeItem, log, project)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/PuzzleEditor.cs
+++ b/src/SerialLoops/Editors/PuzzleEditor.cs
@@ -10,13 +10,9 @@ using System.Linq;
 
 namespace SerialLoops.Editors
 {
-    public class PuzzleEditor : Editor
+    public class PuzzleEditor(PuzzleItem item, Project project, EditorTabsPanel tabs, ILogger log) : Editor(item, log, project, tabs)
     {
         private PuzzleItem _puzzle;
-
-        public PuzzleEditor(PuzzleItem item, Project project, EditorTabsPanel tabs, ILogger log) : base(item, log, project, tabs)
-        {
-        }
 
         public override Container GetEditorPanel()
         {
@@ -64,13 +60,13 @@ namespace SerialLoops.Editors
             
             DropDown accompanyingCharacterDropdown = new() { Enabled = false };
             accompanyingCharacterDropdown.Items.AddRange(PuzzleItem.Characters.Select(c => new ListItem() { Text = c, Key = c }));
-            accompanyingCharacterDropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.AccompanyingCharacter);
+            accompanyingCharacterDropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.AccompanyingCharacterName);
             DropDown powerCharacter1Dropdown = new() { Enabled = false };
             powerCharacter1Dropdown.Items.AddRange(PuzzleItem.Characters.Select(c => new ListItem() { Text = c, Key = c }));
-            powerCharacter1Dropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.PowerCharacter1);
+            powerCharacter1Dropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.PowerCharacter1Name);
             DropDown powerCharacter2Dropdown = new() { Enabled = false };
             powerCharacter2Dropdown.Items.AddRange(PuzzleItem.Characters.Select(c => new ListItem() { Text = c, Key = c }));
-            powerCharacter2Dropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.PowerCharacter2);
+            powerCharacter2Dropdown.SelectedIndex = PuzzleItem.Characters.IndexOf(_puzzle.Puzzle.Settings.PowerCharacter2Name);
 
             mainLayout.Items.Add(new StackLayout()
             {

--- a/src/SerialLoops/Editors/PuzzleEditor.cs
+++ b/src/SerialLoops/Editors/PuzzleEditor.cs
@@ -36,8 +36,8 @@ namespace SerialLoops.Editors
             StackLayout topics = new() { Orientation = Orientation.Vertical, Spacing = 5 };
             foreach (var (topicId, _) in _puzzle.Puzzle.AssociatedTopics.Take(_puzzle.Puzzle.AssociatedTopics.Count - 1))
             {
-                TopicItem topic = (TopicItem)_project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).Topic.Id == topicId);
-                LinkButton topicButton = new() { Text = topic?.Topic.Title.GetSubstitutedString(_project) ?? topicId.ToString() };
+                TopicItem topic = (TopicItem)_project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == topicId);
+                LinkButton topicButton = new() { Text = topic?.TopicEntry.Title.GetSubstitutedString(_project) ?? topicId.ToString() };
                 if (topic is not null)
                 {
                     topicButton.Click += (s, e) => _tabs.OpenTab(topic, _log);

--- a/src/SerialLoops/Editors/ScenarioEditor.cs
+++ b/src/SerialLoops/Editors/ScenarioEditor.cs
@@ -12,7 +12,7 @@ using static HaruhiChokuretsuLib.Archive.Event.ScenarioCommand;
 
 namespace SerialLoops.Editors
 {
-    public class ScenarioEditor : Editor
+    public class ScenarioEditor(ScenarioItem item, ILogger log, Project project, EditorTabsPanel tabs) : Editor(item, log, project, tabs)
     {
         private ScenarioItem _scenario;
         private StackLayout _editorControls;
@@ -27,10 +27,6 @@ namespace SerialLoops.Editors
         private bool _triggerRefresh = true;
 
         private readonly IEnumerable<ListItem> verbs = Enum.GetNames<ScenarioVerb>().Select(v => new ListItem() { Text = v, Key = v });
-
-        public ScenarioEditor(ScenarioItem item, ILogger log, Project project, EditorTabsPanel tabs) : base(item, log, project, tabs)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -24,7 +24,7 @@ using static HaruhiChokuretsuLib.Archive.Event.EventFile;
 
 namespace SerialLoops.Editors
 {
-    public class ScriptEditor : Editor
+    public class ScriptEditor(ScriptItem item, ILogger log, Project project, EditorTabsPanel tabs) : Editor(item, log, project, tabs)
     {
         private ScriptItem _script;
         private Dictionary<ScriptSection, List<ScriptItemCommand>> _commands = new();
@@ -43,10 +43,6 @@ namespace SerialLoops.Editors
         private int _chibiHighlighted = -1;
         private ScriptCommandDropDown _currentSpeakerDropDown; // This property is used for storing the speaker dropdown to append dialogue property dropdowns to
         private Action _updateOptionDropDowns;
-
-        public ScriptEditor(ScriptItem item, ILogger log, Project project, EditorTabsPanel tabs) : base(item, log, project, tabs)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -1415,7 +1415,7 @@ namespace SerialLoops.Editors
 
                         case ScriptParameter.ParameterType.TOPIC:
                             string topicName = _project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Topic &&
-                                ((TopicItem)i).Topic.Id == ((TopicScriptParameter)parameter).TopicId)?.DisplayName;
+                                ((TopicItem)i).TopicEntry.Id == ((TopicScriptParameter)parameter).TopicId)?.DisplayName;
                             if (string.IsNullOrEmpty(topicName))
                             {
                                 // If the topic has been deleted, we will just display the index in a textbox
@@ -1441,7 +1441,7 @@ namespace SerialLoops.Editors
                             else
                             {
                                 StackLayout topicLink = ControlGenerator.GetFileLink(_project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Topic &&
-                                    ((TopicItem)i).Topic.Id == ((TopicScriptParameter)parameter).TopicId), _tabs, _log);
+                                    ((TopicItem)i).TopicEntry.Id == ((TopicScriptParameter)parameter).TopicId), _tabs, _log);
 
                                 ScriptCommandDropDown topicDropDown = new() { Command = command, ParameterIndex = i, Link = (ClearableLinkButton)topicLink.Items[1].Control };
                                 topicDropDown.Items.AddRange(_project.Items.Where(i => i.Type == ItemDescription.ItemType.Topic)
@@ -2502,10 +2502,10 @@ namespace SerialLoops.Editors
             ScriptCommandDropDown dropDown = (ScriptCommandDropDown)sender;
             _log.Log($"Attempting to modify parameter {dropDown.ParameterIndex} to topic {dropDown.SelectedKey} in {dropDown.Command.Index} in file {_script.Name}...");
             ((TopicScriptParameter)dropDown.Command.Parameters[dropDown.ParameterIndex]).TopicId =
-                ((TopicItem)_project.Items.FirstOrDefault(i => dropDown.SelectedKey == i.DisplayName)).Topic.Id;
+                ((TopicItem)_project.Items.FirstOrDefault(i => dropDown.SelectedKey == i.DisplayName)).TopicEntry.Id;
             _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(dropDown.Command.Section)]
                 .Objects[dropDown.Command.Index].Parameters[dropDown.ParameterIndex] =
-                ((TopicItem)_project.Items.First(i => dropDown.SelectedKey == i.DisplayName)).Topic.Id;
+                ((TopicItem)_project.Items.First(i => dropDown.SelectedKey == i.DisplayName)).TopicEntry.Id;
 
             dropDown.Link.Text = dropDown.SelectedKey;
             dropDown.Link.RemoveAllClickEvents();

--- a/src/SerialLoops/Editors/SfxEditor.cs
+++ b/src/SerialLoops/Editors/SfxEditor.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace SerialLoops.Editors
 {
-    public class SfxEditor : Editor
+    public class SfxEditor(SfxItem sfx, Project project, ILogger log) : Editor(sfx, log, project)
     {
         private SfxItem _sfx;
         private SequenceArchive _archive;
@@ -19,10 +19,6 @@ namespace SerialLoops.Editors
 
         public SfxPlayerPanel SfxPlayer { get; set; }
 
-        public SfxEditor(SfxItem sfx, Project project, ILogger log) : base(sfx, log, project)
-        {
-        }
-
         public override Container GetEditorPanel()
         {
             _sfx = (SfxItem)Description;
@@ -30,7 +26,7 @@ namespace SerialLoops.Editors
             _sequence = _archive.Sequences[_sfx.Entry.Index];
 
             Player = new(new(new SfxMixer().WavePlayer));
-            Player.PrepareForSong(new IPlayableBank[] { _sequence.Bank.File }, _sequence.Bank.GetAssociatedWaves());
+            Player.PrepareForSong([_sequence.Bank.File], _sequence.Bank.GetAssociatedWaves());
             _archive.ReadCommandData();
             Player.LoadSong(_archive.Commands, _archive.PublicLabels.ElementAt(_archive.Sequences.IndexOf(_sequence)).Value);
 

--- a/src/SerialLoops/Editors/SystemTextureEditor.cs
+++ b/src/SerialLoops/Editors/SystemTextureEditor.cs
@@ -10,13 +10,9 @@ using System.IO;
 
 namespace SerialLoops.Editors
 {
-    public class SystemTextureEditor : Editor
+    public class SystemTextureEditor(SystemTextureItem systemTexture, Project project, ILogger log) : Editor(systemTexture, log, project)
     {
         private SystemTextureItem _systemTexture;
-
-        public SystemTextureEditor(SystemTextureItem systemTexture, Project project, ILogger log) : base(systemTexture, log, project)
-        {
-        }
 
         public override Container GetEditorPanel()
         {
@@ -61,7 +57,7 @@ namespace SerialLoops.Editors
         private void ExportButton_Click(object sender, EventArgs e)
         {
             SaveFileDialog saveFileDialog = new();
-            saveFileDialog.Filters.Add(new() { Name = "PNG Image", Extensions = new string[] { ".png" } });
+            saveFileDialog.Filters.Add(new() { Name = "PNG Image", Extensions = [".png"] });
             if (saveFileDialog.ShowAndReportIfFileSelected(this))
             {
                 try
@@ -90,7 +86,7 @@ namespace SerialLoops.Editors
         {
             OpenFileDialog openFileDialog = new();
             SKBitmap original = _systemTexture.GetTexture();
-            openFileDialog.Filters.Add(new() { Name = "Supported Images", Extensions = new string[] { ".bmp", ".gif", ".heif", ".jpg", ".jpeg", ".png", ".webp", } });
+            openFileDialog.Filters.Add(new() { Name = "Supported Images", Extensions = [".bmp", ".gif", ".heif", ".jpg", ".jpeg", ".png", ".webp",] });
             if (openFileDialog.ShowAndReportIfFileSelected(this))
             {
                 ImageCropResizeDialog systemTextureResizeDialog = new(SKBitmap.Decode(openFileDialog.FileName), original.Width, original.Height, _log);

--- a/src/SerialLoops/Editors/TopicEditor.cs
+++ b/src/SerialLoops/Editors/TopicEditor.cs
@@ -32,7 +32,7 @@ namespace SerialLoops.Editors
                 Spacing = new(3, 3),
                 Rows =
                 {
-                    ControlGenerator.GetControlWithLabelTable("ID", new Label { Text = _topic.Topic.Id.ToString() }),
+                    ControlGenerator.GetControlWithLabelTable("ID", new Label { Text = _topic.TopicEntry.Id.ToString() }),
                 }
             };
             if (_topic.HiddenMainTopic is not null)
@@ -40,11 +40,11 @@ namespace SerialLoops.Editors
                 idLayout.Rows.Add(ControlGenerator.GetControlWithLabelTable("Hidden ID", new Label { Text = _topic.HiddenMainTopic.Id.ToString() }));
             }
 
-            TextBox titleTextBox = new() { Text = _topic.Topic.Title.GetSubstitutedString(_project), Width = 300 };
+            TextBox titleTextBox = new() { Text = _topic.TopicEntry.Title.GetSubstitutedString(_project), Width = 300 };
             titleTextBox.TextChanged += (sender, args) =>
             {
-                _topic.Topic.Title = titleTextBox.Text.GetOriginalString(_project);
-                _topic.Rename($"{_topic.Topic.Id} - {titleTextBox.Text}");
+                _topic.TopicEntry.Title = titleTextBox.Text.GetOriginalString(_project);
+                _topic.Rename($"{_topic.TopicEntry.Id} - {titleTextBox.Text}");
                 UpdateTabTitle(false, titleTextBox);
             };
 
@@ -71,7 +71,7 @@ namespace SerialLoops.Editors
                     }
                     else
                     {
-                        _topic.Topic.EventIndex = 0;
+                        _topic.TopicEntry.EventIndex = 0;
                     }
                 }
                 else
@@ -82,7 +82,7 @@ namespace SerialLoops.Editors
                     }
                     else
                     {
-                        _topic.Topic.EventIndex = (short)((ListItem)linkedScriptDropDown.Items[linkedScriptDropDown.SelectedIndex]).Tag;
+                        _topic.TopicEntry.EventIndex = (short)((ListItem)linkedScriptDropDown.Items[linkedScriptDropDown.SelectedIndex]).Tag;
                     }
                 }
                 linkedScriptLink.Items.Clear();
@@ -101,10 +101,10 @@ namespace SerialLoops.Editors
                 },
             };
 
-            _baseTimeStepper = new() { Value = _topic.Topic.BaseTimeGain, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
+            _baseTimeStepper = new() { Value = _topic.TopicEntry.BaseTimeGain, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
             _baseTimeStepper.ValueChanged += (sender, args) =>
             {
-                _topic.Topic.BaseTimeGain = (short)_baseTimeStepper.Value;
+                _topic.TopicEntry.BaseTimeGain = (short)_baseTimeStepper.Value;
 
                 UpdateKyonTime();
                 UpdateMikuruTime();
@@ -113,41 +113,41 @@ namespace SerialLoops.Editors
                 UpdateTabTitle(false);
             };
 
-            _kyonTimeStepper = new() { Value = _topic.Topic.KyonTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
-            _kyonTimeLabel = new() { Text = ((int)(_topic.Topic.BaseTimeGain * _topic.Topic.KyonTimePercentage / 100.0)).ToString() };
+            _kyonTimeStepper = new() { Value = _topic.TopicEntry.KyonTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
+            _kyonTimeLabel = new() { Text = ((int)(_topic.TopicEntry.BaseTimeGain * _topic.TopicEntry.KyonTimePercentage / 100.0)).ToString() };
             _kyonTimeStepper.ValueChanged += (sender, args) =>
             {
-                _topic.Topic.KyonTimePercentage = (short)_kyonTimeStepper.Value;
+                _topic.TopicEntry.KyonTimePercentage = (short)_kyonTimeStepper.Value;
 
                 UpdateKyonTime();
                 UpdateTabTitle(false);
             };
 
-            _mikuruTimeStepper = new() { Value = _topic.Topic.MikuruTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
-            _mikuruTimeLabel = new() { Text = ((int)(_topic.Topic.BaseTimeGain * _topic.Topic.MikuruTimePercentage / 100.0)).ToString() };
+            _mikuruTimeStepper = new() { Value = _topic.TopicEntry.MikuruTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
+            _mikuruTimeLabel = new() { Text = ((int)(_topic.TopicEntry.BaseTimeGain * _topic.TopicEntry.MikuruTimePercentage / 100.0)).ToString() };
             _mikuruTimeStepper.ValueChanged += (sender, args) =>
             {
-                _topic.Topic.MikuruTimePercentage = (short)_mikuruTimeStepper.Value;
+                _topic.TopicEntry.MikuruTimePercentage = (short)_mikuruTimeStepper.Value;
 
                 UpdateMikuruTime();
                 UpdateTabTitle(false);
             };
 
-            _nagatoTimeStepper = new() { Value = _topic.Topic.NagatoTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
-            _nagatoTimeLabel = new() { Text = ((int)(_topic.Topic.BaseTimeGain * _topic.Topic.NagatoTimePercentage / 100.0)).ToString() };
+            _nagatoTimeStepper = new() { Value = _topic.TopicEntry.NagatoTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
+            _nagatoTimeLabel = new() { Text = ((int)(_topic.TopicEntry.BaseTimeGain * _topic.TopicEntry.NagatoTimePercentage / 100.0)).ToString() };
             _nagatoTimeStepper.ValueChanged += (sender, args) =>
             {
-                _topic.Topic.NagatoTimePercentage = (short)_nagatoTimeStepper.Value;
+                _topic.TopicEntry.NagatoTimePercentage = (short)_nagatoTimeStepper.Value;
 
                 UpdateNagatoTime();
                 UpdateTabTitle(false);
             };
 
-            _koizumiTimeStepper = new() { Value = _topic.Topic.KoizumiTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
-            _koizumiTimeLabel = new() { Text = ((int)(_topic.Topic.BaseTimeGain * _topic.Topic.KoizumiTimePercentage / 100.0)).ToString() };
+            _koizumiTimeStepper = new() { Value = _topic.TopicEntry.KoizumiTimePercentage, MaxValue = short.MaxValue, MinValue = 0, MaximumDecimalPlaces = 0 };
+            _koizumiTimeLabel = new() { Text = ((int)(_topic.TopicEntry.BaseTimeGain * _topic.TopicEntry.KoizumiTimePercentage / 100.0)).ToString() };
             _koizumiTimeStepper.ValueChanged += (sender, args) =>
             {
-                _topic.Topic.KoizumiTimePercentage = (short)_koizumiTimeStepper.Value;
+                _topic.TopicEntry.KoizumiTimePercentage = (short)_koizumiTimeStepper.Value;
 
                 UpdateKoizumiTime();
                 UpdateTabTitle(false);
@@ -217,24 +217,24 @@ namespace SerialLoops.Editors
                     new ListItem { Key = "4", Text = "Episode 4" },
                     new ListItem { Key = "5", Text = "Episode 5" },
                 },
-                SelectedKey = _topic.Topic.EpisodeGroup.ToString(),
+                SelectedKey = _topic.TopicEntry.EpisodeGroup.ToString(),
             };
             episodeGroupDropDown.SelectedKeyChanged += (sender, args) =>
             {
-                _topic.Topic.EpisodeGroup = byte.Parse(episodeGroupDropDown.SelectedKey);
+                _topic.TopicEntry.EpisodeGroup = byte.Parse(episodeGroupDropDown.SelectedKey);
                 UpdateTabTitle(false);
             };
 
             NumericStepper puzzlePhaseGroupStepper = new()
             {
-                Value = _topic.Topic.PuzzlePhaseGroup,
+                Value = _topic.TopicEntry.PuzzlePhaseGroup,
                 DecimalPlaces = 0,
                 MinValue = 0,
                 MaxValue = 8,
             };
             puzzlePhaseGroupStepper.ValueChanged += (sender, args) =>
             {
-                _topic.Topic.PuzzlePhaseGroup = (byte)puzzlePhaseGroupStepper.Value;
+                _topic.TopicEntry.PuzzlePhaseGroup = (byte)puzzlePhaseGroupStepper.Value;
                 UpdateTabTitle(false);
             };
 
@@ -262,7 +262,7 @@ namespace SerialLoops.Editors
 
             return new TableLayout(idLayout,
                 ControlGenerator.GetControlWithLabel("Title", titleTextBox),
-                ControlGenerator.GetControlWithLabel("Type", _topic.Topic.CardType.ToString()),
+                ControlGenerator.GetControlWithLabel("Type", _topic.TopicEntry.CardType.ToString()),
                 ControlGenerator.GetControlWithLabel("Associated Script", linkedScriptLayout),
                 groupsLayout,
                 new GroupBox() { Text = "Times", Content = timesLayout },
@@ -278,7 +278,7 @@ namespace SerialLoops.Editors
             }
             else
             {
-                associatedScript = _project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Script && ((ScriptItem)i).Event.Index == _topic.Topic.EventIndex);
+                associatedScript = _project.Items.FirstOrDefault(i => i.Type == ItemDescription.ItemType.Script && ((ScriptItem)i).Event.Index == _topic.TopicEntry.EventIndex);
             }
             return associatedScript ?? NoneItem.SCRIPT;
         }

--- a/src/SerialLoops/Editors/TopicEditor.cs
+++ b/src/SerialLoops/Editors/TopicEditor.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace SerialLoops.Editors
 {
-    public class TopicEditor : Editor
+    public class TopicEditor(TopicItem topic, Project project, EditorTabsPanel tabs, ILogger log) : Editor(topic, log, project, tabs)
     {
         private TopicItem _topic;
 
@@ -22,10 +22,6 @@ namespace SerialLoops.Editors
         private Label _nagatoTimeLabel;
         private NumericStepper _koizumiTimeStepper;
         private Label _koizumiTimeLabel;
-
-        public TopicEditor(TopicItem topic, Project project, EditorTabsPanel tabs, ILogger log) : base(topic, log, project, tabs)
-        {
-        }
 
         public override Container GetEditorPanel()
         {

--- a/src/SerialLoops/Editors/VoicedLineEditor.cs
+++ b/src/SerialLoops/Editors/VoicedLineEditor.cs
@@ -16,16 +16,12 @@ using System.Linq;
 
 namespace SerialLoops.Editors
 {
-    public class VoicedLineEditor : Editor
+    public class VoicedLineEditor(VoicedLineItem vce, Project project, ILogger log) : Editor(vce, log, project)
     {
         private VoicedLineItem _vce;
         public SoundPlayerPanel VcePlayer { get; set; }
         private readonly StackLayout _subtitlesPreview = new() { Items = { new SKGuiImage(new(256, 384)) } };
         private string _subtitle;
-
-        public VoicedLineEditor(VoicedLineItem vce, Project project, ILogger log) : base(vce, log, project)
-        {
-        }
 
         public override Container GetEditorPanel()
         {
@@ -36,7 +32,7 @@ namespace SerialLoops.Editors
             extractButton.Click += (obj, args) =>
             {
                 SaveFileDialog saveFileDialog = new() { Title = "Save voiced line as WAV" };
-                saveFileDialog.Filters.Add(new() { Name = "WAV File", Extensions = new string[] { ".wav" } });
+                saveFileDialog.Filters.Add(new() { Name = "WAV File", Extensions = [".wav"] });
                 if (saveFileDialog.ShowAndReportIfFileSelected(this))
                 {
                     WaveFileWriter.CreateWaveFile(saveFileDialog.FileName, _vce.GetWaveProvider(_log));
@@ -47,11 +43,11 @@ namespace SerialLoops.Editors
             replaceButton.Click += (obj, args) =>
             {
                 OpenFileDialog openFileDialog = new() { Title = "Replace voiced line" };
-                openFileDialog.Filters.Add(new() { Name = "Supported Audio Files", Extensions = new string[] { ".wav", ".flac", ".mp3", ".ogg" } });
-                openFileDialog.Filters.Add(new() { Name = "WAV files", Extensions = new string[] { ".wav" } });
-                openFileDialog.Filters.Add(new() { Name = "FLAC files", Extensions = new string[] { ".flac" } });
-                openFileDialog.Filters.Add(new() { Name = "MP3 files", Extensions = new string[] { ".mp3" } });
-                openFileDialog.Filters.Add(new() { Name = "Vorbis files", Extensions = new string[] { ".ogg" } });
+                openFileDialog.Filters.Add(new() { Name = "Supported Audio Files", Extensions = [".wav", ".flac", ".mp3", ".ogg"] });
+                openFileDialog.Filters.Add(new() { Name = "WAV files", Extensions = [".wav"] });
+                openFileDialog.Filters.Add(new() { Name = "FLAC files", Extensions = [".flac"] });
+                openFileDialog.Filters.Add(new() { Name = "MP3 files", Extensions = [".mp3"] });
+                openFileDialog.Filters.Add(new() { Name = "Vorbis files", Extensions = [".ogg"] });
                 if (openFileDialog.ShowAndReportIfFileSelected(this))
                 {
                     LoopyProgressTracker tracker = new();
@@ -87,51 +83,51 @@ namespace SerialLoops.Editors
                     Orientation = Orientation.Vertical,
                     Items =
                     {
-                        VoiceMapFile.VoiceMapStruct.YPosition.TOP.ToString(),
-                        VoiceMapFile.VoiceMapStruct.YPosition.BELOW_TOP.ToString(),
-                        VoiceMapFile.VoiceMapStruct.YPosition.ABOVE_BOTTOM.ToString(),
-                        VoiceMapFile.VoiceMapStruct.YPosition.BOTTOM.ToString(),
+                        VoiceMapFile.VoiceMapEntry.YPosition.TOP.ToString(),
+                        VoiceMapFile.VoiceMapEntry.YPosition.BELOW_TOP.ToString(),
+                        VoiceMapFile.VoiceMapEntry.YPosition.ABOVE_BOTTOM.ToString(),
+                        VoiceMapFile.VoiceMapEntry.YPosition.BOTTOM.ToString(),
                     },
-                    SelectedKey = VoiceMapFile.VoiceMapStruct.YPosition.ABOVE_BOTTOM.ToString(),
+                    SelectedKey = VoiceMapFile.VoiceMapEntry.YPosition.ABOVE_BOTTOM.ToString(),
                 };
-                var voiceMapStruct = _project.VoiceMap.VoiceMapStructs.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
-                if (voiceMapStruct is not null)
+                var VoiceMapEntry = _project.VoiceMap.VoiceMapEntries.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
+                if (VoiceMapEntry is not null)
                 {
                     if (_project.LangCode != "ja")
                     {
-                        subtitleBox.Text = voiceMapStruct.Subtitle.GetSubstitutedString(_project);
+                        subtitleBox.Text = VoiceMapEntry.Subtitle.GetSubstitutedString(_project);
                     }
                     else
                     {
-                        subtitleBox.Text = voiceMapStruct.Subtitle;
+                        subtitleBox.Text = VoiceMapEntry.Subtitle;
                     }
                     _subtitle = _project.LangCode != "ja" ? subtitleBox.Text.GetOriginalString(_project) : subtitleBox.Text;
 
-                    screenSelector.SelectedScreen = voiceMapStruct.TargetScreen == VoiceMapFile.VoiceMapStruct.Screen.TOP 
+                    screenSelector.SelectedScreen = VoiceMapEntry.TargetScreen == VoiceMapFile.VoiceMapEntry.Screen.TOP 
                         ? ScreenScriptParameter.DsScreen.TOP : ScreenScriptParameter.DsScreen.BOTTOM;
-                    yPosSelectionList.SelectedKey = voiceMapStruct.YPos.ToString();
+                    yPosSelectionList.SelectedKey = VoiceMapEntry.YPos.ToString();
                 }
 
                 subtitleBox.TextChanged += (sender, args) =>
                 {
                     _subtitle = _project.LangCode != "ja" ? subtitleBox.Text.GetOriginalString(_project) : subtitleBox.Text;
-                    var voiceMapStruct = _project.VoiceMap.VoiceMapStructs.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
-                    if (voiceMapStruct is null)
+                    var VoiceMapEntry = _project.VoiceMap.VoiceMapEntries.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
+                    if (VoiceMapEntry is null)
                     {
-                        _project.VoiceMap.VoiceMapStructs.Add(new()
+                        _project.VoiceMap.VoiceMapEntries.Add(new()
                         {
                             VoiceFileName = Path.GetFileNameWithoutExtension(_vce.VoiceFile),
                             FontSize = 100,
                             TargetScreen = screenSelector.SelectedScreen == ScreenScriptParameter.DsScreen.TOP
-                                ? VoiceMapFile.VoiceMapStruct.Screen.TOP : VoiceMapFile.VoiceMapStruct.Screen.BOTTOM,
+                                ? VoiceMapFile.VoiceMapEntry.Screen.TOP : VoiceMapFile.VoiceMapEntry.Screen.BOTTOM,
                             Timer = 350,
                         });
-                        _project.VoiceMap.VoiceMapStructs[^1].SetSubtitle(_subtitle, _project.FontReplacement);
-                        _project.VoiceMap.VoiceMapStructs[^1].YPos = Enum.Parse<VoiceMapFile.VoiceMapStruct.YPosition>(yPosSelectionList.SelectedKey);
+                        _project.VoiceMap.VoiceMapEntries[^1].SetSubtitle(_subtitle, _project.FontReplacement);
+                        _project.VoiceMap.VoiceMapEntries[^1].YPos = Enum.Parse<VoiceMapFile.VoiceMapEntry.YPosition>(yPosSelectionList.SelectedKey);
                     }
                     else
                     {
-                        voiceMapStruct.SetSubtitle(_subtitle, _project.FontReplacement);
+                        VoiceMapEntry.SetSubtitle(_subtitle, _project.FontReplacement);
                     }
                     UpdateTabTitle(false, subtitleBox);
                     UpdatePreview();
@@ -139,11 +135,11 @@ namespace SerialLoops.Editors
 
                 screenSelector.ScreenChanged += (sender, args) =>
                 {
-                    var voiceMapStruct = _project.VoiceMap.VoiceMapStructs.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
-                    if (voiceMapStruct is not null)
+                    var VoiceMapEntry = _project.VoiceMap.VoiceMapEntries.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
+                    if (VoiceMapEntry is not null)
                     {
-                        voiceMapStruct.TargetScreen = screenSelector.SelectedScreen == ScreenScriptParameter.DsScreen.TOP
-                            ? VoiceMapFile.VoiceMapStruct.Screen.TOP : VoiceMapFile.VoiceMapStruct.Screen.BOTTOM;
+                        VoiceMapEntry.TargetScreen = screenSelector.SelectedScreen == ScreenScriptParameter.DsScreen.TOP
+                            ? VoiceMapFile.VoiceMapEntry.Screen.TOP : VoiceMapFile.VoiceMapEntry.Screen.BOTTOM;
                         UpdateTabTitle(false);
                         UpdatePreview();
                     }
@@ -151,10 +147,10 @@ namespace SerialLoops.Editors
 
                 yPosSelectionList.SelectedKeyChanged += (sender, args) =>
                 {
-                    var voiceMapStruct = _project.VoiceMap.VoiceMapStructs.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
-                    if (voiceMapStruct is not null)
+                    var VoiceMapEntry = _project.VoiceMap.VoiceMapEntries.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
+                    if (VoiceMapEntry is not null)
                     {
-                        voiceMapStruct.YPos = Enum.Parse<VoiceMapFile.VoiceMapStruct.YPosition>(yPosSelectionList.SelectedKey);
+                        VoiceMapEntry.YPos = Enum.Parse<VoiceMapFile.VoiceMapEntry.YPosition>(yPosSelectionList.SelectedKey);
                         UpdateTabTitle(false);
                         UpdatePreview();
                     }
@@ -216,8 +212,8 @@ namespace SerialLoops.Editors
             canvas.DrawColor(SKColors.DarkGray);
             canvas.DrawLine(new SKPoint { X = 0, Y = 192 }, new SKPoint { X = 256, Y = 192 }, DialogueScriptParameter.Paint00);
 
-            var voiceMapStruct = _project.VoiceMap.VoiceMapStructs.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
-            bool bottomScreen = voiceMapStruct.TargetScreen == VoiceMapFile.VoiceMapStruct.Screen.BOTTOM;
+            var VoiceMapEntry = _project.VoiceMap.VoiceMapEntries.FirstOrDefault(v => v.VoiceFileName == Path.GetFileNameWithoutExtension(_vce.VoiceFile));
+            bool bottomScreen = VoiceMapEntry.TargetScreen == VoiceMapFile.VoiceMapEntry.Screen.BOTTOM;
             if (bottomScreen)
             {
                 for (int i = 0; i <= 1; i++)
@@ -227,8 +223,8 @@ namespace SerialLoops.Editors
                         canvas,
                         DialogueScriptParameter.Paint07,
                         _project,
-                        i + voiceMapStruct.X,
-                        1 + voiceMapStruct.Y + (bottomScreen ? 192 : 0),
+                        i + VoiceMapEntry.X,
+                        1 + VoiceMapEntry.Y + (bottomScreen ? 192 : 0),
                         false
                     );
                 }
@@ -239,8 +235,8 @@ namespace SerialLoops.Editors
                 canvas,
                 DialogueScriptParameter.Paint00, 
                 _project,
-                voiceMapStruct.X,
-                voiceMapStruct.Y + (bottomScreen ? 192 : 0),
+                VoiceMapEntry.X,
+                VoiceMapEntry.Y + (bottomScreen ? 192 : 0),
                 false
             );
 

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -7,7 +7,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>$(SLAssemblyVersion)</Version>
     <InformationalVersion>$(SLVersion)</InformationalVersion>
     <AssemblyName>SerialLoops.Eto</AssemblyName>

--- a/src/SerialLoops/Utility/AnimatedImage.cs
+++ b/src/SerialLoops/Utility/AnimatedImage.cs
@@ -32,7 +32,7 @@ namespace SerialLoops.Utility
 
         public void UpdateImage()
         {
-            if (FramesWithTimings.Any())
+            if (FramesWithTimings.Count != 0)
             {
                 Content = FramesWithTimings[CurrentFrame].Frame;
             }

--- a/test/SerialLoops.Tests/CoreTests.cs
+++ b/test/SerialLoops.Tests/CoreTests.cs
@@ -118,7 +118,7 @@ namespace SerialLoops.Tests
         public void GroupSelectionItemTest(string groupSelectionName)
         {
             var groupSelection = (GroupSelectionItem)_project.FindItem(groupSelectionName);
-            Assert.That(groupSelection.Selection.RouteSelections, Is.Not.Empty);
+            Assert.That(groupSelection.Selection.Activities, Is.Not.Empty);
         }
 
         [Test, TestCaseSource(nameof(MapNames)), Parallelizable(ParallelScope.All)]

--- a/test/SerialLoops.Tests/SerialLoops.Tests.csproj
+++ b/test/SerialLoops.Tests/SerialLoops.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Closes #306. Closes #307. Fixes #308. Closes #311.

The switch to .NET 8.0 makes this change look bigger than it is. While upgrading the choku lib to .NET 8, I made a bunch of underlying breaking changes to its APIs (just renaming classes and such) which is why you see a bunch of changes throughout.

Highlights:
* .NET 8 upgrade, including a bunch of small changes to code style that come with that upgrade to a newer C#
* Upgrade a ton of packages along the way, including bumping NitroPacker and the Choku lib to their .NET 8 versions
* Before, if a patch failed to apply, we left the build directory in an unclean state (with patch files just sitting there). New code explicitly reverts those patches and deletes unnecessary directories.
* Added functionality to NitroPacker to allow naming the docker containers we create when patching, which gives us the handy ability to call `docker rm` afterwards and clean up those containers
* Surfaced the make/docker logging to the user through a loading modal which will hopefully make that process less confusing