### PR TITLE
Improve perf with some concurrency magic

### DIFF
--- a/src/SerialLoops.Lib/Build.cs
+++ b/src/SerialLoops.Lib/Build.cs
@@ -224,7 +224,7 @@ namespace SerialLoops.Lib
         {
             try
             {
-                GraphicsFile grpFile = grp.Files.FirstOrDefault(f => f.Index == index);
+                GraphicsFile grpFile = grp.GetFileByIndex(index);
 
                 if (index == 0xE50)
                 {
@@ -353,8 +353,8 @@ namespace SerialLoops.Lib
         {
             try
             {
-                EventFile file = archive.Files.FirstOrDefault(f => f.Index == index);
-                file.Data = File.ReadAllBytes(filePath).ToList();
+                EventFile file = archive.GetFileByIndex(index);
+                file.Data = [.. File.ReadAllBytes(filePath)];
                 file.Edited = true;
                 archive.Files[archive.Files.IndexOf(file)] = file;
             }
@@ -367,7 +367,7 @@ namespace SerialLoops.Lib
         {
             try
             {
-                DataFile file = archive.Files.FirstOrDefault(f => f.Index == index);
+                DataFile file = archive.GetFileByIndex(index);
                 file.Data = File.ReadAllBytes(filePath).ToList();
                 file.Edited = true;
                 archive.Files[archive.Files.IndexOf(file)] = file;
@@ -381,7 +381,7 @@ namespace SerialLoops.Lib
         {
             try
             {
-                GraphicsFile file = archive.Files.FirstOrDefault(f => f.Index == index);
+                GraphicsFile file = archive.GetFileByIndex(index);
                 GraphicsFile newFile = new()
                 {
                     Name = file.Name,

--- a/src/SerialLoops.Lib/Items/BackgroundItem.cs
+++ b/src/SerialLoops.Lib/Items/BackgroundItem.cs
@@ -21,7 +21,6 @@ namespace SerialLoops.Lib.Items
         public int Flag { get; set; }
         public short ExtrasShort { get; set; }
         public byte ExtrasByte { get; set; }
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
         public BackgroundItem(string name) : base(name, ItemType.Background)
         {
@@ -30,9 +29,9 @@ namespace SerialLoops.Lib.Items
         {
             Id = id;
             BackgroundType = entry.Type;
-            Graphic1 = project.Grp.Files.First(g => g.Index == entry.BgIndex1);
-            Graphic2 = project.Grp.Files.FirstOrDefault(g => g.Index == entry.BgIndex2); // can be null if type is SINGLE_TEX
-            CgExtraData cgEntry = project.Extra.Cgs.FirstOrDefault(c => c.BgId == Id);
+            Graphic1 = project.Grp.GetFileByIndex(entry.BgIndex1);
+            Graphic2 = project.Grp.GetFileByIndex(entry.BgIndex2); // can be null if type is SINGLE_TEX
+            CgExtraData cgEntry = project.Extra.Cgs.AsParallel().FirstOrDefault(c => c.BgId == Id);
             if (cgEntry is not null)
             {
                 CgName = cgEntry?.Name?.GetSubstitutedString(project);
@@ -40,12 +39,10 @@ namespace SerialLoops.Lib.Items
                 ExtrasShort = cgEntry?.Unknown02 ?? 0;
                 ExtrasByte = cgEntry?.Unknown04 ?? 0;
             }
-            PopulateScriptUses(project.Evt);
         }
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project.Evt);
         }
 
         public SKBitmap GetBackground()
@@ -224,23 +221,6 @@ namespace SerialLoops.Lib.Items
             {
                 // TODO: Export screen information for KBGs
             }
-        }
-
-        public void PopulateScriptUses(ArchiveFile<EventFile> evt)
-        {
-            string[] bgCommands = new string[]
-            {
-                EventFile.CommandVerb.KBG_DISP.ToString(),
-                EventFile.CommandVerb.BG_DISP.ToString(),
-                EventFile.CommandVerb.BG_DISP2.ToString(),
-                EventFile.CommandVerb.BG_DISPCG.ToString(),
-                EventFile.CommandVerb.BG_FADE.ToString(),
-            };
-
-            ScriptUses = evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => bgCommands.Contains(c.Command.Mnemonic)).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == Id || t.c.Command.Mnemonic == EventFile.CommandVerb.BG_FADE.ToString() && t.c.Parameters[1] == Id).ToArray();
         }
 
         public SKBitmap GetPreview(Project project)

--- a/src/SerialLoops.Lib/Items/BackgroundMusicItem.cs
+++ b/src/SerialLoops.Lib/Items/BackgroundMusicItem.cs
@@ -23,7 +23,6 @@ namespace SerialLoops.Lib.Items
         public string BgmName { get; set; }
         public short? Flag { get; set; }
         public string CachedWaveFile { get; set; }
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
         public BackgroundMusicItem(string bgmFile, int index, Project project) : base(Path.GetFileNameWithoutExtension(bgmFile), ItemType.BGM)
         {
@@ -34,20 +33,10 @@ namespace SerialLoops.Lib.Items
             Flag = project.Extra.Bgms.FirstOrDefault(b => b.Index == Index)?.Flag;
             DisplayName = string.IsNullOrEmpty(BgmName) ? Name : $"{Name} - {BgmName}";
             CanRename = string.IsNullOrEmpty(BgmName);
-            PopulateScriptUses(project);
         }
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project);
-        }
-
-        public void PopulateScriptUses(Project project)
-        {
-            ScriptUses = project.Evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.BGM_PLAY.ToString()).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == Index).ToArray();
         }
 
         public void Replace(string audioFile, string baseDirectory, string iterativeDirectory, string bgmCachedFile, bool loopEnabled, uint loopStartSample, uint loopEndSample, ILogger log, IProgressTracker tracker, CancellationToken cancellationToken)

--- a/src/SerialLoops.Lib/Items/CharacterSpriteItem.cs
+++ b/src/SerialLoops.Lib/Items/CharacterSpriteItem.cs
@@ -13,18 +13,15 @@ namespace SerialLoops.Lib.Items
     {
         public CharacterSprite Sprite { get; set; }
         public int Index { get; set; }
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
         public CharacterSpriteItem(CharacterSprite sprite, CharacterDataFile chrdata, Project project) : base($"SPR_{sprite.Character}_{chrdata.Sprites.IndexOf(sprite):D3}", ItemType.Character_Sprite)
         {
             Sprite = sprite;
             Index = chrdata.Sprites.IndexOf(sprite);
-            PopulateScriptUses(project.Evt);
         }
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project.Evt);
         }
 
         public List<(SKBitmap Frame, int Timing)> GetClosedMouthAnimation(Project project)
@@ -39,8 +36,8 @@ namespace SerialLoops.Lib.Items
 
         public SKBitmap GetBaseLayout(Project project)
         {
-            List<GraphicsFile> textures = new() { project.Grp.Files.First(f => f.Index == Sprite.TextureIndex1), project.Grp.Files.First(f => f.Index == Sprite.TextureIndex2), project.Grp.Files.First(f => f.Index == Sprite.TextureIndex3) };
-            GraphicsFile layout = project.Grp.Files.First(g => g.Index == Sprite.LayoutIndex);
+            List<GraphicsFile> textures = new() { project.Grp.GetFileByIndex(Sprite.TextureIndex1), project.Grp.GetFileByIndex(Sprite.TextureIndex2), project.Grp.GetFileByIndex(Sprite.TextureIndex3) };
+            GraphicsFile layout = project.Grp.GetFileByIndex(Sprite.LayoutIndex);
             (SKBitmap spriteBitmap, _) = layout.GetLayout(textures, 0, layout.LayoutEntries.Count, darkMode: false, preprocessedList: true);
 
             return spriteBitmap;
@@ -48,26 +45,18 @@ namespace SerialLoops.Lib.Items
 
         public List<(SKBitmap Frame, short Timing)> GetEyeFrames(Project project)
         {
-            GraphicsFile eyeTexture = project.Grp.Files.First(f => f.Index == Sprite.EyeTextureIndex);
-            GraphicsFile eyeAnimation = project.Grp.Files.First(f => f.Index == Sprite.EyeAnimationIndex);
+            GraphicsFile eyeTexture = project.Grp.GetFileByIndex(Sprite.EyeTextureIndex);
+            GraphicsFile eyeAnimation = project.Grp.GetFileByIndex(Sprite.EyeAnimationIndex);
 
             return eyeAnimation.GetAnimationFrames(eyeTexture).Select(g => g.GetImage()).Zip(eyeAnimation.AnimationEntries.Select(a => ((FrameAnimationEntry)a).Time)).ToList();
         }
 
         public List<(SKBitmap Frame, short Timing)> GetMouthFrames(Project project)
         {
-            GraphicsFile mouthTexture = project.Grp.Files.First(f => f.Index == Sprite.MouthTextureIndex);
-            GraphicsFile mouthAnimation = project.Grp.Files.First(f => f.Index == Sprite.MouthAnimationIndex);
+            GraphicsFile mouthTexture = project.Grp.GetFileByIndex(Sprite.MouthTextureIndex);
+            GraphicsFile mouthAnimation = project.Grp.GetFileByIndex(Sprite.MouthAnimationIndex);
 
             return mouthAnimation.GetAnimationFrames(mouthTexture).Select(g => g.GetImage()).ToList().Zip(mouthAnimation.AnimationEntries.Select(a => ((FrameAnimationEntry)a).Time)).ToList();
-        }
-
-        public void PopulateScriptUses(ArchiveFile<EventFile> evt)
-        {
-            ScriptUses = evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => c.Command.Mnemonic == "DIALOGUE").Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[1] == Index).ToArray();
         }
         
         public SKBitmap GetPreview(Project project)

