### PR TITLE
Add project import/export

### DIFF
--- a/src/SerialLoops.Lib/IO.cs
+++ b/src/SerialLoops.Lib/IO.cs
@@ -180,8 +180,17 @@ namespace SerialLoops.Lib
             }
         }
 
-        public static void CopyFiles(string sourceDirectory, string destinationDirectory, ILogger log, string filter = "*")
+        public static void CopyFiles(string sourceDirectory, string destinationDirectory, ILogger log, string filter = "*", bool recursive = false)
         {
+            if (recursive)
+            {
+                foreach (string dir in Directory.GetDirectories(sourceDirectory))
+                {
+                    string newDir = Path.Combine(destinationDirectory, Path.GetFileName(dir));
+                    Directory.CreateDirectory(newDir);
+                    CopyFiles(dir, newDir, log, filter, recursive);
+                }
+            }
             foreach (string file in Directory.GetFiles(sourceDirectory, filter))
             {
                 try

--- a/src/SerialLoops/Controls/HomePanel.cs
+++ b/src/SerialLoops/Controls/HomePanel.cs
@@ -41,6 +41,9 @@ namespace SerialLoops.Controls
 
             LinkButton openProjectLink = new() { Text = Application.Instance.Localize(this, "Open Project") };
             openProjectLink.Click += _mainForm.OpenProject_Executed;
+
+            LinkButton importProjectlink = new() { Text = Application.Instance.Localize(this, "Import Project") };
+            importProjectlink.Click += _mainForm.ImportProjectCommand_Executed;
             
             LinkButton editSaveLink = new() { Text = Application.Instance.Localize(this, "Edit Save File") };
             editSaveLink.Click += _mainForm.EditSaveFileCommand_Executed;
@@ -61,6 +64,7 @@ namespace SerialLoops.Controls
                     ControlGenerator.GetTextHeader(Application.Instance.Localize(this, "Start")),
                     ControlGenerator.GetControlWithIcon(newProjectLink, "New", _log),
                     ControlGenerator.GetControlWithIcon(openProjectLink, "Open", _log),
+                    importProjectlink,
                     ControlGenerator.GetControlWithIcon(editSaveLink, "Edit_Save", _log),
                     ControlGenerator.GetControlWithIcon(preferencesLink, "Options", _log),
                     ControlGenerator.GetControlWithIcon(aboutLink, "Help", _log),

--- a/src/SerialLoops/Dialogs/ProjectCreationDialog.eto.cs
+++ b/src/SerialLoops/Dialogs/ProjectCreationDialog.eto.cs
@@ -22,7 +22,7 @@ namespace SerialLoops
         private DropDown _languageDropDown;
         private Label _romPath;
 
-        private const string NO_ROM_TEXT = "None Selected";
+        public const string NO_ROM_TEXT = "None Selected";
         private static readonly Regex ALLOWED_CHARACTERS_REGEX = new(@"[A-z\d-_\.]");
 
         void InitializeComponent()
@@ -172,6 +172,7 @@ namespace SerialLoops
             {
                 NewProject = new(_nameBox.Text, _languageDropDown.Items[_languageDropDown.SelectedIndex].Key, Config, s => Application.Instance.Localize(null, s), Log);
                 string romPath = _romPath.Text;
+                NewProject.SetBaseRomHash(romPath);
                 LoopyProgressTracker tracker = new(s => Application.Instance.Localize(null, s));
                 ProgressDialog _ = new(() => 
                 {

--- a/src/SerialLoops/Dialogs/ProjectImportDialog.cs
+++ b/src/SerialLoops/Dialogs/ProjectImportDialog.cs
@@ -1,0 +1,136 @@
+﻿using Eto.Forms;
+using SerialLoops.Lib;
+using SerialLoops.Utility;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace SerialLoops.Dialogs
+{
+    public class ProjectImportDialog : Dialog<(string Slzip, string Rom)>
+    {
+        private string _romHash;
+        private string _slzipPath = string.Empty;
+        private string _romPath = string.Empty;
+
+        public ProjectImportDialog()
+        {
+            _romHash = Application.Instance.Localize(this, "Select an exported project to see expected ROM hash");
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            Label expectedRomHash = new() { Text = string.Format(Application.Instance.Localize(this, "Expected ROM CRC32 Hash: {0}"), _romHash) };
+            Label baseRomPath = new() { Text = Application.Instance.Localize(this, ProjectCreationDialog.NO_ROM_TEXT) };
+            Label slzipPath = new() { Text = Application.Instance.Localize(this, "No exported project selected") };
+            CheckBox overrideHashCheckBox = new() { Text = "Ignore Hash?", Enabled = false, Checked = false };
+
+            Button slzipButton = new() { Text = Application.Instance.Localize(this, "Open Exported Project") };
+            slzipButton.Click += (sender, args) =>
+            {
+                OpenFileDialog openFileDialog = new();
+                openFileDialog.Filters.Add(new(Application.Instance.Localize(this, "Serial Loops Exported Project"), $".{Project.EXPORT_FORMAT}"));
+                if (openFileDialog.ShowAndReportIfFileSelected(this))
+                {
+                    _slzipPath = openFileDialog.FileName;
+                    slzipPath.Text = _slzipPath;
+                    using FileStream slzipFs = File.OpenRead(_slzipPath);
+                    using ZipArchive slzip = new(slzipFs);
+                    _romHash = slzip.Comment;
+                    expectedRomHash.Text = string.Format(Application.Instance.Localize(this, "Expected ROM SHA-1 Hash: {0}"), $"{_romHash:X8}");
+                }
+            };
+
+            Button baseRomButton = new() { Text = Application.Instance.Localize(this, "Open ROM") };
+            baseRomButton.Click += (sender, args) =>
+            {
+                OpenFileDialog openFileDialog = new();
+                openFileDialog.Filters.Add(new(Application.Instance.Localize(this, "Chokuretsu ROM"), ".nds"));
+                if (openFileDialog.ShowAndReportIfFileSelected(this))
+                {
+                    byte[] romBytes = File.ReadAllBytes(openFileDialog.FileName);
+                    string expectedHash = string.Join("", SHA1.HashData(romBytes).Select(b => $"{b:X2}"));
+                    if (!_romHash.Equals(expectedHash))
+                    {
+                        MessageBox.Show(this,
+                            Application.Instance.Localize(this, "The selected ROM's hash does not match the expected ROM hash. Please ensure you are using the correct base ROM.\n\nIf you wish to ignore this, please check the \"Ignore Hash\" checkbox."),
+                            Application.Instance.Localize(this, "ROM Hash Mismatch"), MessageBoxType.Warning);
+                        overrideHashCheckBox.Enabled = true;
+                    }
+                    else
+                    {
+                        overrideHashCheckBox.Checked = false;
+                        overrideHashCheckBox.Enabled = false;
+                    }
+                    _romPath = openFileDialog.FileName;
+                    baseRomPath.Text = _romPath;
+                }
+            };
+
+            Button importButton = new() { Text = Application.Instance.Localize(this, "Import") };
+            importButton.Click += (sender, args) =>
+            {
+                if (string.IsNullOrEmpty(_slzipPath) || string.IsNullOrEmpty(_romPath))
+                {
+                    MessageBox.Show(this, Application.Instance.Localize(this, "Both an exported project and a base ROM must be selected to import a project."), Application.Instance.Localize(this, "Error"), MessageBoxType.Error);
+                }
+                else if (overrideHashCheckBox.Enabled && !(overrideHashCheckBox.Checked ?? false))
+                {
+                    MessageBox.Show(this, Application.Instance.Localize(this, "The base ROM hash does not match the expected hash! Please check the \"Ignore Hash\" checkbox if you wish to override this."),
+                        Application.Instance.Localize(this, "Error"), MessageBoxType.Error);
+                }
+                else
+                {
+                    Close((_slzipPath, _romPath));
+                }
+            };
+
+            Button cancelButton = new() { Text = Application.Instance.Localize(this, "Cancel") };
+            cancelButton.Click += (sender, args) => Close();
+
+            Content = new StackLayout()
+            {
+                Spacing = 10,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                Orientation = Orientation.Vertical,
+                Items =
+                {
+                    expectedRomHash,
+                    new StackLayout
+                    {
+                        Spacing = 10,
+                        Orientation = Orientation.Horizontal,
+                        Items =
+                        {
+                            slzipButton,
+                            slzipPath,
+                        }
+                    },
+                    new StackLayout
+                    {
+                        Spacing = 10,
+                        Orientation = Orientation.Horizontal,
+                        Items =
+                        {
+                            baseRomButton,
+                            baseRomPath,
+                        }
+                    },
+                    overrideHashCheckBox,
+                    new StackLayout
+                    {
+                        Spacing = 10,
+                        Orientation = Orientation.Horizontal,
+                        Items =
+                        {
+                            importButton,
+                            cancelButton,
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/SerialLoops/MainForm.eto.cs
+++ b/src/SerialLoops/MainForm.eto.cs
@@ -18,7 +18,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
-using static SkiaSharp.HarfBuzz.SKShaper;
 
 namespace SerialLoops
 {

--- a/src/SerialLoops/Strings.Designer.cs
+++ b/src/SerialLoops/Strings.Designer.cs
@@ -664,6 +664,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Both an exported project and a base ROM must be selected to import a project..
+        /// </summary>
+        public static string Both_an_exported_project_and_a_base_ROM_must_be_selected_to_import_a_project_ {
+            get {
+                return ResourceManager.GetString("Both an exported project and a base ROM must be selected to import a project.", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Both Screens.
         /// </summary>
         public static string Both_Screens {
@@ -2095,6 +2104,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error.
+        /// </summary>
+        public static string Error {
+            get {
+                return ResourceManager.GetString("Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error: duplicate hack detected! A file with the same name as a file in this hack has already been imported..
         /// </summary>
         public static string Error__duplicate_hack_detected__A_file_with_the_same_name_as_a_file_in_this_hack_has_already_been_imported_ {
@@ -2147,6 +2165,15 @@ namespace SerialLoops {
         public static string Exception_occurred_while_parsing_projects_cache_json_ {
             get {
                 return ResourceManager.GetString("Exception occurred while parsing projects_cache.json!", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected ROM SHA-1 Hash: {0}.
+        /// </summary>
+        public static string Expected_ROM_SHA_1_Hash___0_ {
+            get {
+                return ResourceManager.GetString("Expected ROM SHA-1 Hash: {0}", resourceCulture);
             }
         }
         
@@ -3243,6 +3270,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Import.
+        /// </summary>
+        public static string Import {
+            get {
+                return ResourceManager.GetString("Import", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import a Hack.
         /// </summary>
         public static string Import_a_Hack {
@@ -3964,6 +4000,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No exported project selected.
+        /// </summary>
+        public static string No_exported_project_selected {
+            get {
+                return ResourceManager.GetString("No exported project selected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No hacks applied!.
         /// </summary>
         public static string No_hacks_applied_ {
@@ -3996,6 +4041,15 @@ namespace SerialLoops {
         public static string No_recent_projects__Create_one_and_it_will_appear_here_ {
             get {
                 return ResourceManager.GetString("No recent projects. Create one and it will appear here.", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No ROM Hash Recorded!.
+        /// </summary>
+        public static string No_ROM_Hash_Recorded_ {
+            get {
+                return ResourceManager.GetString("No ROM Hash Recorded!", resourceCulture);
             }
         }
         
@@ -4104,6 +4158,15 @@ namespace SerialLoops {
         public static string Open_Chokuretsu_Save_File {
             get {
                 return ResourceManager.GetString("Open Chokuretsu Save File", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Exported Project.
+        /// </summary>
+        public static string Open_Exported_Project {
+            get {
+                return ResourceManager.GetString("Open Exported Project", resourceCulture);
             }
         }
         
@@ -5026,6 +5089,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ROM Hash Mismatch.
+        /// </summary>
+        public static string ROM_Hash_Mismatch {
+            get {
+                return ResourceManager.GetString("ROM Hash Mismatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Route &quot;{0}&quot; Completed.
         /// </summary>
         public static string Route___0___Completed {
@@ -5510,6 +5582,15 @@ namespace SerialLoops {
         public static string Select_a_Topic {
             get {
                 return ResourceManager.GetString("Select a Topic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select an exported project to see expected ROM hash.
+        /// </summary>
+        public static string Select_an_exported_project_to_see_expected_ROM_hash {
+            get {
+                return ResourceManager.GetString("Select an exported project to see expected ROM hash", resourceCulture);
             }
         }
         
@@ -6081,11 +6162,43 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The base ROM hash does not match the expected hash! Please check the \&quot;Ignore Hash\&quot; checkbox if you wish to override this..
+        /// </summary>
+        public static string The_base_ROM_hash_does_not_match_the_expected_hash__Please_check_the___Ignore_Hash___checkbox_if_you_wish_to_override_this_ {
+            get {
+                return ResourceManager.GetString("The base ROM hash does not match the expected hash! Please check the \\\"Ignore Has" +
+                        "h\\\" checkbox if you wish to override this.", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The changes made will require Serial Loops to be restarted. Is that okay?.
         /// </summary>
         public static string The_changes_made_will_require_Serial_Loops_to_be_restarted__Is_that_okay_ {
             get {
                 return ResourceManager.GetString("The changes made will require Serial Loops to be restarted. Is that okay?", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The selected ROM&apos;s hash does not match the expected ROM hash. Please ensure you are using the correct base ROM.\n\nIf you wish to ignore this, please check the \&quot;Ignore Hash\&quot; checkbox..
+        /// </summary>
+        public static string The_selected_ROM_s_hash_does_not_match_the_expected_ROM_hash__Please_ensure_you_are_using_the_correct_base_ROM__n_nIf_you_wish_to_ignore_this__please_check_the___Ignore_Hash___checkbox_ {
+            get {
+                return ResourceManager.GetString("The selected ROM\'s hash does not match the expected ROM hash. Please ensure you a" +
+                        "re using the correct base ROM.\\n\\nIf you wish to ignore this, please check the \\" +
+                        "\"Ignore Hash\\\" checkbox.", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There is no recorded base ROM hash for this project. This is likely because this project was created with an older version of Serial Loops. Please select the base ROM used for this project so the hash can be recorded now..
+        /// </summary>
+        public static string There_is_no_recorded_base_ROM_hash_for_this_project__This_is_likely_because_this_project_was_created_with_an_older_version_of_Serial_Loops__Please_select_the_base_ROM_used_for_this_project_so_the_hash_can_be_recorded_now_ {
+            get {
+                return ResourceManager.GetString("There is no recorded base ROM hash for this project. This is likely because this " +
+                        "project was created with an older version of Serial Loops. Please select the bas" +
+                        "e ROM used for this project so the hash can be recorded now.", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Strings.Designer.cs
+++ b/src/SerialLoops/Strings.Designer.cs
@@ -2196,6 +2196,24 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Export Project.
+        /// </summary>
+        public static string Export_Project {
+            get {
+                return ResourceManager.GetString("Export Project", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export Project....
+        /// </summary>
+        public static string Export_Project___ {
+            get {
+                return ResourceManager.GetString("Export Project...", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Export SFX.
         /// </summary>
         public static string Export_SFX {
@@ -2214,6 +2232,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exported Project.
+        /// </summary>
+        public static string Exported_Project {
+            get {
+                return ResourceManager.GetString("Exported Project", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Exporting BGM.
         /// </summary>
         public static string Exporting_BGM {
@@ -2228,6 +2255,15 @@ namespace SerialLoops {
         public static string Exporting_GIF___ {
             get {
                 return ResourceManager.GetString("Exporting GIF...", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exporting Project.
+        /// </summary>
+        public static string Exporting_Project {
+            get {
+                return ResourceManager.GetString("Exporting Project", resourceCulture);
             }
         }
         
@@ -2531,6 +2567,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to export project.
+        /// </summary>
+        public static string Failed_to_export_project {
+            get {
+                return ResourceManager.GetString("Failed to export project", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to export system texture {0} to file {1}.
         /// </summary>
         public static string Failed_to_export_system_texture__0__to_file__1_ {
@@ -2546,6 +2591,15 @@ namespace SerialLoops {
             get {
                 return ResourceManager.GetString("Failed to find character item -- have you saved all of your changes to character " +
                         "names?", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to import project.
+        /// </summary>
+        public static string Failed_to_import_project {
+            get {
+                return ResourceManager.GetString("Failed to import project", resourceCulture);
             }
         }
         
@@ -3203,6 +3257,33 @@ namespace SerialLoops {
         public static string Import_Hack {
             get {
                 return ResourceManager.GetString("Import Hack", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Import Project.
+        /// </summary>
+        public static string Import_Project {
+            get {
+                return ResourceManager.GetString("Import Project", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Import Project....
+        /// </summary>
+        public static string Import_Project___ {
+            get {
+                return ResourceManager.GetString("Import Project...", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Importing Project.
+        /// </summary>
+        public static string Importing_Project {
+            get {
+                return ResourceManager.GetString("Importing Project", resourceCulture);
             }
         }
         
@@ -4450,6 +4531,15 @@ namespace SerialLoops {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Project exported successfully!.
+        /// </summary>
+        public static string Project_exported_successfully_ {
+            get {
+                return ResourceManager.GetString("Project exported successfully!", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project not provided to project creation dialog.
         /// </summary>
         public static string Project_not_provided_to_project_creation_dialog {
@@ -5501,6 +5591,15 @@ namespace SerialLoops {
         public static string Select_Template_to_Apply {
             get {
                 return ResourceManager.GetString("Select Template to Apply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Serial Loops Exported Project.
+        /// </summary>
+        public static string Serial_Loops_Exported_Project {
+            get {
+                return ResourceManager.GetString("Serial Loops Exported Project", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Strings.resx
+++ b/src/SerialLoops/Strings.resx
@@ -309,6 +309,9 @@
     <value>Both</value>
     <comment>Checkbox for "Both Screens"</comment>
   </data>
+  <data name="Both an exported project and a base ROM must be selected to import a project." xml:space="preserve">
+    <value>Both an exported project and a base ROM must be selected to import a project.</value>
+  </data>
   <data name="Both Screens" xml:space="preserve">
     <value>Both Screens</value>
   </data>
@@ -788,6 +791,9 @@
   <data name="Erase data options title" xml:space="preserve">
     <value>Erase data options title</value>
   </data>
+  <data name="Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
   <data name="Error getting script command tree for script {0} ({1})" xml:space="preserve">
     <value>Error getting script command tree for script {0} ({1})</value>
     <comment>{0} is the script display name, {1} is the script's underlying name</comment>
@@ -806,6 +812,10 @@
   </data>
   <data name="Exception occurred while parsing projects_cache.json!" xml:space="preserve">
     <value>Exception occurred while parsing projects_cache.json!</value>
+  </data>
+  <data name="Expected ROM SHA-1 Hash: {0}" xml:space="preserve">
+    <value>Expected ROM SHA-1 Hash: {0}</value>
+    <comment>{0} is the SHA-1 hash of the ROM that is expected when importing a project</comment>
   </data>
   <data name="Export" xml:space="preserve">
     <value>Export</value>
@@ -1178,6 +1188,10 @@
   <data name="Image Files" xml:space="preserve">
     <value>Image Files</value>
   </data>
+  <data name="Import" xml:space="preserve">
+    <value>Import</value>
+    <comment>As in import an exported project</comment>
+  </data>
   <data name="Import a Hack" xml:space="preserve">
     <value>Import a Hack</value>
   </data>
@@ -1423,6 +1437,9 @@
   <data name="No emulator path has been set.\nPlease set the path to a Nintendo DS emulator in Preferences to use Build &amp; Run." xml:space="preserve">
     <value>No emulator path has been set.\nPlease set the path to a Nintendo DS emulator in Preferences to use Build &amp; Run.</value>
   </data>
+  <data name="No exported project selected" xml:space="preserve">
+    <value>No exported project selected</value>
+  </data>
   <data name="No hacks applied!" xml:space="preserve">
     <value>No hacks applied!</value>
   </data>
@@ -1435,6 +1452,9 @@
   <data name="No recent projects. Create one and it will appear here." xml:space="preserve">
     <value>No recent projects. Create one and it will appear here.</value>
   </data>
+  <data name="No ROM Hash Recorded!" xml:space="preserve">
+    <value>No ROM Hash Recorded!</value>
+  </data>
   <data name="No save data ticker tape" xml:space="preserve">
     <value>No save data ticker tape</value>
   </data>
@@ -1446,6 +1466,7 @@
   </data>
   <data name="None Selected" xml:space="preserve">
     <value>None Selected</value>
+    <comment>In the context of "no ROM selected"</comment>
   </data>
   <data name="Number of Saves:" xml:space="preserve">
     <value>Number of Saves: </value>
@@ -1470,6 +1491,10 @@
   </data>
   <data name="Open Chokuretsu Save File" xml:space="preserve">
     <value>Open Chokuretsu Save File</value>
+  </data>
+  <data name="Open Exported Project" xml:space="preserve">
+    <value>Open Exported Project</value>
+    <comment>As in a slzip exported project</comment>
   </data>
   <data name="Open Project" xml:space="preserve">
     <value>Open Project</value>
@@ -1782,6 +1807,10 @@
   <data name="Results" xml:space="preserve">
     <value>Results</value>
   </data>
+  <data name="ROM Hash Mismatch" xml:space="preserve">
+    <value>ROM Hash Mismatch</value>
+    <comment>Message box title when there is a mismatch between the expected ROM hash and the selected ROM hash on project import</comment>
+  </data>
   <data name="Route &quot;{0}&quot; Completed" xml:space="preserve">
     <value>Route "{0}" Completed</value>
     <comment>{0} is the name of a route following a group selection that has been completed</comment>
@@ -1943,6 +1972,9 @@
   </data>
   <data name="Select a Topic" xml:space="preserve">
     <value>Select a Topic</value>
+  </data>
+  <data name="Select an exported project to see expected ROM hash" xml:space="preserve">
+    <value>Select an exported project to see expected ROM hash</value>
   </data>
   <data name="Select base ROM" xml:space="preserve">
     <value>Select base ROM</value>
@@ -2140,8 +2172,17 @@
   <data name="Text Voice Font" xml:space="preserve">
     <value>Text Voice Font</value>
   </data>
+  <data name="The base ROM hash does not match the expected hash! Please check the \&quot;Ignore Hash\&quot; checkbox if you wish to override this." xml:space="preserve">
+    <value>The base ROM hash does not match the expected hash! Please check the \"Ignore Hash\" checkbox if you wish to override this.</value>
+  </data>
   <data name="The changes made will require Serial Loops to be restarted. Is that okay?" xml:space="preserve">
     <value>The changes made will require Serial Loops to be restarted. Is that okay?</value>
+  </data>
+  <data name="The selected ROM's hash does not match the expected ROM hash. Please ensure you are using the correct base ROM.\n\nIf you wish to ignore this, please check the \&quot;Ignore Hash\&quot; checkbox." xml:space="preserve">
+    <value>The selected ROM's hash does not match the expected ROM hash. Please ensure you are using the correct base ROM.\n\nIf you wish to ignore this, please check the \"Ignore Hash\" checkbox.</value>
+  </data>
+  <data name="There is no recorded base ROM hash for this project. This is likely because this project was created with an older version of Serial Loops. Please select the base ROM used for this project so the hash can be recorded now." xml:space="preserve">
+    <value>There is no recorded base ROM hash for this project. This is likely because this project was created with an older version of Serial Loops. Please select the base ROM used for this project so the hash can be recorded now.</value>
   </data>
   <data name="This script is not included in the event table." xml:space="preserve">
     <value>This script is not included in the event table.</value>

--- a/src/SerialLoops/Strings.resx
+++ b/src/SerialLoops/Strings.resx
@@ -822,17 +822,30 @@
   <data name="Export Patch" xml:space="preserve">
     <value>Export Patch</value>
   </data>
+  <data name="Export Project" xml:space="preserve">
+    <value>Export Project</value>
+  </data>
+  <data name="Export Project..." xml:space="preserve">
+    <value>Export Project...</value>
+  </data>
   <data name="Export SFX" xml:space="preserve">
     <value>Export SFX</value>
   </data>
   <data name="Export Sprites" xml:space="preserve">
     <value>Export Sprites</value>
   </data>
+  <data name="Exported Project" xml:space="preserve">
+    <value>Exported Project</value>
+    <comment>Past tense verb as in "project has been exported"</comment>
+  </data>
   <data name="Exporting BGM" xml:space="preserve">
     <value>Exporting BGM</value>
   </data>
   <data name="Exporting GIF..." xml:space="preserve">
     <value>Exporting GIF…</value>
+  </data>
+  <data name="Exporting Project" xml:space="preserve">
+    <value>Exporting Project</value>
   </data>
   <data name="Extract" xml:space="preserve">
     <value>Extract</value>
@@ -933,11 +946,19 @@
   <data name="Failed to export layout for sprite {0} to file" xml:space="preserve">
     <value>Failed to export layout for sprite {0} to file</value>
   </data>
+  <data name="Failed to export project" xml:space="preserve">
+    <value>Failed to export project</value>
+    <comment>Failed to export the Serial Loops project file to an slzip, basically</comment>
+  </data>
   <data name="Failed to export system texture {0} to file {1}" xml:space="preserve">
     <value>Failed to export system texture {0} to file {1}</value>
   </data>
   <data name="Failed to find character item -- have you saved all of your changes to character names?" xml:space="preserve">
     <value>Failed to find character item -- have you saved all of your changes to character names?</value>
+  </data>
+  <data name="Failed to import project" xml:space="preserve">
+    <value>Failed to import project</value>
+    <comment>Failed to import slzip into Serial Loops project</comment>
   </data>
   <data name="Failed to insert ARM9 assembly hacks" xml:space="preserve">
     <value>Failed to insert ARM9 assembly hacks</value>
@@ -1162,6 +1183,15 @@
   </data>
   <data name="Import Hack" xml:space="preserve">
     <value>Import Hack</value>
+  </data>
+  <data name="Import Project" xml:space="preserve">
+    <value>Import Project</value>
+  </data>
+  <data name="Import Project..." xml:space="preserve">
+    <value>Import Project...</value>
+  </data>
+  <data name="Importing Project" xml:space="preserve">
+    <value>Importing Project</value>
   </data>
   <data name="Include lip flap animation?" xml:space="preserve">
     <value>Include lip flap animation?</value>
@@ -1586,6 +1616,9 @@
   <data name="Project Creation Warning" xml:space="preserve">
     <value>Project Creation Warning</value>
   </data>
+  <data name="Project exported successfully!" xml:space="preserve">
+    <value>Project exported successfully!</value>
+  </data>
   <data name="Project not provided to project creation dialog" xml:space="preserve">
     <value>Project not provided to project creation dialog</value>
   </data>
@@ -1940,6 +1973,10 @@
   </data>
   <data name="Select..." xml:space="preserve">
     <value>Select…</value>
+  </data>
+  <data name="Serial Loops Exported Project" xml:space="preserve">
+    <value>Serial Loops Exported Project</value>
+    <comment>Refers to the "slzip" archive that is the exported project format</comment>
   </data>
   <data name="Serial Loops Project" xml:space="preserve">
     <value>Serial Loops Project</value>


### PR DESCRIPTION
Closes #248.

This adds a project import/export button. They still need icons @WiIIiam278. Dead simple process, but totally works -- we just create a zip archive of the proj file + font charset + portions of the base directory. On import, we unpack a base ROM (which we check for integrity with a filehash), unzip the slzip, copy to the iterative directory, then do a build before loading the project.

Additionally, this removes the `MainDirectory` entry from the slproj format. We now construct that from config + project name. Should be reliable enough and makes the proj format portable. 