### PR TITLE
Adjust SFX references, add nameplate export

### DIFF
--- a/src/SerialLoops/Dialogs/ItemReferenceDialogs.cs
+++ b/src/SerialLoops/Dialogs/ItemReferenceDialogs.cs
@@ -67,7 +67,8 @@ namespace SerialLoops.Dialogs
             MinimumSize = new Size(400, 275);
             Padding = 10;
 
-            List<ItemDescription> results = Project.Items.FindAll(i => !IGNORED_ORPHAN_TYPES.Contains(i.Type) && i.GetReferencesTo(Project).Count == 0);
+            List<ItemDescription> results = Project.Items.FindAll(i => !IGNORED_ORPHAN_TYPES.Contains(i.Type) && i.GetReferencesTo(Project).Count == 0
+            && !(i.Type == ItemDescription.ItemType.SFX && ((SfxItem)i).Name.Contains("SSE") && ((SfxItem)i).AssociatedGroups.Count > 0)); // assume SFX that are in groups are referenced in code
             Content = new StackLayout
             {
                 Orientation = Orientation.Vertical,

--- a/src/SerialLoops/Editors/CharacterEditor.cs
+++ b/src/SerialLoops/Editors/CharacterEditor.cs
@@ -1,4 +1,5 @@
 ﻿using Eto.Forms;
+using HaruhiChokuretsuLib.Archive.Graphics;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Controls;
 using SerialLoops.Lib;
@@ -35,11 +36,25 @@ namespace SerialLoops.Editors
             using SKCanvas baseCanvas = new(nameplatePreview);
             baseCanvas.DrawBitmap(_project.NameplateBitmap, new SKRect(0, 16 * ((int)_character.MessageInfo.Character - 1), 64, 16 * ((int)_character.MessageInfo.Character)), new SKRect(0, 0, 64, 16));
             baseCanvas.Flush();
+            Button exportNameplatePreviewButton = new() { Text = "Export" };
+            exportNameplatePreviewButton.Click += (sender, args) =>
+            {
+                SaveFileDialog saveFileDialog = new();
+                saveFileDialog.Filters.Add(new() { Name = Application.Instance.Localize(this, "PNG image"), Extensions = [".png"] });
+                if (saveFileDialog.ShowAndReportIfFileSelected(this))
+                {
+                    using FileStream fs = new(saveFileDialog.FileName, FileMode.Create);
+                    nameplatePreview.Encode(fs, SKEncodedImageFormat.Png, GraphicsFile.PNG_QUALITY);
+                }
+            };
             StackLayout nameplatePreviewLayout = new()
             {
+                Orientation = Orientation.Horizontal,
+                Spacing = 5,
                 Items =
                 {
                     new SKGuiImage(nameplatePreview),
+                    exportNameplatePreviewButton,
                 },
             };
 


### PR DESCRIPTION
* Adds a quick fix to the SFX references by removing SSEs that have a sound group from the orphaned items dialog (as they are [most likely] referenced in code)
* Adds an "export" button for the nameplates in the character editor