--- a/src/SerialLoops.Lib/Items/ChibiItem.cs
+++ b/src/SerialLoops.Lib/Items/ChibiItem.cs
@@ -17,22 +17,20 @@ namespace SerialLoops.Lib.Items
         public List<(string Name, ChibiGraphics Chibi)> ChibiEntries { get; set; } = new();
         public Dictionary<string, bool> ChibiEntryModifications { get; set; } = new();
         public Dictionary<string, List<(SKBitmap Frame, short Timing)>> ChibiAnimations { get; set; } = new();
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
         public ChibiItem(Chibi chibi, Project project) : base($"CHIBI{chibi.ChibiEntries[0].Animation}", ItemType.Chibi)
         {
-            List<string> chibiIndices = new() { "", "KYN", "HAL", "MIK", "NAG", "KOI" };
+            List<string> chibiIndices = ["", "KYN", "HAL", "MIK", "NAG", "KOI"];
 
             Chibi = chibi;
-            string firstAnimationName = project.Grp.Files.First(f => f.Index == Chibi.ChibiEntries[0].Animation).Name;
+            string firstAnimationName = project.Grp.GetFileByIndex(Chibi.ChibiEntries[0].Animation).Name;
             Name = $"CHIBI_{firstAnimationName[0..firstAnimationName.IndexOf('_')]}";
             DisplayName = $"CHIBI_{firstAnimationName[0..firstAnimationName.IndexOf('_')]}";
             ChibiIndex = chibiIndices.IndexOf(firstAnimationName[0..3]);
             ChibiEntries.AddRange(Chibi.ChibiEntries.Where(c => c.Animation > 0)
-                .Select(c => (project.Grp.Files.First(f => f.Index == c.Animation).Name[0..^3], new ChibiGraphics(c, project))));
+                .Select(c => (project.Grp.GetFileByIndex(c.Animation).Name[0..^3], new ChibiGraphics(c, project))));
             ChibiEntries.ForEach(e => ChibiEntryModifications.Add(e.Name, false));
             ChibiEntries.ForEach(e => ChibiAnimations.Add(e.Name, GetChibiAnimation(e.Name, project.Grp)));
-            PopulateScriptUses(project.Evt);
         }
 
         public void SetChibiAnimation(string entryName, List<(SKBitmap, short)> framesAndTimings)
@@ -59,19 +57,6 @@ namespace SerialLoops.Lib.Items
         {
             ChibiAnimations.Clear();
             ChibiEntries.ForEach(e => ChibiAnimations.Add(e.Name, GetChibiAnimation(e.Name, project.Grp)));
-            PopulateScriptUses(project.Evt);
-        }
-
-        public void PopulateScriptUses(ArchiveFile<EventFile> evt)
-        {
-            string[] chibiCommands = new string[] { "CHIBI_ENTEREXIT" };
-
-            var list = evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => chibiCommands.Contains(c.Command.Mnemonic)).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == ChibiIndex).ToList();
-
-            ScriptUses = list.ToArray();
         }
 
         SKBitmap IPreviewableGraphic.GetPreview(Project project)
@@ -105,8 +90,8 @@ namespace SerialLoops.Lib.Items
 
             public ChibiGraphics(ChibiEntry entry, Project project)
             {
-                Texture = project.Grp.Files.First(g => g.Index == entry.Texture);
-                Animation = project.Grp.Files.First(g => g.Index == entry.Animation);
+                Texture = project.Grp.GetFileByIndex(entry.Texture);
+                Animation = project.Grp.GetFileByIndex(entry.Animation);
             }
 
             public void Write(Project project, ILogger log)

--- a/src/SerialLoops.Lib/Items/ChibiItem.cs
+++ b/src/SerialLoops.Lib/Items/ChibiItem.cs
@@ -1,6 +1,5 @@
 ﻿using HaruhiChokuretsuLib.Archive;
 using HaruhiChokuretsuLib.Archive.Data;
-using HaruhiChokuretsuLib.Archive.Event;
 using HaruhiChokuretsuLib.Archive.Graphics;
 using HaruhiChokuretsuLib.Util;
 using SkiaSharp;
@@ -13,20 +12,22 @@ namespace SerialLoops.Lib.Items
     public class ChibiItem : Item, IPreviewableGraphic
     {
         public Chibi Chibi { get; set; }
+        public int TopScreenIndex { get; set; }
         public int ChibiIndex { get; set; }
         public List<(string Name, ChibiGraphics Chibi)> ChibiEntries { get; set; } = new();
         public Dictionary<string, bool> ChibiEntryModifications { get; set; } = new();
         public Dictionary<string, List<(SKBitmap Frame, short Timing)>> ChibiAnimations { get; set; } = new();
 
-        public ChibiItem(Chibi chibi, Project project) : base($"CHIBI{chibi.ChibiEntries[0].Animation}", ItemType.Chibi)
+        public ChibiItem(Chibi chibi, int chibiIndex, Project project) : base($"CHIBI{chibi.ChibiEntries[0].Animation}", ItemType.Chibi)
         {
             List<string> chibiIndices = ["", "KYN", "HAL", "MIK", "NAG", "KOI"];
 
             Chibi = chibi;
+            ChibiIndex = chibiIndex + 1;
             string firstAnimationName = project.Grp.GetFileByIndex(Chibi.ChibiEntries[0].Animation).Name;
             Name = $"CHIBI_{firstAnimationName[0..firstAnimationName.IndexOf('_')]}";
             DisplayName = $"CHIBI_{firstAnimationName[0..firstAnimationName.IndexOf('_')]}";
-            ChibiIndex = chibiIndices.IndexOf(firstAnimationName[0..3]);
+            TopScreenIndex = chibiIndices.IndexOf(firstAnimationName[0..3]);
             ChibiEntries.AddRange(Chibi.ChibiEntries.Where(c => c.Animation > 0)
                 .Select(c => (project.Grp.GetFileByIndex(c.Animation).Name[0..^3], new ChibiGraphics(c, project))));
             ChibiEntries.ForEach(e => ChibiEntryModifications.Add(e.Name, false));

--- a/src/SerialLoops.Lib/Items/ItemDescription.cs
+++ b/src/SerialLoops.Lib/Items/ItemDescription.cs
@@ -101,13 +101,12 @@ namespace SerialLoops.Lib.Items
 
                 case ItemType.Chibi:
                     ChibiItem chibi = (ChibiItem)this;
-                    int chibiIndex = project.Items.Where(i => i.Type == ItemType.Chibi).ToList().IndexOf(chibi) + 1;
                     references.AddRange(project.Items.Where(i => i.Type == ItemType.Script && project.Evt.Files.Where(e =>
-                        e.MapCharactersSection?.Objects?.Any(t => t.CharacterIndex == chibiIndex) ?? false).Select(e => e.Index).Contains(((ScriptItem)i).Event.Index)));
+                        e.MapCharactersSection?.Objects?.Any(t => t.CharacterIndex == chibi.ChibiIndex) ?? false).Select(e => e.Index).Contains(((ScriptItem)i).Event.Index)));
                     (string ScriptName, ScriptCommandInvocation command)[] chibiScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
                         e.ScriptSections.SelectMany(sec =>
                             sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.CHIBI_ENTEREXIT.ToString()).Select(c => (e.Name[0..^1], c))))
-                        .Where(t => t.c.Parameters[0] == chibi.ChibiIndex).ToArray();
+                        .Where(t => t.c.Parameters[0] == chibi.TopScreenIndex).ToArray();
                     references.AddRange(project.Items.Where(i => chibiScriptUses.Select(s => s.ScriptName).Contains(i.Name)));
                     return references.Distinct().ToList();
 

--- a/src/SerialLoops.Lib/Items/ItemDescription.cs
+++ b/src/SerialLoops.Lib/Items/ItemDescription.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using static HaruhiChokuretsuLib.Archive.Data.QMapFile;
 
 namespace SerialLoops.Lib.Items
 {
@@ -59,29 +60,58 @@ namespace SerialLoops.Lib.Items
 
         public List<ItemDescription> GetReferencesTo(Project project)
         {
-            List<ItemDescription> references = new();
+            List<ItemDescription> references = [];
             ScenarioItem scenario = (ScenarioItem)project.Items.First(i => i.Name == "Scenario");
             switch (Type)
             {
                 case ItemType.Background:
                     BackgroundItem bg = (BackgroundItem)this;
-                    return project.Items.Where(i => bg.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+                    string[] bgCommands =
+                    [
+                        EventFile.CommandVerb.KBG_DISP.ToString(),
+                        EventFile.CommandVerb.BG_DISP.ToString(),
+                        EventFile.CommandVerb.BG_DISP2.ToString(),
+                        EventFile.CommandVerb.BG_DISPCG.ToString(),
+                        EventFile.CommandVerb.BG_FADE.ToString(),
+                    ];
+                    (string ScriptName, ScriptCommandInvocation command)[] bgScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => bgCommands.Contains(c.Command.Mnemonic)).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[0] == bg.Id || t.c.Command.Mnemonic == EventFile.CommandVerb.BG_FADE.ToString() && t.c.Parameters[1] == bg.Id).ToArray();
+                    return project.Items.Where(i => bgScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+
                 case ItemType.BGM:
                     BackgroundMusicItem bgm = (BackgroundMusicItem)this;
-                    return project.Items.Where(i => bgm.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+                    (string ScriptName, ScriptCommandInvocation comamnd)[] bgmScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.BGM_PLAY.ToString()).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[0] == bgm.Index).ToArray();
+                    return project.Items.Where(i => bgmScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+
                 case ItemType.Character:
                     CharacterItem character = (CharacterItem)this;
                     return project.Items.Where(i => i.Type == ItemType.Script && ((ScriptItem)i).Event.DialogueSection.Objects.Any(l => l.Speaker == character.MessageInfo.Character)).ToList();
+
                 case ItemType.Character_Sprite:
                     CharacterSpriteItem sprite = (CharacterSpriteItem)this;
-                    return project.Items.Where(i => sprite.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+                    (string ScriptName, ScriptCommandInvocation command)[] spriteScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.DIALOGUE.ToString()).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[1] == sprite.Index).ToArray();
+                    return project.Items.Where(i => spriteScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+
                 case ItemType.Chibi:
                     ChibiItem chibi = (ChibiItem)this;
                     int chibiIndex = project.Items.Where(i => i.Type == ItemType.Chibi).ToList().IndexOf(chibi) + 1;
                     references.AddRange(project.Items.Where(i => i.Type == ItemType.Script && project.Evt.Files.Where(e =>
                         e.MapCharactersSection?.Objects?.Any(t => t.CharacterIndex == chibiIndex) ?? false).Select(e => e.Index).Contains(((ScriptItem)i).Event.Index)));
-                    references.AddRange(project.Items.Where(i => chibi.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)));
+                    (string ScriptName, ScriptCommandInvocation command)[] chibiScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.CHIBI_ENTEREXIT.ToString()).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[0] == chibi.ChibiIndex).ToArray();
+                    references.AddRange(project.Items.Where(i => chibiScriptUses.Select(s => s.ScriptName).Contains(i.Name)));
                     return references.Distinct().ToList();
