### PR TITLE
Add emulator flatpak support for Linux

### DIFF
--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -36,6 +36,7 @@ namespace SerialLoops.Lib
         public string DevkitArmPath { get; set; }
         public bool UseDocker { get; set; }
         public string DevkitArmDockerTag { get; set; }
+        public string EmulatorFlatpak { get; set; }
         public string EmulatorPath { get; set; }
         public bool AutoReopenLastProject { get; set; }
         public bool RememberProjectWorkspace { get; set; }
@@ -75,7 +76,7 @@ namespace SerialLoops.Lib
             }
 
             Hacks = JsonSerializer.Deserialize<ObservableCollection<AsmHack>>(File.ReadAllText(Path.Combine(HacksDirectory, "hacks.json")));
-            
+
             // Pull in new hacks in case we've updated the program with more
             List<AsmHack> builtinHacks = JsonSerializer.Deserialize<List<AsmHack>>(File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "hacks.json")));
             IEnumerable<AsmHack> missingHacks = builtinHacks.Where(h => !Hacks.Contains(h));

--- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -74,18 +75,25 @@ namespace SerialLoops.Lib.Factories
 
             // TODO: Probably make a way of defining "presets" of common emulator install paths on different platforms.
             // Ideally this should be as painless as possible.
-            string emulatorPath = "";
+            bool emulatorExists = false;
+            string emulatorPath = string.Empty;
+            string emulatorFlatpak = string.Empty;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 emulatorPath = Path.Combine("/Applications", "melonDS.app");
+                emulatorExists = Directory.Exists(emulatorPath);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                emulatorPath = Path.Combine("/snap", "melonds", "current", "usr", "local", "bin", "melonDS");
+                emulatorFlatpak = "net.kuribo64.melonDS";
+                Process flatpakProc = Process.Start((new ProcessStartInfo("flatpak", ["info", emulatorFlatpak])));
+                flatpakProc?.WaitForExit();
+                emulatorExists = flatpakProc?.ExitCode == 0;
             }
-            if (!Directory.Exists(emulatorPath) && !File.Exists(emulatorPath)) // on Mac, .app is a dir, so we check both of these
+            if (!emulatorExists) // on Mac, .app is a dir, so we check both of these
             {
-                emulatorPath = "";
+                emulatorPath = string.Empty;
+                emulatorFlatpak = string.Empty;
                 log.LogWarning("Valid emulator path not found in config.json.");
             }
 
@@ -95,6 +103,7 @@ namespace SerialLoops.Lib.Factories
                 CurrentCultureName = CultureInfo.CurrentCulture.Name,
                 DevkitArmPath = devkitArmDir,
                 EmulatorPath = emulatorPath,
+                EmulatorFlatpak = emulatorFlatpak,
                 UseDocker = false,
                 DevkitArmDockerTag = "latest",
                 AutoReopenLastProject = false,

--- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
@@ -86,9 +86,16 @@ namespace SerialLoops.Lib.Factories
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 emulatorFlatpak = "net.kuribo64.melonDS";
-                Process flatpakProc = Process.Start((new ProcessStartInfo("flatpak", ["info", emulatorFlatpak])));
-                flatpakProc?.WaitForExit();
-                emulatorExists = flatpakProc?.ExitCode == 0;
+                try
+                {
+                    Process flatpakProc = Process.Start((new ProcessStartInfo("flatpak", ["info", emulatorFlatpak])));
+                    flatpakProc?.WaitForExit();
+                    emulatorExists = flatpakProc?.ExitCode == 0;
+                }
+                catch
+                {
+                    emulatorExists = false;
+                }
             }
             if (!emulatorExists) // on Mac, .app is a dir, so we check both of these
             {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -1968,6 +1968,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Emulator Flatpak.
+        /// </summary>
+        public static string Emulator_Flatpak {
+            get {
+                return ResourceManager.GetString("Emulator Flatpak", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Emulator Path.
         /// </summary>
         public static string Emulator_Path {
@@ -4274,8 +4283,8 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No emulator path has been set.
-        ///Please set the path to a Nintendo DS emulator in Preferences to use Build &amp; Run..
+        ///   Looks up a localized string similar to No emulator path/flatpak has been set.
+        ///Please set the path to a Nintendo DS emulator or specify a Nintendo DS emulator flatpak in Preferences to use Build &amp; Run..
         /// </summary>
         public static string No_emulator_path_has_been_set__nPlease_set_the_path_to_a_Nintendo_DS_emulator_in_Preferences_to_use_Build___Run_ {
             get {

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -1525,8 +1525,8 @@ In order to preserve state, no hacks were applied.</value>
     <value>No Emulator Path</value>
   </data>
   <data name="No emulator path has been set.\nPlease set the path to a Nintendo DS emulator in Preferences to use Build &amp; Run." xml:space="preserve">
-    <value>No emulator path has been set.
-Please set the path to a Nintendo DS emulator in Preferences to use Build &amp; Run.</value>
+    <value>No emulator path/flatpak has been set.
+Please set the path to a Nintendo DS emulator or specify a Nintendo DS emulator flatpak in Preferences to use Build &amp; Run.</value>
   </data>
   <data name="No exported project selected" xml:space="preserve">
     <value>No exported project selected</value>
@@ -2635,4 +2635,13 @@ No project is currently open. Would you like to create a new project?</value>
   <data name="Failed to replace screen image: image too complex (generated more than 255 tiles); please use a simpler image" xml:space="preserve">
     <value>Failed to replace screen image: image too complex (generated more than 255 tiles); please use a simpler image</value>
   </data>
+<<<<<<< Updated upstream
+=======
+  <data name="Load Sound" xml:space="preserve">
+    <value>Load Sound</value><comment>The name of a parameter for the SND_PLAY command which indicates whether a sound should be loaded or not</comment>
+  </data>
+  <data name="Emulator Flatpak" xml:space="preserve">
+    <value>Emulator Flatpak</value>
+  </data>
+>>>>>>> Stashed changes
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2635,13 +2635,7 @@ No project is currently open. Would you like to create a new project?</value>
   <data name="Failed to replace screen image: image too complex (generated more than 255 tiles); please use a simpler image" xml:space="preserve">
     <value>Failed to replace screen image: image too complex (generated more than 255 tiles); please use a simpler image</value>
   </data>
-<<<<<<< Updated upstream
-=======
-  <data name="Load Sound" xml:space="preserve">
-    <value>Load Sound</value><comment>The name of a parameter for the SND_PLAY command which indicates whether a sound should be loaded or not</comment>
-  </data>
   <data name="Emulator Flatpak" xml:space="preserve">
     <value>Emulator Flatpak</value>
   </data>
->>>>>>> Stashed changes
 </root>

--- a/src/SerialLoops/ViewModels/Dialogs/PreferencesDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/PreferencesDialogViewModel.cs
@@ -61,6 +61,12 @@ namespace SerialLoops.ViewModels.Dialogs
                         Path = Configuration.EmulatorPath,
                         OnChange = (path) => Configuration.EmulatorPath = path,
                     },
+                    new TextOption
+                    {
+                        OptionName = Strings.Emulator_Flatpak,
+                        Value = Configuration.EmulatorFlatpak,
+                        OnChange = (flatpak) => Configuration.EmulatorFlatpak = flatpak,
+                    },
                     new BooleanOption
                     {
                         OptionName = Strings.Use_Docker_for_ASM_Hacks,

--- a/src/SerialLoops/ViewModels/Dialogs/PreferencesDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/PreferencesDialogViewModel.cs
@@ -66,6 +66,7 @@ namespace SerialLoops.ViewModels.Dialogs
                         OptionName = Strings.Emulator_Flatpak,
                         Value = Configuration.EmulatorFlatpak,
                         OnChange = (flatpak) => Configuration.EmulatorFlatpak = flatpak,
+                        Enabled = !OperatingSystem.IsLinux(),
                     },
                     new BooleanOption
                     {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -655,9 +655,9 @@ namespace SerialLoops.ViewModels
         {
             if (OpenProject is not null)
             {
-                if (string.IsNullOrWhiteSpace(CurrentConfig.EmulatorPath))
+                if (string.IsNullOrWhiteSpace(CurrentConfig.EmulatorPath) && string.IsNullOrWhiteSpace(CurrentConfig.EmulatorFlatpak))
                 {
-                    Log.LogWarning("Attempted to build and run project while no emulator path was set.");
+                    Log.LogWarning("Attempted to build and run project while no emulator path/flatpak was set.");
                     await Window.ShowMessageBoxAsync(Strings.No_Emulator_Path, Strings.No_emulator_path_has_been_set__nPlease_set_the_path_to_a_Nintendo_DS_emulator_in_Preferences_to_use_Build___Run_,
                         ButtonEnum.Ok, Icon.Warning, Log);
                     await PreferencesCommand_Executed();
@@ -674,13 +674,26 @@ namespace SerialLoops.ViewModels
                             {
                                 // If the EmulatorPath is an .app bundle, we need to run the executable inside it
                                 string emulatorExecutable = CurrentConfig.EmulatorPath;
+                                if (!string.IsNullOrWhiteSpace(CurrentConfig.EmulatorFlatpak))
+                                {
+                                    emulatorExecutable = "flatpak";
+                                }
                                 if (emulatorExecutable.EndsWith(".app"))
                                 {
                                     emulatorExecutable = Path.Combine(CurrentConfig.EmulatorPath, "Contents", "MacOS",
                                         Path.GetFileNameWithoutExtension(CurrentConfig.EmulatorPath));
                                 }
 
-                                Process.Start(emulatorExecutable, $"\"{Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")}\"");
+                                string[] emulatorArgs = [Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")];
+                                if (emulatorExecutable.Equals("flatpak"))
+                                {
+                                    emulatorArgs =
+                                    [
+                                        "run", CurrentConfig.EmulatorFlatpak,
+                                        Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")
+                                    ];
+                                }
+                                Process.Start(emulatorExecutable, emulatorArgs);
                             }
                             catch (Exception ex)
                             {

--- a/test/SerialLoops.Tests.Headless/ProjectRequiredTests.cs
+++ b/test/SerialLoops.Tests.Headless/ProjectRequiredTests.cs
@@ -33,7 +33,7 @@ namespace SerialLoops.Tests.Headless
     {
         // To run these tests locally, you can create a file called 'ui_vals.json' and place it next to the test assembly (in the output folder)
         private UiVals? _uiVals;
-        private List<string> _dirsToDelete = [];
+        private readonly List<string> _dirsToDelete = [];
 
         [OneTimeSetUp]
         public void Setup()


### PR DESCRIPTION
This adds emulator flatpak support for Linux, making it so we can run a flatpak-installed emulator directly from the app. Since flatpak installation is an officially maintained route on Linux (Arisotura herself is the author of the melonDS flatpak), this seems like the way to go. There is also a snap package, but that is not officially maintained, so I think this support makes more sense. You can still download the tar and run the executable directly through the `EmulatorPath` property, ofc.