### PR TITLE
Fixup the Linux official build by fixing RPM package name

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -46,7 +46,7 @@ stages:
           rid: 'linux-x64'
           artifactPath: '$(Build.SourcesDirectory)/src/SerialLoops.$(platformName)/bin/Gtk/Release/net6.0/linux-x64/publish.tar.gz'
           secondArtifactPath: '$(Build.SourcesDirectory)/dpkg-build/SerialLoops.deb'
-          thirdArtifactPath: '$(Build.SourcesDirectory)/rpmbuild/RPMS/x86_64/SerialLoops-$(Version)-1.fc38.x86_64.rpm'
+          thirdArtifactPath: '$(Build.SourcesDirectory)/rpmbuild/RPMS/x86_64/SerialLoops-$(Version)-1.fc39.x86_64.rpm'
           extraPublishParams: ''
         macOS-x64:
           imageName: 'macOS-latest'
@@ -133,7 +133,7 @@ stages:
         mv $(Build.SourcesDirectory)/../SerialLoops-$(Version).tar.gz $(Build.SourcesDirectory)/rpmbuild/SOURCES/
         Write-Output "Name:           SerialLoops`nVersion:        $(Version)`nRelease:        1%{?dist}`nSummary:        Editor for Suzumiya Haruhi no Chokuretsu`nExclusiveArch:  x86_64`n`nLicense:        GPLv3`nURL:            https://haroohie.club/chokuretsu/serial-loops`nSource0:        %{name}-%{version}.tar.gz`nSource1:        https://github.com/haroohie-club/SerialLoops`n`nBuildRequires:  dotnet-sdk-6.0`nRequires:       openal-soft make`n`n%global debug_package %{nil}`n%define __os_install_post %{nil}`n`n%description`nAn editor for the Nintendo DS game Suzumiya Haruhi no Chokuretsu (The Series of Haruhi Suzumiya)`n`n%prep`n%setup -q`n`n%build`ndotnet publish src/SerialLoops.Gtk/SerialLoops.Gtk.csproj -c Release -f net6.0 -r linux-x64 --self-contained /p:DebugType=None /p:DebugSymbols=false /p:PublishSingleFile=true`n`n%install`nrm -rf %{buildroot}`nmkdir -p %{buildroot}/%{_bindir}`nmkdir -p %{buildroot}/%{_libdir}/SerialLoops`nmkdir -p %{buildroot}/%{_datadir}/applications`ncp -r src/SerialLoops.Gtk/bin/Release/net6.0/linux-x64/publish/* %{buildroot}/%{_libdir}/SerialLoops/`nchmod 777 %{buildroot}/%{_libdir}/SerialLoops/`nln -s %{_libdir}/SerialLoops/SerialLoops %{buildroot}/%{_bindir}/SerialLoops`nprintf `"[Desktop Entry]\nVersion=%{version}\nName=Serial Loops\nComment=Editor for Suzumiya Haruhi no Chokuretsu\nExec=%{_bindir}/SerialLoops\nIcon=%{_libdir}/SerialLoops/Icons/AppIcon.png\nTerminal=false\nType=Application\nCategories=Utility;Application;\n`" > %{buildroot}/%{_datadir}/applications/SerialLoops.desktop`nchmod +x %{buildroot}/%{_datadir}/applications/SerialLoops.desktop`n`n%files`n%dir %{_libdir}/SerialLoops`n%{_bindir}/SerialLoops`n%{_libdir}/SerialLoops`n%{_datadir}/applications/SerialLoops.desktop`n" | Out-File -FilePath rpmbuild/SPECS/SerialLoops.spec
         chmod +x $(Build.SourcesDirectory)/install/rpm-scripts/rpm-make.sh
-        docker run -v $(Build.SourcesDirectory)/install/rpm-scripts:/rpm-scripts -v $(Build.SourcesDirectory)/rpmbuild:/root/rpmbuild -e VERSION=$(Version) fedora /rpm-scripts/rpm-make.sh
+        docker run -v $(Build.SourcesDirectory)/install/rpm-scripts:/rpm-scripts -v $(Build.SourcesDirectory)/rpmbuild:/root/rpmbuild -e VERSION=$(Version) fedora:39 /rpm-scripts/rpm-make.sh
       displayName: Create Linux tar, dpkg, and rpm
       condition: eq(variables['rid'], 'linux-x64')
 
@@ -225,7 +225,7 @@ stages:
     - pwsh: |
         Move-Item -Path $(Build.ArtifactStagingDirectory)/Linux-v$(Version)/publish.tar.gz -Destination $(Build.ArtifactStagingDirectory)/SerialLoops-linux-x64-v$(Version).tar.gz
         Move-Item -Path $(Build.ArtifactStagingDirectory)/Linux-v$(Version)-2/SerialLoops.deb -Destination $(Build.ArtifactStagingDirectory)/SerialLoops-$(Version)_amd64.deb
-        Move-Item -Path $(Build.ArtifactStagingDirectory)/Linux-v$(Version)-3/SerialLoops-$(Version)-1.fc38.x86_64.rpm -Destination $(Build.ArtifactStagingDirectory)/SerialLoops-$(Version)-1.fc38.x86_64.rpm
+        Move-Item -Path $(Build.ArtifactStagingDirectory)/Linux-v$(Version)-3/SerialLoops-$(Version)-1.fc39.x86_64.rpm -Destination $(Build.ArtifactStagingDirectory)/SerialLoops-$(Version)-1.fc39.x86_64.rpm
         Move-Item -Path "$(Build.ArtifactStagingDirectory)/macOS-x64-v$(Version)/Serial Loops.dmg" -Destination $(Build.ArtifactStagingDirectory)/SerialLoops-macOS-x64-v$(Version).dmg
         Move-Item -Path "$(Build.ArtifactStagingDirectory)/macOS-arm-v$(Version)/Serial Loops.dmg" -Destination $(Build.ArtifactStagingDirectory)/SerialLoops-macOS-arm-v$(Version).dmg
         Move-Item -Path $(Build.ArtifactStagingDirectory)/Windows-v$(Version)/publish.zip -Destination $(Build.ArtifactStagingDirectory)/SerialLoops-windows-x64-v$(Version).zip


### PR DESCRIPTION
The official build is breaking rn bc the RPM artifact is named wrong. Reason: the fedora image updated underneath us. I've just gone with latest but have now pinned us at 39 for now.