+
                 case ItemType.Group_Selection:
                     GroupSelectionItem groupSelection = (GroupSelectionItem)this;
                     if (scenario.Scenario.Commands.Any(c => c.Verb == ScenarioCommand.ScenarioVerb.ROUTE_SELECT && c.Parameter == groupSelection.Index))
@@ -89,13 +119,24 @@ namespace SerialLoops.Lib.Items
                         references.Add(scenario);
                     }
                     return references;
+
                 case ItemType.Map:
                     MapItem map = (MapItem)this;
+                    (string ScriptName, ScriptCommandInvocation command)[] mapScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.LOAD_ISOMAP.ToString()).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[0] == map.Map.Index).ToArray();
                     return project.Items.Where(i => i.Type == ItemType.Puzzle && ((PuzzleItem)i).Puzzle.Settings.MapId == map.QmapIndex)
-                        .Concat(project.Items.Where(i => map.ScriptUses.Select(s => s.ScriptName).Contains(i.Name))).ToList();
+                        .Concat(project.Items.Where(i => mapScriptUses.Select(s => s.ScriptName).Contains(i.Name))).ToList();
+
                 case ItemType.Place:
                     PlaceItem place = (PlaceItem)this;
-                    return project.Items.Where(i => place.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+                    (string ScriptName, ScriptCommandInvocation command)[] placeScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.SET_PLACE.ToString()).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[1] == place.Index).ToArray();
+                    return project.Items.Where(i => placeScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+
                 case ItemType.Puzzle:
                     PuzzleItem puzzle = (PuzzleItem)this;
                     if (scenario.Scenario.Commands.Any(c => c.Verb == ScenarioCommand.ScenarioVerb.PUZZLE_PHASE && c.Parameter == puzzle.Puzzle.Index))
@@ -103,6 +144,7 @@ namespace SerialLoops.Lib.Items
                         references.Add(scenario);
                     }
                     return references;
+
                 case ItemType.Script:
                     ScriptItem script = (ScriptItem)this;
                     if (scenario.Scenario.Commands.Any(c => c.Verb == ScenarioCommand.ScenarioVerb.LOAD_SCENE && c.Parameter == script.Event.Index))
@@ -115,17 +157,38 @@ namespace SerialLoops.Lib.Items
                         (((TopicItem)i).HiddenMainTopic?.EventIndex ?? -1) == script.Event.Index)));
                     references.AddRange(project.Items.Where(i => i.Type == ItemType.Script && ((ScriptItem)i).Event.ConditionalsSection.Objects.Contains(Name)));
                     return references;
+
                 case ItemType.SFX:
                     SfxItem sfx = (SfxItem)this;
-                    references.AddRange(project.Items.Where(i => sfx.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)));
+                    (string ScriptName, ScriptCommandInvocation command)[] sfxScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.SND_PLAY.ToString()).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[0] == sfx.Index).ToArray();
+                    references.AddRange(project.Items.Where(i => sfxScriptUses.Select(s => s.ScriptName).Contains(i.Name)));
                     references.AddRange(project.Items.Where(c => c.Type == ItemType.Character && ((CharacterItem)c).MessageInfo.VoiceFont == sfx.Index));
                     return references;
+
                 case ItemType.Topic:
                     TopicItem topic = (TopicItem)this;
-                    return project.Items.Where(i => topic.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+                    (string ScriptName, ScriptCommandInvocation command)[] topicScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.TOPIC_GET.ToString()).Select(c => (e.Name[0..^1], c))))
+                        .Where(t => t.c.Parameters[0] == topic.TopicEntry.Id).ToArray();
+                    return project.Items.Where(i => topicScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+
                 case ItemType.Voice:
                     VoicedLineItem voicedLine = (VoicedLineItem)this;
-                    return project.Items.Where(i => voicedLine.ScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+                    (string ScriptName, ScriptCommandInvocation command)[] vceScriptUses = project.Evt.Files.AsParallel().SelectMany(e =>
+                        e.ScriptSections.SelectMany(sec =>
+                            sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.DIALOGUE.ToString()).Select(c => (e.Name[0..^1], c))))
+                            .Where(t => t.c.Parameters[5] == voicedLine.Index)
+                            .Concat(project.Evt.Files.AsParallel().SelectMany(e =>
+                            e.ScriptSections.SelectMany(sec =>
+                                sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.VCE_PLAY.ToString()).Select(c => (e.Name[0..^1], c))))
+                            .Where(t => t.c.Parameters[0] == voicedLine.Index))
+                            .ToArray();
+                    return project.Items.Where(i => vceScriptUses.Select(s => s.ScriptName).Contains(i.Name)).ToList();
+
                 default:
                     return references;
             }

--- a/src/SerialLoops.Lib/Items/ItemDescription.cs
+++ b/src/SerialLoops.Lib/Items/ItemDescription.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using static HaruhiChokuretsuLib.Archive.Data.QMapFile;
 
 namespace SerialLoops.Lib.Items
 {

--- a/src/SerialLoops.Lib/Items/ItemItem.cs
+++ b/src/SerialLoops.Lib/Items/ItemItem.cs
@@ -18,7 +18,7 @@ namespace SerialLoops.Lib.Items
         }
         public ItemItem(string name, int itemIndex, short grpIndex, Project project) : base(name, ItemType.Item)
         {
-            ItemGraphic = project.Grp.Files[grpIndex - 1];
+            ItemGraphic = project.Grp.GetFileByIndex(grpIndex);
             ItemIndex = itemIndex;
         }
 

--- a/src/SerialLoops.Lib/Items/MapItem.cs
+++ b/src/SerialLoops.Lib/Items/MapItem.cs
@@ -12,7 +12,6 @@ namespace SerialLoops.Lib.Items
     {
         public MapFile Map { get; set; }
         public int QmapIndex { get; set; }
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
         public MapItem(string name) : base(name, ItemType.Map)
         {
@@ -21,12 +20,11 @@ namespace SerialLoops.Lib.Items
         {
             Map = map;
             QmapIndex = qmapIndex;
-            PopulateScriptUses(project.Evt);
         }
 
         public SKPoint GetOrigin(ArchiveFile<GraphicsFile> grp)
         {
-            GraphicsFile layout = grp.Files.First(f => f.Index == Map.Settings.LayoutFileIndex);
+            GraphicsFile layout = grp.GetFileByIndex(Map.Settings.LayoutFileIndex);
             return new SKPoint(layout.LayoutEntries[Map.Settings.LayoutSizeDefinitionIndex].ScreenX, layout.LayoutEntries[Map.Settings.LayoutSizeDefinitionIndex].ScreenY);
         }
 
@@ -39,7 +37,7 @@ namespace SerialLoops.Lib.Items
             }
             else
             {
-                map = Map.GetMapImages(grp, 0, grp.Files.First(f => f.Index == Map.Settings.LayoutFileIndex).LayoutEntries.Count);
+                map = Map.GetMapImages(grp, 0, grp.GetFileByIndex(Map.Settings.LayoutFileIndex).LayoutEntries.Count);
             }
             SKBitmap mapWithGrid = new(map.Width, map.Height);
             SKCanvas canvas = new(mapWithGrid);
@@ -119,18 +117,6 @@ namespace SerialLoops.Lib.Items
             };
         }
 
-        public void PopulateScriptUses(ArchiveFile<EventFile> evt)
-        {
-            string[] chibiCommands = ["LOAD_ISOMAP"];
-
-            var list = evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => chibiCommands.Contains(c.Command.Mnemonic)).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == Map.Index).ToList();
-
-            ScriptUses = list.ToArray();
-        }
-
         private static SKBitmap GetMapIcon(string name, int size)
         {
             SKBitmap icon = new(size, size);
@@ -141,7 +127,6 @@ namespace SerialLoops.Lib.Items
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project.Evt);
         }
     }
 }

--- a/src/SerialLoops.Lib/Items/PlaceItem.cs
+++ b/src/SerialLoops.Lib/Items/PlaceItem.cs
@@ -14,19 +14,16 @@ namespace SerialLoops.Lib.Items
         public int Index { get; set; }
         public GraphicsFile PlaceGraphic { get; set; }
         public string PlaceName { get; set; }
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
-        public PlaceItem(int index, GraphicsFile placeGrp, Project project) : base(placeGrp.Name[0..^3], ItemType.Place)
+        public PlaceItem(int index, GraphicsFile placeGrp) : base(placeGrp.Name[0..^3], ItemType.Place)
         {
             Index = index;
             CanRename = false;
             PlaceGraphic = placeGrp;
-            PopulateScriptUses(project.Evt);
         }
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project.Evt);
         }
 
         public static SKBitmap Unscramble(SKBitmap placeGraphic)
