### PR TITLE
Use Application Data directory to store config.json rather than the app path

### DIFF
--- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
@@ -26,6 +26,10 @@ namespace SerialLoops.Lib.Factories
                 defaultConfig.ConfigPath = configJson;
                 defaultConfig.InitializeHacks(log);
                 defaultConfig.InitializeScriptTemplates(localize, log);
+                if (!Directory.Exists(Path.GetDirectoryName(configJson)))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(configJson)!);
+                }
                 IO.WriteStringFile(configJson, JsonSerializer.Serialize(defaultConfig), log);
                 return defaultConfig;
             }

--- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
@@ -17,7 +17,7 @@ namespace SerialLoops.Lib.Factories
     {
         public Config LoadConfig(Func<string, string> localize, ILogger log)
         {
-            string configJson = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "config.json");
+            string configJson = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SerialLoops", "config.json");
 
             if (!File.Exists(configJson))
             {


### PR DESCRIPTION
Closes #238.

We discussed using special folders (AppData makes most sense) to store various files. Really the only file we "store" (as in don't ship with the app itself) is the config.json, so this moves that to AppData. Tested on Linux.