### PR TITLE
Fixup ASM hack application crash

### DIFF
--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -449,7 +449,10 @@ namespace SerialLoops
 
         private void Application_LocalizeString(object sender, LocalizeEventArgs e)
         {
-            e.LocalizedText = Strings.ResourceManager.GetString(e.Text, CultureInfo.CurrentCulture);
+            if (!string.IsNullOrEmpty(e.Text))
+            {
+                e.LocalizedText = Strings.ResourceManager.GetString(e.Text, CultureInfo.CurrentCulture);
+            }
         }
 
         private void UpdateRecentProjects()


### PR DESCRIPTION
In order to localize more efficiently, the `LoopyProgressTracker` attempts to localize all its strings. This is normally fine, but during ASM hack application, we pass all strings that come back from make/docker which can result in null strings being passed. This caused a crash that was caught by our UI tests.