@@ -119,14 +116,6 @@ namespace SerialLoops.Lib.Items
             }
 
             return newPlaceBitmap;
-        }
-
-        public void PopulateScriptUses(ArchiveFile<EventFile> evt)
-        {
-            ScriptUses = evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => c.Command.Mnemonic == "SET_PLACE").Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[1] == Index).ToArray();
         }
 
         public class CustomFontMapper : FontMapper

--- a/src/SerialLoops.Lib/Items/PuzzleItem.cs
+++ b/src/SerialLoops.Lib/Items/PuzzleItem.cs
@@ -20,8 +20,8 @@ namespace SerialLoops.Lib.Items
 
         public override void Refresh(Project project, ILogger log)
         {
-            GraphicsFile singularityLayout = project.Grp.Files.First(f => f.Index == Puzzle.Settings.SingularityLayout);
-            GraphicsFile singularityTexture = project.Grp.Files.First(f => f.Index == Puzzle.Settings.SingularityTexture);
+            GraphicsFile singularityLayout = project.Grp.GetFileByIndex(Puzzle.Settings.SingularityLayout);
+            GraphicsFile singularityTexture = project.Grp.GetFileByIndex(Puzzle.Settings.SingularityTexture);
             SingularityImage = singularityLayout.GetLayout(
                     [singularityTexture],
                     0,

--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -200,7 +200,7 @@ namespace SerialLoops.Lib.Items
                 {
                     if (chibi.ChibiIndex > 0)
                     {
-                        chibis.Add((ChibiItem)project.Items.First(i => i.Type == ItemType.Chibi && ((ChibiItem)i).ChibiIndex == chibi.ChibiIndex));
+                        chibis.Add((ChibiItem)project.Items.First(i => i.Type == ItemType.Chibi && ((ChibiItem)i).TopScreenIndex == chibi.ChibiIndex));
                     }
                 }
                 for (int i = 0; i < commands.Count; i++)
@@ -208,7 +208,7 @@ namespace SerialLoops.Lib.Items
                     if (commands[i].Verb == CommandVerb.OP_MODE)
                     {
                         // Kyon auto-added by OP_MODE command
-                        ChibiItem chibi = (ChibiItem)project.Items.First(i => i.Type == ItemType.Chibi && ((ChibiItem)i).ChibiIndex == 1);
+                        ChibiItem chibi = (ChibiItem)project.Items.First(i => i.Type == ItemType.Chibi && ((ChibiItem)i).TopScreenIndex == 1);
                         if (!chibis.Contains(chibi))
                         {
                             chibis.Add(chibi);
@@ -221,7 +221,7 @@ namespace SerialLoops.Lib.Items
                             ChibiItem chibi = ((ChibiScriptParameter)commands[i].Parameters[0]).Chibi;
                             if (!chibis.Contains(chibi))
                             {
-                                if (chibi.ChibiIndex < 1 || chibis.Count == 0)
+                                if (chibi.TopScreenIndex < 1 || chibis.Count == 0)
                                 {
                                     chibis.Add(chibi);
                                 }
@@ -230,7 +230,7 @@ namespace SerialLoops.Lib.Items
                                     bool inserted = false;
                                     for (int j = 0; j < chibis.Count; j++)
                                     {
-                                        if (chibis[j].ChibiIndex > chibi.ChibiIndex)
+                                        if (chibis[j].TopScreenIndex > chibi.TopScreenIndex)
                                         {
                                             chibis.Insert(j, chibi);
                                             inserted = true;

--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -609,7 +609,7 @@ namespace SerialLoops.Lib.Items
 
                 if (preview.ChibiEmote.EmotingChibi is not null)
                 {
-                    SKBitmap emotes = project.Grp.Files.First(f => f.Name == "SYS_ADV_T08DNX").GetImage(width: 32, transparentIndex: 0);
+                    SKBitmap emotes = project.Grp.GetFileByName("SYS_ADV_T08DNX").GetImage(width: 32, transparentIndex: 0);
                     int chibiY = preview.TopScreenChibis.First(c => c.Chibi == preview.ChibiEmote.EmotingChibi).Y;
                     canvas.DrawBitmap(emotes, new SKRect(0, preview.ChibiEmote.InternalYOffset, 32, preview.ChibiEmote.InternalYOffset + 32), new SKRect(preview.ChibiEmote.ExternalXOffset + 16, chibiY - 32, preview.ChibiEmote.ExternalXOffset + 48, chibiY));
                 }

--- a/src/SerialLoops.Lib/Items/SfxItem.cs
+++ b/src/SerialLoops.Lib/Items/SfxItem.cs
@@ -1,5 +1,4 @@
 ﻿using HaruhiChokuretsuLib.Archive.Data;
-using HaruhiChokuretsuLib.Archive.Event;
 using HaruhiChokuretsuLib.Audio.SDAT.SoundArchiveComponents;
 using HaruhiChokuretsuLib.Util;
 using System.Collections.Generic;
@@ -13,7 +12,6 @@ namespace SerialLoops.Lib.Items
         public SfxEntry Entry { get; set; }
         public string AssociatedBank { get; private set; }
         public List<string> AssociatedGroups { get; set; }
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
         public SfxItem(SfxEntry entry, string name, short index, Project project) : base(name, ItemType.SFX)
         {
@@ -21,20 +19,10 @@ namespace SerialLoops.Lib.Items
             Index = index;
             AssociatedBank = project.Snd.SequenceArchives[entry.SequenceArchive].File.Sequences[entry.Index].Bank.Name;
             AssociatedGroups = project.Snd.Groups.Where(g => g.Entries.Any(e => e.LoadBank && ((BankInfo)e.Entry).Name.Equals(AssociatedBank))).Select(g => g.Name).ToList();
-            PopulateScriptUses(project);
         }
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project);
-        }
-
-        public void PopulateScriptUses(Project project)
-        {
-            ScriptUses = project.Evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.SND_PLAY.ToString()).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == Index).ToArray();
         }
     }
 }

--- a/src/SerialLoops.Lib/Items/SystemTextureItem.cs
+++ b/src/SerialLoops.Lib/Items/SystemTextureItem.cs
@@ -19,7 +19,7 @@ namespace SerialLoops.Lib.Items
         public SystemTextureItem(SystemTexture sysTex, Project project, string name, int width = -1, int height = -1) : base(name, ItemType.System_Texture)
         {
             SysTex = sysTex;
-            Grp = project.Grp.Files.First(f => f.Index == sysTex.GrpIndex);
+            Grp = project.Grp.GetFileByIndex(sysTex.GrpIndex);
             if (SysTex.Screen == SysTexScreen.BOTTOM_SCREEN)
             {
                 Grp.ImageForm = GraphicsFile.Form.TEXTURE;

--- a/src/SerialLoops.Lib/Items/TopicItem.cs
+++ b/src/SerialLoops.Lib/Items/TopicItem.cs
@@ -16,20 +16,10 @@ namespace SerialLoops.Lib.Items
             DisplayName = $"{topic.Id} - {topic.Title.GetSubstitutedString(project)}";
             CanRename = false;
             TopicEntry = topic;
-            PopulateScriptUses(project);
         }
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project);
-        }
-
-        public void PopulateScriptUses(Project project)
-        {
-            ScriptUses = project.Evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.TOPIC_GET.ToString()).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == TopicEntry.Id).ToArray();
         }
     }
 }

--- a/src/SerialLoops.Lib/Items/VoicedLineItem.cs
+++ b/src/SerialLoops.Lib/Items/VoicedLineItem.cs
@@ -19,14 +19,12 @@ namespace SerialLoops.Lib.Items
         public string VoiceFile { get; set; }
         public int Index { get; set; }
         public AdxEncoding AdxType { get; set; }
-        public (string ScriptName, ScriptCommandInvocation command)[] ScriptUses { get; set; }
 
         public VoicedLineItem(string voiceFile, int index, Project project) : base(Path.GetFileNameWithoutExtension(voiceFile), ItemType.Voice)
         {
             VoiceFile = Path.GetRelativePath(project.IterativeDirectory, voiceFile);
             _vceFile = voiceFile;
             Index = index;
-            PopulateScriptUses(project);
         }
         
         public IWaveProvider GetWaveProvider(ILogger log, bool loop = false)
