### PR TITLE
Fixup the crop/resize canvas scaling bug

### DIFF
--- a/src/SerialLoops/Controls/SKCropResizeCanvas.cs
+++ b/src/SerialLoops/Controls/SKCropResizeCanvas.cs
@@ -11,14 +11,6 @@ namespace SerialLoops.Controls
 {
     public class SKCropResizeCanvas : SKCanvasView
     {
-        // This should be looked into more. There is some unexpected behavior with drawing an SKSurface on Win/Mac -- requires multiplying the
-        // width/height of the draw destination by 1.5. This is not required on Linux, which is weird!
-#if WINDOWS || MACOS
-        private const float SURFACE_SIZE_MULTIPLIER = 1.5f;
-#else
-        private const float SURFACE_SIZE_MULTIPLIER = 1.0f;
-#endif
-
         private const int KEY_CHANGE_AMOUNT = 10;
         private double _aspectRatio;
         private Point? _lastPointerPosition;
@@ -117,6 +109,7 @@ namespace SerialLoops.Controls
 
         protected virtual void OnPaintSurface(SKSurface surface)
         {
+            Scale = 1;
             SKCanvas canvas = surface.Canvas;
             canvas.Clear();
             if (SourceBitmap is not null && ImageLocation is not null && SourceWidth is not null && SourceHeight is not null)
@@ -147,8 +140,8 @@ namespace SerialLoops.Controls
                     SKRect surfaceRect = new(
                         SelectionAreaLocation?.X ?? 0f,
                         SelectionAreaLocation?.Y ?? 0f,
-                        (SelectionAreaLocation?.X ?? 0f) + (FinalBitmap?.Width ?? 0f) * SURFACE_SIZE_MULTIPLIER,
-                        (SelectionAreaLocation?.Y ?? 0f) + (FinalBitmap?.Height ?? 0f) * SURFACE_SIZE_MULTIPLIER);
+                        (SelectionAreaLocation?.X ?? 0f) + (FinalBitmap?.Width ?? 0f),
+                        (SelectionAreaLocation?.Y ?? 0f) + (FinalBitmap?.Height ?? 0f));
                     finalCanvas.DrawImage(surface.Snapshot(), surfaceRect, new SKRect(0, 0, FinalBitmap.Width, FinalBitmap.Height));
                     finalCanvas.Flush();
                 }


### PR DESCRIPTION
I finally found the issue! Weirdly, for some reason, the scale parameter was getting set to 1.5. Resetting it to 1 every time we paint fixes the issue.