### PR TITLE
Update NitroPacker to allow for better Docker container deletion

### DIFF
--- a/src/SerialLoops.Lib/ProjectSettings.cs
+++ b/src/SerialLoops.Lib/ProjectSettings.cs
@@ -9,11 +9,11 @@ using static HaroohieClub.NitroPacker.Nitro.Card.Rom.RomBanner;
 
 namespace SerialLoops.Lib
 {
-    public class ProjectSettings
+    public class ProjectSettings(NdsProjectFile file, ILogger log)
     {
-        public NdsProjectFile File { get; }
+        public NdsProjectFile File { get; } = file;
         private BannerV1 Banner => File.RomInfo.Banner.Banner;
-        private readonly ILogger _log;
+        private readonly ILogger _log = log;
         
         public string Name {
             get => Banner.GameName[0];
@@ -58,11 +58,5 @@ namespace SerialLoops.Lib
                 Banner.Pltt = grp.PaletteData.ToArray();
             }
         }
-        public ProjectSettings(NdsProjectFile file, ILogger log)
-        {
-            File = file;
-            _log = log;
-        }
-
     }
 }

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0.1" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.35.2" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.35.3" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NitroPacker.Core" Version="2.4.4" />
     <PackageReference Include="NLayer" Version="1.15.0" />

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.1" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0.1" />
     <PackageReference Include="HaruhiChokuretsuLib" Version="0.35.2" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.4.3" />
+    <PackageReference Include="NitroPacker.Core" Version="2.4.4" />
     <PackageReference Include="NLayer" Version="1.15.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />


### PR DESCRIPTION
Rather than assigning container names and deleting them at our level, I've made it so NitroPacker just passes the `--rm` parameter by default so containers get auto-removed after running.

Also fixes #323 by taking an update from the Chokuretsu lib that fixed the underlying problem.