@@ -133,22 +131,6 @@ namespace SerialLoops.Lib.Items
 
         public override void Refresh(Project project, ILogger log)
         {
-            PopulateScriptUses(project);
-        }
-
-        public void PopulateScriptUses(Project project)
-        {
-            var list = project.Evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.DIALOGUE.ToString()).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[5] == Index).ToList();
-            list.AddRange(project.Evt.Files.SelectMany(e =>
-                e.ScriptSections.SelectMany(sec =>
-                    sec.Objects.Where(c => c.Command.Mnemonic == EventFile.CommandVerb.VCE_PLAY.ToString()).Select(c => (e.Name[0..^1], c))))
-                .Where(t => t.c.Parameters[0] == Index));
-
-            ScriptUses = list.ToArray();
-        }
-        
+        }        
     }
 }

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -536,10 +536,10 @@ namespace SerialLoops.Lib
             {
                 ChibiFile chibiFile = Dat.GetFileByName("CHIBIS").CastTo<ChibiFile>();
                 tracker.Focus("Chibis", chibiFile.Chibis.Count);
-                Items.AddRange(chibiFile.Chibis.AsParallel().Select(c =>
+                Items.AddRange(chibiFile.Chibis.AsParallel().Select((c, i) =>
                 {
                     tracker.Finished++;
-                    return new ChibiItem(c, this);
+                    return new ChibiItem(c, i, this);
                 }));
             }
             catch (Exception ex)

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -398,6 +398,7 @@ namespace SerialLoops.Lib
             {
                 BgTableFile bgTable = Dat.GetFileByName("BGTBLS").CastTo<BgTableFile>();
                 tracker.Focus("Backgrounds", bgTable.BgTableEntries.Count);
+                List<string> names = [];
                 Items.AddRange(bgTable.BgTableEntries.AsParallel().Select((entry, i) =>
                 {
                     if (entry.BgIndex1 > 0)
@@ -405,11 +406,12 @@ namespace SerialLoops.Lib
                         GraphicsFile nameGraphic = Grp.GetFileByIndex(entry.BgIndex1);
                         string name = $"BG_{nameGraphic.Name[0..nameGraphic.Name.LastIndexOf('_')]}";
                         string bgNameBackup = name;
-                        for (int j = 1; Items.Select(j => j.Name).Contains(name); j++)
+                        for (int j = 1; names.Contains(name); j++)
                         {
                             name = $"{bgNameBackup}{j:D2}";
                         }
                         tracker.Finished++;
+                        names.Add(name);
                         return new BackgroundItem(name, i, entry, this);
                     }
                     else

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -829,7 +829,7 @@ namespace SerialLoops.Lib
             {
                 return null;
             }
-            return Items.FirstOrDefault(i => name.Contains(" - ") ? i.Name == name.Split(" - ")[0] : i.DisplayName == name);
+            return Items.FirstOrDefault(i => i.DisplayName == name);
         }
 
         public static (Project Project, LoadProjectResult Result) OpenProject(string projFile, Config config, Func<string, string> localize, ILogger log, IProgressTracker tracker)

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -300,7 +300,7 @@ namespace SerialLoops.Lib
             tracker.Finished++;
             try
             {
-                FontMap = Dat.Files.First(f => f.Name == "FONTS").CastTo<FontFile>();
+                FontMap = Dat.GetFileByName("FONTS").CastTo<FontFile>();
             }
             catch (Exception ex)
             {
@@ -310,7 +310,7 @@ namespace SerialLoops.Lib
             tracker.Finished++;
             try
             {
-                SpeakerBitmap = Grp.Files.First(f => f.Name == "SYS_CMN_B12DNX").GetImage(transparentIndex: 0);
+                SpeakerBitmap = Grp.GetFileByName("SYS_CMN_B12DNX").GetImage(transparentIndex: 0);
             }
             catch (Exception ex)
             {
@@ -319,7 +319,7 @@ namespace SerialLoops.Lib
             }
             try
             {
-                NameplateBitmap = Grp.Files.First(f => f.Name == "SYS_CMN_B12DNX").GetImage();
+                NameplateBitmap = Grp.GetFileByName("SYS_CMN_B12DNX").GetImage();
             }
             catch (Exception ex)
             {
@@ -329,7 +329,7 @@ namespace SerialLoops.Lib
             tracker.Finished++;
             try
             {
-                DialogueBitmap = Grp.Files.First(f => f.Name == "SYS_CMN_B02DNX").GetImage(transparentIndex: 0);
+                DialogueBitmap = Grp.GetFileByName("SYS_CMN_B02DNX").GetImage(transparentIndex: 0);
             }
             catch (Exception ex)
             {
@@ -339,9 +339,9 @@ namespace SerialLoops.Lib
             tracker.Finished++;
             try
             {
-                GraphicsFile fontFile = Grp.Files.First(f => f.Name == "ZENFONTBNF");
+                GraphicsFile fontFile = Grp.GetFileByName("ZENFONTBNF");
                 fontFile.InitializeFontFile();
-                FontBitmap = Grp.Files.First(f => f.Name == "ZENFONTBNF").GetImage(transparentIndex: 0);
+                FontBitmap = Grp.GetFileByName("ZENFONTBNF").GetImage(transparentIndex: 0);
             }
             catch (Exception ex)
             {
@@ -353,7 +353,7 @@ namespace SerialLoops.Lib
             tracker.Focus("Static Files", 4);
             try
             {
-                Extra = Dat.Files.First(f => f.Name == "EXTRAS").CastTo<ExtraFile>();
+                Extra = Dat.GetFileByName("EXTRAS").CastTo<ExtraFile>();
             }
             catch (Exception ex)
             {
@@ -363,7 +363,7 @@ namespace SerialLoops.Lib
             tracker.Finished++;
             try
             {
-                EventFile scenario = Evt.Files.First(f => f.Name == "SCENARIOS");
+                EventFile scenario = Evt.GetFileByName("SCENARIOS");
                 scenario.InitializeScenarioFile();
                 Scenario = scenario.Scenario;
             }
@@ -375,7 +375,7 @@ namespace SerialLoops.Lib
             tracker.Finished++;
             try
             {
-                MessInfo = Dat.Files.First(f => f.Name == "MESSINFOS").CastTo<MessageInfoFile>();
+                MessInfo = Dat.GetFileByName("MESSINFOS").CastTo<MessageInfoFile>();
             }
             catch (Exception ex)
             {
@@ -385,7 +385,7 @@ namespace SerialLoops.Lib
             tracker.Finished++;
             try
             {
-                UiText = Dat.Files.First(f => f.Name == "MESSS").CastTo<MessageFile>();
+                UiText = Dat.GetFileByName("MESSS").CastTo<MessageFile>();
             }
             catch (Exception ex)
             {
@@ -396,24 +396,27 @@ namespace SerialLoops.Lib
 
             try
             {
-                BgTableFile bgTable = Dat.Files.First(f => f.Name == "BGTBLS").CastTo<BgTableFile>();
+                BgTableFile bgTable = Dat.GetFileByName("BGTBLS").CastTo<BgTableFile>();
                 tracker.Focus("Backgrounds", bgTable.BgTableEntries.Count);
-                for (int i = 0; i < bgTable.BgTableEntries.Count; i++)
+                Items.AddRange(bgTable.BgTableEntries.AsParallel().Select((entry, i) =>
                 {
-                    BgTableEntry entry = bgTable.BgTableEntries[i];
                     if (entry.BgIndex1 > 0)
                     {
-                        GraphicsFile nameGraphic = Grp.Files.First(g => g.Index == entry.BgIndex1);
-                        string name = $"BG_{nameGraphic.Name[0..(nameGraphic.Name.LastIndexOf('_'))]}";
+                        GraphicsFile nameGraphic = Grp.GetFileByIndex(entry.BgIndex1);
+                        string name = $"BG_{nameGraphic.Name[0..nameGraphic.Name.LastIndexOf('_')]}";
                         string bgNameBackup = name;
-                        for (int j = 1; Items.Select(i => i.Name).Contains(name); j++)
+                        for (int j = 1; Items.Select(j => j.Name).Contains(name); j++)
                         {
                             name = $"{bgNameBackup}{j:D2}";
                         }
-                        Items.Add(new BackgroundItem(name, i, entry, this));
+                        tracker.Finished++;
+                        return new BackgroundItem(name, i, entry, this);
                     }
-                    tracker.Finished++;
-                }
+                    else
+                    {
+                        return null;
+                    }
+                }).Where(b => b is not null));
             }
             catch (Exception ex)
             {
@@ -423,7 +426,7 @@ namespace SerialLoops.Lib
 
             try
             {
-                SoundDS = Dat.Files.First(s => s.Name == "SND_DSS").CastTo<SoundDSFile>();
+                SoundDS = Dat.GetFileByName("SND_DSS").CastTo<SoundDSFile>();
             }
             catch (Exception ex)
             {
@@ -433,7 +436,7 @@ namespace SerialLoops.Lib
             {
                 if (VoiceMapIsV06OrHigher())
                 {
-                    VoiceMap = Evt.Files.First(v => v.Name == "VOICEMAPS").CastTo<VoiceMapFile>();
+                    VoiceMap = Evt.GetFileByName("VOICEMAPS").CastTo<VoiceMapFile>();
                 }
             }
             catch (Exception ex)
@@ -444,13 +447,13 @@ namespace SerialLoops.Lib
 
             try
             {
-                string[] bgmFiles = SoundDS.BgmSection.Where(bgm => bgm is not null).Select(bgm => Path.Combine(IterativeDirectory, "rom", "data", bgm)).ToArray(); /*Directory.GetFiles(Path.Combine(IterativeDirectory, "rom", "data", "bgm")).OrderBy(s => s).ToArray();*/
+                string[] bgmFiles = SoundDS.BgmSection.AsParallel().Where(bgm => bgm is not null).Select(bgm => Path.Combine(IterativeDirectory, "rom", "data", bgm)).ToArray(); /*Directory.GetFiles(Path.Combine(IterativeDirectory, "rom", "data", "bgm")).OrderBy(s => s).ToArray();*/
                 tracker.Focus("BGM Tracks", bgmFiles.Length);
-                for (int i = 0; i < bgmFiles.Length; i++)
+                Items.AddRange(bgmFiles.AsParallel().Select((bgm, i) =>
                 {
-                    Items.Add(new BackgroundMusicItem(bgmFiles[i], i, this));
                     tracker.Finished++;
-                }
+                    return new BackgroundMusicItem(bgm, i, this);
+                }));
             }
             catch (Exception ex)
             {
@@ -459,13 +462,13 @@ namespace SerialLoops.Lib
             }
             try
             {
-                string[] voiceFiles = SoundDS.VoiceSection.Where(vce => vce is not null).Select(vce => Path.Combine(IterativeDirectory, "rom", "data", vce)).ToArray(); /*Directory.GetFiles(Path.Combine(IterativeDirectory, "rom", "data", "vce")).OrderBy(s => s).ToArray();*/
+                string[] voiceFiles = SoundDS.VoiceSection.AsParallel().Where(vce => vce is not null).Select(vce => Path.Combine(IterativeDirectory, "rom", "data", vce)).ToArray(); /*Directory.GetFiles(Path.Combine(IterativeDirectory, "rom", "data", "vce")).OrderBy(s => s).ToArray();*/
                 tracker.Focus("Voiced Lines", voiceFiles.Length);
-                for (int i = 0; i < voiceFiles.Length; i++)
+                Items.AddRange(voiceFiles.AsParallel().Select((vce, i) =>
                 {
-                    Items.Add(new VoicedLineItem(voiceFiles[i], i + 1, this));
                     tracker.Finished++;
-                }
+                    return new VoicedLineItem(vce, i + 1, this);
+                }));
             }
             catch (Exception ex)
             {
@@ -497,9 +500,13 @@ namespace SerialLoops.Lib
 
             try
             {
-                ItemFile itemFile = Dat.Files.First(f => f.Name == "ITEMS").CastTo<ItemFile>();
-                tracker.Focus("Items", 1);
-                Items.AddRange(itemFile.Items.Where(i => i > 0).Select((i, idx) => new ItemItem(Grp.Files[i - 1].Name, idx, i, this)));
+                ItemFile itemFile = Dat.GetFileByName("ITEMS").CastTo<ItemFile>();
+                tracker.Focus("Items", itemFile.Items.Count);
+                Items.AddRange(itemFile.Items.AsParallel().Where(i => i > 0).Select((i, idx) =>
+                {
+                    tracker.Finished++;
+                    return new ItemItem(Grp.GetFileByIndex(i).Name, idx, i, this);
+                }));
             }
             catch (Exception ex)
             {
@@ -509,10 +516,13 @@ namespace SerialLoops.Lib
 
             try
             {
-                tracker.Focus("Character Sprites", 1);
-                CharacterDataFile chrdata = Dat.Files.First(d => d.Name == "CHRDATAS").CastTo<CharacterDataFile>();
-                Items.AddRange(chrdata.Sprites.Where(s => (int)s.Character > 0).Select(s => new CharacterSpriteItem(s, chrdata, this)));
-                tracker.Finished++;
+                CharacterDataFile chrdata = Dat.GetFileByName("CHRDATAS").CastTo<CharacterDataFile>();
+                tracker.Focus("Character Sprites", chrdata.Sprites.Count);
+                Items.AddRange(chrdata.Sprites.AsParallel().Where(s => (int)s.Character > 0).Select(s =>
+                {
+                    tracker.Finished++;
+                    return new CharacterSpriteItem(s, chrdata, this);
+                }));
             }
             catch (Exception ex)
             {
@@ -522,13 +532,13 @@ namespace SerialLoops.Lib
 
             try
             {
-                ChibiFile chibiFile = Dat.Files.First(d => d.Name == "CHIBIS").CastTo<ChibiFile>();
+                ChibiFile chibiFile = Dat.GetFileByName("CHIBIS").CastTo<ChibiFile>();
                 tracker.Focus("Chibis", chibiFile.Chibis.Count);
-                foreach (Chibi chibi in chibiFile.Chibis)
+                Items.AddRange(chibiFile.Chibis.AsParallel().Select(c =>
                 {
-                    Items.Add(new ChibiItem(chibi, this));
                     tracker.Finished++;
-                }
+                    return new ChibiItem(c, this);
+                }));
             }
             catch (Exception ex)
             {
@@ -538,10 +548,12 @@ namespace SerialLoops.Lib
 
             try
             {
-                tracker.Focus("Characters", 1);
-                Items.AddRange(Dat.Files.First(d => d.Name == "MESSINFOS").CastTo<MessageInfoFile>()
-                    .MessageInfos.Where(m => (int)m.Character > 0).Select(m => new CharacterItem(m, Characters[(int)m.Character], this)));
-                tracker.Finished++;
+                tracker.Focus("Characters", MessInfo.MessageInfos.Count);
+                Items.AddRange(MessInfo.MessageInfos.AsParallel().Where(m => (int)m.Character > 0).Select(m =>
+                {
+                    tracker.Finished++;
+                    return new CharacterItem(m, Characters[(int)m.Character], this);
+                }));
             }
             catch (Exception ex)
             {
@@ -551,11 +563,14 @@ namespace SerialLoops.Lib
 
             try
             {
-                tracker.Focus("Scripts", 1);
-                Items.AddRange(Evt.Files
+                tracker.Focus("Scripts", Evt.Files.Count - 5);
+                Items.AddRange(Evt.Files.AsParallel()
                     .Where(e => !new string[] { "CHESSS", "EVTTBLS", "TOPICS", "SCENARIOS", "TUTORIALS", "VOICEMAPS" }.Contains(e.Name))
-                    .Select(e => new ScriptItem(e, Localize, log)));
-                tracker.Finished++;
+                    .Select(e =>
+                    {
+                        tracker.Finished++;
+                        return new ScriptItem(e, Localize, log);
+                    }));
             }
             catch (Exception ex)
             {
@@ -563,10 +578,9 @@ namespace SerialLoops.Lib
                 return new(LoadProjectState.FAILED);
             }
 
-
             try
             {
-                TutorialFile = Evt.Files.First(t => t.Name == "TUTORIALS");
+                TutorialFile = Evt.GetFileByName("TUTORIALS");
                 TutorialFile.InitializeTutorialFile();
             }
             catch (Exception ex)
@@ -577,12 +591,15 @@ namespace SerialLoops.Lib
 
             try
             {
-                tracker.Focus("Maps", 1);
-                QMapFile qmap = Dat.Files.First(f => f.Name == "QMAPS").CastTo<QMapFile>();
-                Items.AddRange(Dat.Files
+                QMapFile qmap = Dat.GetFileByName("QMAPS").CastTo<QMapFile>();
+                tracker.Focus("Maps", qmap.QMaps.Count);
+                Items.AddRange(Dat.Files.AsParallel()
                     .Where(d => qmap.QMaps.Select(q => q.Name.Replace(".", "")).Contains(d.Name))
-                    .Select(m => new MapItem(m.CastTo<MapFile>(), qmap.QMaps.FindIndex(q => q.Name.Replace(".", "") == m.Name), this)));
-                tracker.Finished++;
+                    .Select(m =>
+                    {
+                        tracker.Finished++;
+                        return new MapItem(m.CastTo<MapFile>(), qmap.QMaps.FindIndex(q => q.Name.Replace(".", "") == m.Name), this);
+                    }));
             }
             catch (Exception ex)
             {
@@ -592,13 +609,13 @@ namespace SerialLoops.Lib
 
             try
             {
-                PlaceFile placeFile = Dat.Files.First(f => f.Name == "PLACES").CastTo<PlaceFile>();
+                PlaceFile placeFile = Dat.GetFileByName("PLACES").CastTo<PlaceFile>();
                 tracker.Focus("Places", placeFile.PlaceGraphicIndices.Count);
-                for (int i = 0; i < placeFile.PlaceGraphicIndices.Count; i++)
+                Items.AddRange(placeFile.PlaceGraphicIndices.Select((pidx, i) =>
                 {
-                    GraphicsFile placeGrp = Grp.Files.First(g => g.Index == placeFile.PlaceGraphicIndices[i]);
-                    Items.Add(new PlaceItem(i, placeGrp, this));
-                }
+                    tracker.Finished++;
+                    return new PlaceItem(i, Grp.GetFileByIndex(pidx));
+                }));
                 tracker.Finished++;
             }
             catch (Exception ex)
@@ -609,11 +626,13 @@ namespace SerialLoops.Lib
 
             try
             {
-                tracker.Focus("Puzzles", 1);
-                Items.AddRange(Dat.Files
-                    .Where(d => d.Name.StartsWith("SLG"))
-                    .Select(d => new PuzzleItem(d.CastTo<PuzzleFile>(), this, log)));
-                tracker.Finished++;
+                var puzzleDats = Dat.Files.AsParallel().Where(d => d.Name.StartsWith("SLG"));
+                tracker.Focus("Puzzles", puzzleDats.Count());
+                Items.AddRange(puzzleDats.Select(d =>
+                {
+                    tracker.Finished++;
+                    return new PuzzleItem(d.CastTo<PuzzleFile>(), this, log);
+                }));
             }
             catch (Exception ex)
             {
@@ -623,17 +642,17 @@ namespace SerialLoops.Lib
 
             try
             {
-                Evt.Files.First(f => f.Name == "TOPICS").InitializeTopicFile();
-                TopicFile = Evt.Files.First(f => f.Name == "TOPICS");
+                TopicFile = Evt.GetFileByName("TOPICS");
+                TopicFile.InitializeTopicFile();
                 tracker.Focus("Topics", TopicFile.Topics.Count);
                 foreach (Topic topic in TopicFile.Topics)
                 {
                     // Main topics have shadow topics that are located at ID + 40 (this is actually how the game finds them)
                     // So if we're a main topic and we see another topic 40 back, we know we're one of these shadow topics and should really be
                     // rolled into the original main topic
-                    if (topic.Type == TopicType.Main && Items.Any(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == topic.Id - 40))
+                    if (topic.Type == TopicType.Main && Items.AsParallel().Any(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == topic.Id - 40))
                     {
-                        ((TopicItem)Items.First(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == topic.Id - 40)).HiddenMainTopic = topic;
+                        ((TopicItem)Items.AsParallel().First(i => i.Type == ItemDescription.ItemType.Topic && ((TopicItem)i).TopicEntry.Id == topic.Id - 40)).HiddenMainTopic = topic;
                     }
                     else
                     {
@@ -650,40 +669,40 @@ namespace SerialLoops.Lib
 
             try
             {
-                SystemTextureFile systemTextureFile = Dat.Files.First(f => f.Name == "SYSTEXS").CastTo<SystemTextureFile>();
+                SystemTextureFile systemTextureFile = Dat.GetFileByName("SYSTEXS").CastTo<SystemTextureFile>();
                 tracker.Focus("System Textures",
-                    5 + systemTextureFile.SystemTextures.Count(s => Grp.Files.Where(g => g.Name.StartsWith("XTR") || g.Name.StartsWith("SYS") && !g.Name.Contains("_SPC_") && g.Name != "SYS_CMN_B12DNX" && g.Name != "SYS_PPT_001DNX").Select(g => g.Index).Distinct().Contains(s.GrpIndex)));
-                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.Files.First(g => g.Name == "LOGO_CO_SEGDNX").Index), this, "SYSTEX_LOGO_SEGA", height: 192));
+                    5 + systemTextureFile.SystemTextures.Count(s => Grp.Files.AsParallel().Where(g => g.Name.StartsWith("XTR") || g.Name.StartsWith("SYS") && !g.Name.Contains("_SPC_") && g.Name != "SYS_CMN_B12DNX" && g.Name != "SYS_PPT_001DNX").Select(g => g.Index).Distinct().Contains(s.GrpIndex)));
+                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.GetFileByName("LOGO_CO_SEGDNX").Index), this, "SYSTEX_LOGO_SEGA", height: 192));
                 tracker.Finished++;
-                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.Files.First(g => g.Name == "LOGO_CO_AQIDNX").Index), this, "SYSTEX_LOGO_AQI", height: 192));
+                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.GetFileByName("LOGO_CO_AQIDNX").Index), this, "SYSTEX_LOGO_AQI", height: 192));
                 tracker.Finished++;
-                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.Files.First(g => g.Name == "LOGO_MW_ACTDNX").Index), this, "SYSTEX_LOGO_MOBICLIP", height: 192));
+                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.GetFileByName("LOGO_MW_ACTDNX").Index), this, "SYSTEX_LOGO_MOBICLIP", height: 192));
                 tracker.Finished++;
-                string criLogoName = Grp.Files.Any(f => f.Name == "CREDITS") ? "SYSTEX_LOGO_HAROOHIE" : "SYSTEX_LOGO_CRIWARE";
-                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.Files.First(g => g.Name == "LOGO_MW_CRIDNX").Index), this, criLogoName, height: 192));
+                string criLogoName = Grp.Files.AsParallel().Any(f => f.Name == "CREDITS") ? "SYSTEX_LOGO_HAROOHIE" : "SYSTEX_LOGO_CRIWARE";
+                Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.GetFileByName("LOGO_MW_CRIDNX").Index), this, criLogoName, height: 192));
                 tracker.Finished++;
                 if (Grp.Files.Any(f => f.Name == "CREDITS"))
                 {
-                    Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.Files.First(g => g.Name == "CREDITS").Index), this, "SYSTEX_LOGO_CREDITS", height: 192));
+                    Items.Add(new SystemTextureItem(systemTextureFile.SystemTextures.First(s => s.GrpIndex == Grp.GetFileByName("CREDITS").Index), this, "SYSTEX_LOGO_CREDITS", height: 192));
                 }
                 tracker.Finished++;
-                foreach (SystemTexture extraSysTex in systemTextureFile.SystemTextures.Where(s => Grp.Files.Where(g => g.Name.StartsWith("XTR")).Distinct().Select(g => g.Index).Contains(s.GrpIndex)))
+                foreach (SystemTexture extraSysTex in systemTextureFile.SystemTextures.Where(s => Grp.Files.AsParallel().Where(g => g.Name.StartsWith("XTR")).Distinct().Select(g => g.Index).Contains(s.GrpIndex)))
                 {
-                    Items.Add(new SystemTextureItem(extraSysTex, this, $"SYSTEX_{Grp.Files.First(g => g.Index == extraSysTex.GrpIndex).Name[0..^3]}"));
+                    Items.Add(new SystemTextureItem(extraSysTex, this, $"SYSTEX_{Grp.GetFileByIndex(extraSysTex.GrpIndex).Name[0..^3]}"));
                     tracker.Finished++;
                 }
                 // Exclude B12 as that's the nameplates we replace in the character items and PPT_001 as that's the puzzle phase singularity we'll be replacing in the puzzle items
                 // We also exclude the "special" graphics as they do not include all of them in the SYSTEX file (should be made to be edited manually)
-                foreach (SystemTexture sysSysTex in systemTextureFile.SystemTextures.Where(s => Grp.Files.Where(g => g.Name.StartsWith("SYS") && !g.Name.Contains("_SPC_") && g.Name != "SYS_CMN_B12DNX" && g.Name != "SYS_PPT_001DNX").Select(g => g.Index).Contains(s.GrpIndex)).DistinctBy(s => s.GrpIndex))
+                foreach (SystemTexture sysSysTex in systemTextureFile.SystemTextures.Where(s => Grp.Files.AsParallel().Where(g => g.Name.StartsWith("SYS") && !g.Name.Contains("_SPC_") && g.Name != "SYS_CMN_B12DNX" && g.Name != "SYS_PPT_001DNX").Select(g => g.Index).Contains(s.GrpIndex)).DistinctBy(s => s.GrpIndex))
                 {
-                    if (Grp.Files.First(g => g.Index == sysSysTex.GrpIndex).Name[0..^4].EndsWith("T6"))
+                    if (Grp.GetFileByIndex(sysSysTex.GrpIndex).Name[0..^4].EndsWith("T6"))
                     {
                         // special case the ep headers
-                        Items.Add(new SystemTextureItem(sysSysTex, this, $"SYSTEX_{Grp.Files.First(g => g.Index == sysSysTex.GrpIndex).Name[0..^3]}", height: 192));
+                        Items.Add(new SystemTextureItem(sysSysTex, this, $"SYSTEX_{Grp.GetFileByIndex(sysSysTex.GrpIndex).Name[0..^3]}", height: 192));
                     }
                     else
                     {
-                        Items.Add(new SystemTextureItem(sysSysTex, this, $"SYSTEX_{Grp.Files.First(g => g.Index == sysSysTex.GrpIndex).Name[0..^3]}"));
+                        Items.Add(new SystemTextureItem(sysSysTex, this, $"SYSTEX_{Grp.GetFileByIndex(sysSysTex.GrpIndex).Name[0..^3]}"));
                     }
                     tracker.Finished++;
                 }
@@ -699,7 +718,7 @@ namespace SerialLoops.Lib
             {
                 // Scenario item must be created after script and puzzle items are constructed
                 tracker.Focus("Scenario", 1);
-                scenarioFile = Evt.Files.First(f => f.Name == "SCENARIOS");
+                scenarioFile = Evt.GetFileByName("SCENARIOS");
                 scenarioFile.InitializeScenarioFile();
                 Items.Add(new ScenarioItem(scenarioFile.Scenario, this, log));
                 tracker.Finished++;
@@ -713,11 +732,11 @@ namespace SerialLoops.Lib
             try
             {
                 tracker.Focus("Group Selections", scenarioFile.Scenario.Selects.Count);
-                for (int i = 0; i < scenarioFile.Scenario.Selects.Count; i++)
+                Items.AddRange(scenarioFile.Scenario.Selects.Select((s, i) =>
                 {
-                    Items.Add(new GroupSelectionItem(scenarioFile.Scenario.Selects[i], i, this));
                     tracker.Finished++;
-                }
+                    return new GroupSelectionItem(s, i, this);
+                }));
             }
             catch (Exception ex)
             {
@@ -765,7 +784,7 @@ namespace SerialLoops.Lib
 
         public bool VoiceMapIsV06OrHigher()
         {
-            return Evt.Files.Any(f => f.Name == "VOICEMAPS") && Encoding.ASCII.GetString(Evt.Files.First(f => f.Name == "VOICEMAPS").Data.Skip(0x08).Take(4).ToArray()) == "SUBS";
+            return Evt.Files.AsParallel().Any(f => f.Name == "VOICEMAPS") && Encoding.ASCII.GetString(Evt.GetFileByName("VOICEMAPS").Data.Skip(0x08).Take(4).ToArray()) == "SUBS";
         }
 
         public void MigrateProject(string newRom, ILogger log, IProgressTracker tracker)

--- a/src/SerialLoops.Lib/Script/Parameters/ChibiScriptParameter.cs
+++ b/src/SerialLoops.Lib/Script/Parameters/ChibiScriptParameter.cs
@@ -6,7 +6,7 @@ namespace SerialLoops.Lib.Script.Parameters
     public class ChibiScriptParameter : ScriptParameter
     {
         public ChibiItem Chibi { get; set; }
-        public override short[] GetValues(object obj = null) => new short[] { (short)Chibi.ChibiIndex };
+        public override short[] GetValues(object obj = null) => new short[] { (short)Chibi.TopScreenIndex };
 
         public ChibiScriptParameter(string name, ChibiItem chibi) : base(name, ParameterType.CHIBI)
         {

--- a/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
@@ -533,7 +533,7 @@ namespace SerialLoops.Lib.Script
                         switch (i)
                         {
                             case 0:
-                                parameters.Add(new ChibiScriptParameter(localize("Chibi"), (ChibiItem)project.Items.First(i => i.Type == ItemDescription.ItemType.Chibi && (parameter) == ((ChibiItem)i).ChibiIndex)));
+                                parameters.Add(new ChibiScriptParameter(localize("Chibi"), (ChibiItem)project.Items.First(i => i.Type == ItemDescription.ItemType.Chibi && (parameter) == ((ChibiItem)i).TopScreenIndex)));
                                 break;
                             case 1:
                                 parameters.Add(new ChibiEmoteScriptParameter(localize("Emote"), parameter));
@@ -561,7 +561,7 @@ namespace SerialLoops.Lib.Script
                         switch (i)
                         {
                             case 0:
-                                parameters.Add(new ChibiScriptParameter(localize("Chibi"), (ChibiItem)project.Items.First(i => i.Type == ItemDescription.ItemType.Chibi && (parameter) == ((ChibiItem)i).ChibiIndex)));
+                                parameters.Add(new ChibiScriptParameter(localize("Chibi"), (ChibiItem)project.Items.First(i => i.Type == ItemDescription.ItemType.Chibi && (parameter) == ((ChibiItem)i).TopScreenIndex)));
                                 break;
                             case 1:
                                 parameters.Add(new ChibiEnterExitScriptParameter(localize("Enter/Exit"), parameter));

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0.1" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.36.7" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.37.0" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.4.6" />
+    <PackageReference Include="NitroPacker.Core" Version="2.4.7" />
     <PackageReference Include="NLayer" Version="1.15.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />

--- a/src/SerialLoops/Controls/ItemExplorerPanel.cs
+++ b/src/SerialLoops/Controls/ItemExplorerPanel.cs
@@ -39,7 +39,6 @@ namespace SerialLoops.Controls
             if (Viewer.SelectedItem is not null)
             {
                 ((TreeGridView)Viewer.Control).ContextMenu = Viewer.SelectedItem.Text.GetContextMenu(_project, this, _tabs, _log);
-                
             }
         }
 

--- a/src/SerialLoops/Dialogs/SaveSlotEditorDialog.cs
+++ b/src/SerialLoops/Dialogs/SaveSlotEditorDialog.cs
@@ -172,7 +172,7 @@ namespace SerialLoops.Dialogs
                         quickSave.EpisodeHeader = _quickSaveScriptPreview.EpisodeHeader;
                         for (int i = 1; i <= 5; i++)
                         {
-                            if (_quickSaveScriptPreview.TopScreenChibis.Any(c => c.Chibi.ChibiIndex == i))
+                            if (_quickSaveScriptPreview.TopScreenChibis.Any(c => c.Chibi.TopScreenIndex == i))
                             {
                                 quickSave.TopScreenChibis |= (CharacterMask)(1 << i);
                             }
@@ -436,7 +436,7 @@ namespace SerialLoops.Dialogs
             {
                 if (quickSave.TopScreenChibis.HasFlag((CharacterMask)(1 << i)))
                 {
-                    ChibiItem chibi = (ChibiItem)_project.Items.First(it => it.Type == ItemDescription.ItemType.Chibi && ((ChibiItem)it).ChibiIndex == i);
+                    ChibiItem chibi = (ChibiItem)_project.Items.First(it => it.Type == ItemDescription.ItemType.Chibi && ((ChibiItem)it).TopScreenIndex == i);
                     topScreenChibis.Add((chibi, chibiCurrentX, chibiY));
                     chibiCurrentX += chibi.ChibiAnimations.First().Value.ElementAt(0).Frame.Width - 16;
                 }

--- a/src/SerialLoops/Editors/PuzzleEditor.cs
+++ b/src/SerialLoops/Editors/PuzzleEditor.cs
@@ -30,7 +30,7 @@ namespace SerialLoops.Editors
             };
 
             MapItem map = (MapItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Map && i.Name ==
-                _project.Dat.Files.First(f => f.Name == "QMAPS").CastTo<QMapFile>().QMaps[_puzzle.Puzzle.Settings.MapId].Name[0..^2]);
+                _project.Dat.GetFileByName("QMAPS").CastTo<QMapFile>().QMaps[_puzzle.Puzzle.Settings.MapId].Name[0..^2]);
 
             GroupBox topicsBox = new() { Text = Application.Instance.Localize(this, "Associated Main Topics"), Padding = 5 };
             StackLayout topics = new() { Orientation = Orientation.Vertical, Spacing = 5 };

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -220,7 +220,7 @@ namespace SerialLoops.Editors
 
                                 case CommandVerb.CHIBI_ENTEREXIT:
                                 case CommandVerb.CHIBI_EMOTE:
-                                    invocation.Parameters[0] = (short)((ChibiItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Chibi)).ChibiIndex;
+                                    invocation.Parameters[0] = (short)((ChibiItem)_project.Items.First(i => i.Type == ItemDescription.ItemType.Chibi)).TopScreenIndex;
                                     break;
 
                                 case CommandVerb.DIALOGUE:
@@ -436,7 +436,7 @@ namespace SerialLoops.Editors
         {
             List<ChibiItem> allChibis = _project.Items.Where(i => i.Type == ItemDescription.ItemType.Chibi && ((ChibiItem)i).ChibiAnimations.Any(c => c.Key.Contains("_01_"))).Cast<ChibiItem>().ToList();
             List<ChibiItem> usedChibis = allChibis.Where(c => _script.Event.StartingChibisSection.Objects
-                .Select(sc => sc.ChibiIndex).ToList().Contains((short)c.ChibiIndex)).Cast<ChibiItem>().ToList();
+                .Select(sc => sc.ChibiIndex).ToList().Contains((short)c.TopScreenIndex)).Cast<ChibiItem>().ToList();
             ListBox availableChibisBox = new();
             ListBox usedChibisBox = new();
             availableChibisBox.Items.AddRange(allChibis.Where(i => !usedChibis.Contains(i)).Select(c => new ListItem { Key = c.DisplayName, Text = c.DisplayName }));
@@ -451,7 +451,7 @@ namespace SerialLoops.Editors
                 IListItem chibiSelected = (IListItem)availableChibisBox.SelectedValue;
                 availableChibisBox.Items.Remove(chibiSelected);
                 usedChibisBox.Items.Add(chibiSelected);
-                _script.Event.StartingChibisSection.Objects.Insert(_script.Event.StartingChibisSection.Objects.Count - 1, new() { ChibiIndex = (short)allChibis.First(c => c.DisplayName == chibiSelected.Text).ChibiIndex });
+                _script.Event.StartingChibisSection.Objects.Insert(_script.Event.StartingChibisSection.Objects.Count - 1, new() { ChibiIndex = (short)allChibis.First(c => c.DisplayName == chibiSelected.Text).TopScreenIndex });
                 UpdateTabTitle(false);
                 Application.Instance.Invoke(() => UpdatePreview());
             };
@@ -464,9 +464,9 @@ namespace SerialLoops.Editors
                 IListItem chibiSelected = (IListItem)usedChibisBox.SelectedValue;
                 usedChibisBox.Items.Remove(chibiSelected);
                 availableChibisBox.Items.Add(chibiSelected);
-                availableChibisBox.Items.Sort((a, b) => allChibis.First(c => c.DisplayName == a.Key).ChibiIndex - allChibis.First(c => c.DisplayName == b.Key).ChibiIndex);
+                availableChibisBox.Items.Sort((a, b) => allChibis.First(c => c.DisplayName == a.Key).TopScreenIndex - allChibis.First(c => c.DisplayName == b.Key).TopScreenIndex);
                 _script.Event.StartingChibisSection.Objects.Remove(_script.Event.StartingChibisSection.Objects
-                    .First(c => c.ChibiIndex == (short)allChibis.First(c => c.DisplayName == chibiSelected.Text).ChibiIndex));
+                    .First(c => c.ChibiIndex == (short)allChibis.First(c => c.DisplayName == chibiSelected.Text).TopScreenIndex));
                 UpdateTabTitle(false);
                 Application.Instance.Invoke(() => UpdatePreview());
             };
@@ -1656,7 +1656,7 @@ namespace SerialLoops.Editors
                 (ChibiItem)_project.Items.First(i => i.Name == dropDown.SelectedKey);
             _script.Event.ScriptSections[_script.Event.ScriptSections.IndexOf(dropDown.Command.Section)]
                 .Objects[dropDown.Command.Index].Parameters[dropDown.ParameterIndex] =
-                (short)((ChibiItem)_project.Items.First(i => i.Name == dropDown.SelectedKey)).ChibiIndex;
+                (short)((ChibiItem)_project.Items.First(i => i.Name == dropDown.SelectedKey)).TopScreenIndex;
             UpdateTabTitle(false, dropDown);
             Application.Instance.Invoke(() => UpdatePreview());
         }

--- a/src/SerialLoops/Editors/ScriptEditor.cs
+++ b/src/SerialLoops/Editors/ScriptEditor.cs
@@ -165,7 +165,7 @@ namespace SerialLoops.Editors
                         verbSelecter.Focus();
                     };
 
-                    MessageInfoFile messInfos = _project.Dat.Files.First(d => d.Name == "MESSINFOS").CastTo<MessageInfoFile>();
+                    MessageInfoFile messInfos = _project.Dat.GetFileByName("MESSINFOS").CastTo<MessageInfoFile>();
                     cancelButton.Click += (sender, args) =>
                     {
                         dialog.Close();

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -714,7 +714,7 @@ namespace SerialLoops
                         ScenarioStruct scenario = ((ScenarioItem)item).Scenario;
                         IO.WriteStringFile(
                             Path.Combine("assets", "events",
-                                $"{OpenProject.Evt.Files.First(f => f.Name == "SCENARIOS").Index:X3}.s"),
+                                $"{OpenProject.Evt.GetFileByName("SCENARIOS").Index:X3}.s"),
                             // TODO: Refactor this logic into the chokuretsu library so that we don't end up with ugliness like this for all of our includes
                             scenario.GetSource(new()
                             {


### PR DESCRIPTION
Closes #310 in both letter and spirit.

Introduces two new `ArchiveFile` methods from a lib change:
* `GetFileByIndex` &ndash; gets a file with direct indexing which is a huge perf bump from before
* `GetFileByName` &ndash; gets a file with by name with a PLINQ query which is faster than just doing it regularly

I made sure to replace the old file lookups we had with these two. Things should load quicker in general now.

In addition, in an effort to improve project load times, I removed the `ScriptUses` property from all items that have it and stopped calculating script usages at load/save time. Instead, we now calculate them as part of reference lookup. It turns out that this is preferable as load times are now blazing fast and you can't really tell that reference lookups have slowed down at all except for the orphaned files dialog which still isn't that slow (and is a lower priority than opening a project anyway).