### PR TITLE
Bind item names and commands to their TreeItem classes to cause them to update automatically

### DIFF
--- a/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
@@ -6,6 +6,8 @@ using HaruhiChokuretsuLib.Util;
 using QuikGraph;
 using QuikGraph.Algorithms.Observers;
 using QuikGraph.Algorithms.Search;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Script.Parameters;
 using SerialLoops.Lib.Util;
@@ -13,7 +15,7 @@ using static HaruhiChokuretsuLib.Archive.Event.EventFile;
 
 namespace SerialLoops.Lib.Script
 {
-    public class ScriptItemCommand
+    public class ScriptItemCommand : ReactiveObject
     {
         public ScriptCommandInvocation Invocation { get; set; }
         public CommandVerb Verb { get; set; }
@@ -25,7 +27,7 @@ namespace SerialLoops.Lib.Script
 
         public static ScriptItemCommand FromInvocation(ScriptCommandInvocation invocation, ScriptSection section, int index, EventFile eventFile, Project project, Func<string, string> localize, ILogger log)
         {
-            return new()
+            ScriptItemCommand command = new()
             {
                 Invocation = invocation,
                 Verb = (CommandVerb)Enum.Parse(typeof(CommandVerb), invocation.Command.Mnemonic),
@@ -35,6 +37,8 @@ namespace SerialLoops.Lib.Script
                 Script = eventFile,
                 Project = project,
             };
+            command.UpdateDisplay();
+            return command;
         }
 
         public ScriptItemCommand()
@@ -60,11 +64,13 @@ namespace SerialLoops.Lib.Script
             }).ToList();
             shortParams.AddRange(new short[16 - shortParams.Count]);
             Invocation = new(CommandsAvailable.First(c => c.Mnemonic == verb.ToString())) { Parameters = shortParams };
+            UpdateDisplay();
         }
         public ScriptItemCommand(CommandVerb verb, params ScriptParameter[] parameters)
         {
             Verb = verb;
             Parameters = [.. parameters];
+            UpdateDisplay();
         }
 
         public List<ScriptItemCommand> WalkCommandGraph(Dictionary<ScriptSection, List<ScriptItemCommand>> commandTree, AdjacencyGraph<ScriptSection, ScriptSectionEdge> graph)
@@ -696,20 +702,31 @@ namespace SerialLoops.Lib.Script
             return parameters;
         }
 
+        [Reactive]
+        public string Display { get; set; }
+
+        public void UpdateDisplay()
+        {
+            Display = ToString();
+        }
+
         public override string ToString()
         {
             string str = $"{Verb}";
-            if (Verb == CommandVerb.DIALOGUE)
+            switch (Verb)
             {
-                str += $" {((DialogueScriptParameter)Parameters[0]).Line.Text.GetSubstitutedString(Project)[0..Math.Min(((DialogueScriptParameter)Parameters[0]).Line.Text.Length, 10)]}...";
-            }
-            else if (Verb == CommandVerb.GOTO)
-            {
-                str += $" {((ScriptSectionScriptParameter)Parameters[0]).Section.Name}";
-            }
-            else if (Verb == CommandVerb.VGOTO)
-            {
-                str += $" {((ConditionalScriptParameter)Parameters[0]).Conditional}, {((ScriptSectionScriptParameter)Parameters[1]).Section.Name}";
+                case CommandVerb.DIALOGUE:
+                    str += $" {((DialogueScriptParameter)Parameters[0]).Line.Text.GetSubstitutedString(Project)[0..Math.Min(((DialogueScriptParameter)Parameters[0]).Line.Text.Length, 10)]}...";
+                    break;
+                case CommandVerb.GOTO:
+                    str += $" {((ScriptSectionScriptParameter)Parameters[0]).Section.Name}";
+                    break;
+                case CommandVerb.VGOTO:
+                    str += $" {((ConditionalScriptParameter)Parameters[0]).Conditional}, {((ScriptSectionScriptParameter)Parameters[1]).Section.Name}";
+                    break;
+                case CommandVerb.WAIT:
+                    str += $" {((ShortScriptParameter)Parameters[0]).Value}";
+                    break;
             }
             return str;
         }

--- a/src/SerialLoops/Models/ITreeItem.cs
+++ b/src/SerialLoops/Models/ITreeItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Reactive.Subjects;
 using Avalonia.Controls;
 
 namespace SerialLoops.Models

--- a/src/SerialLoops/Models/ItemDescriptionTreeItem.cs
+++ b/src/SerialLoops/Models/ItemDescriptionTreeItem.cs
@@ -1,27 +1,46 @@
 ﻿using System.Collections.ObjectModel;
+using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Layout;
+using ReactiveUI;
 using SerialLoops.Lib.Items;
 
 namespace SerialLoops.Models
 {
-    public class ItemDescriptionTreeItem(ItemDescription description) : ITreeItem
+    public class ItemDescriptionTreeItem : ITreeItem, IViewFor<ItemDescription>
     {
-        public string Text { get; set; } = description.DisplayName;
+        private TextBlock _textBlock = new();
+        StackPanel _panel = new()
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 3,
+            Margin = new(2),
+        };
+
+        public string Text { get; set; }
         public Avalonia.Svg.Svg Icon { get; set; } = null;
         public ObservableCollection<ITreeItem> Children { get; set; } = null;
         public bool IsExpanded { get; set; } = false;
 
+        public ItemDescriptionTreeItem(ItemDescription item)
+        {
+            ViewModel = item;
+            this.OneWayBind(ViewModel, vm => vm.DisplayName, v => v._textBlock.Text);
+            this.Bind(ViewModel, vm => vm.DisplayName, v => v.Text);
+            _panel.Children.Add(_textBlock);
+        }
+
         public Control GetDisplay()
         {
-            StackPanel panel = new()
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing = 3,
-                Margin = new(2),
-            };
-            panel.Children.Add(new TextBlock { Text = Text });
-            return panel;
+            return _panel;
         }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ItemDescription)value;
+        }
+
+        public ItemDescription ViewModel { get; set; }
     }
 }

--- a/src/SerialLoops/Models/ItemDescriptionTreeItem.cs
+++ b/src/SerialLoops/Models/ItemDescriptionTreeItem.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using ReactiveUI;

--- a/src/SerialLoops/Models/ScriptCommandTreeItem.cs
+++ b/src/SerialLoops/Models/ScriptCommandTreeItem.cs
@@ -1,41 +1,45 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using Avalonia.Controls;
 using Avalonia.Layout;
+using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using SerialLoops.Lib.Script;
 
 namespace SerialLoops.Models
 {
-    public class ScriptCommandTreeItem(ScriptItemCommand command) : ITreeItem
+    public class ScriptCommandTreeItem : ITreeItem, IViewFor<ScriptItemCommand>
     {
-        private ScriptItemCommand _command = command;
-        public ScriptItemCommand Command
+        private TextBlock _textBlock = new();
+        StackPanel _panel = new()
         {
-            get => _command;
-            set
-            {
-                _command = value;
-                Text = _command.ToString();
-            }
-        }
+            Orientation = Orientation.Horizontal,
+            Spacing = 3,
+            Margin = new(2),
+        };
 
-        [Reactive]
-        public string Text { get; set; } = command.ToString();
+        public string Text { get; set; }
         public Avalonia.Svg.Svg Icon { get; set; } = null;
         public ObservableCollection<ITreeItem> Children { get; set; } = null;
         public bool IsExpanded { get; set; } = false;
 
+        public ScriptCommandTreeItem(ScriptItemCommand command)
+        {
+            ViewModel = command;
+            this.OneWayBind(ViewModel, vm => vm.Display, v => v._textBlock.Text);
+            _panel.Children.Add(_textBlock);
+        }
+
         public Control GetDisplay()
         {
-            StackPanel panel = new()
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing = 3,
-                Margin = new(2),
-            };
-            panel.Children.Add(new TextBlock { Text = Text });
-            return panel;
+            return _panel;
         }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ScriptItemCommand)value;
+        }
+
+        public ScriptItemCommand ViewModel { get; set; }
     }
 }

--- a/src/SerialLoops/Models/ScriptSectionTreeItem.cs
+++ b/src/SerialLoops/Models/ScriptSectionTreeItem.cs
@@ -4,38 +4,46 @@ using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using HaruhiChokuretsuLib.Archive.Event;
+using ReactiveUI;
 using SerialLoops.Lib.Script;
 
 namespace SerialLoops.Models
 {
-    public class ScriptSectionTreeItem(ScriptSection section, List<ScriptItemCommand> commands) : ITreeItem
+    public class ScriptSectionTreeItem : ITreeItem, IViewFor<ScriptSection>
     {
-        private ScriptSection _section = section;
-        public ScriptSection Section
+        private TextBlock _textBlock = new();
+        StackPanel _panel = new()
         {
-            get => _section;
-            set
-            {
-                _section = value;
-                Text = _section.Name;
-            }
-        }
+            Orientation = Orientation.Horizontal,
+            Spacing = 3,
+            Margin = new(2),
+        };
 
-        public string Text { get; set; } = section.Name;
+        public string Text { get; set; }
         public Avalonia.Svg.Svg Icon { get; set; } = null;
-        public ObservableCollection<ITreeItem> Children { get; set; } = new([.. commands.Select(c => new ScriptCommandTreeItem(c))]);
+        public ObservableCollection<ITreeItem> Children { get; set; }
         public bool IsExpanded { get; set; } = true;
+
+        public ScriptSectionTreeItem(ScriptSection section, List<ScriptItemCommand> commands)
+        {
+            ViewModel = section;
+            Children = new([.. commands.Select(c => new ScriptCommandTreeItem(c))]);
+            this.OneWayBind(ViewModel, vm => vm.Name, v => v._textBlock.Text);
+            this.Bind(ViewModel, vm => vm.Name, v => v.Text);
+            _panel.Children.Add(_textBlock);
+        }
 
         public Control GetDisplay()
         {
-            StackPanel panel = new()
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing = 3,
-                Margin = new(2),
-            };
-            panel.Children.Add(new TextBlock { Text = Text });
-            return panel;
+            return _panel;
         }
+
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ScriptSection)value;
+        }
+
+        public ScriptSection ViewModel { get; set; }
     }
 }

--- a/src/SerialLoops/Models/SectionTreeItem.cs
+++ b/src/SerialLoops/Models/SectionTreeItem.cs
@@ -21,11 +21,14 @@ namespace SerialLoops.Models
             {
                 Orientation = Orientation.Horizontal,
                 Spacing = 3,
-                Margin = new(2),
             };
             if (Icon is not null)
             {
-                panel.Children.Add(Icon); // We don't add a control if there's no icon (unlike bitmaps)
+                if (Icon.Parent is not null)
+                {
+                    ((StackPanel)Icon.Parent).Children.Clear();
+                }
+                panel.Children.Add(Icon);
             }
             panel.Children.Add(new TextBlock { Text = Text });
             return panel;

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/DialogueScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/DialogueScriptCommandEditorViewModel.cs
@@ -106,6 +106,7 @@ namespace SerialLoops.ViewModels.Editors.ScriptCommandEditors
 
                 ScriptEditor.UpdatePreview();
                 Script.UnsavedChanges = true;
+                Command.UpdateDisplay();
             }
         }
 

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/WaitScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/WaitScriptCommandEditorViewModel.cs
@@ -17,6 +17,7 @@ namespace SerialLoops.ViewModels.Editors.ScriptCommandEditors
                 Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
                     .Objects[Command.Index].Parameters[0] = _waitTime;
                 Script.UnsavedChanges = true;
+                Command.UpdateDisplay();
             }
         }
     }

--- a/src/SerialLoops/ViewModels/Editors/ScriptEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptEditorViewModel.cs
@@ -64,7 +64,7 @@ namespace SerialLoops.ViewModels.Editors
                         new HierarchicalExpanderColumn<ITreeItem>(
                             new TemplateColumn<ITreeItem>(null, new FuncDataTemplate<ITreeItem>((val, namescope) =>
                             {
-                                return GetItemPanel(val);
+                                return val?.GetDisplay();
                             }), options: new TemplateColumnOptions<ITreeItem>() { IsTextSearchEnabled = true }),
                             i => i.Children
                         )
@@ -94,29 +94,6 @@ namespace SerialLoops.ViewModels.Editors
                 _script.Refresh(_project, _log);
             }
             Commands = _script.GetScriptCommandTree(_project, _log);
-        }
-
-        private StackPanel GetItemPanel(ITreeItem val)
-        {
-            if (val is null)
-            {
-                return null;
-            }
-            StackPanel panel = new()
-            {
-                Orientation = Avalonia.Layout.Orientation.Horizontal,
-                Spacing = 3,
-            };
-            if (val.Icon is not null)
-            {
-                if (val.Icon.Parent is not null)
-                {
-                    ((StackPanel)val.Icon.Parent).Children.Clear();
-                }
-                panel.Children.Add(val.Icon);
-            }
-            panel.Children.Add(new TextBlock { Text = val.Text });
-            return panel;
         }
 
         private void UpdateCommandViewModel()

--- a/src/SerialLoops/ViewModels/Panels/ItemExplorerPanelViewModel.cs
+++ b/src/SerialLoops/ViewModels/Panels/ItemExplorerPanelViewModel.cs
@@ -36,11 +36,11 @@ namespace SerialLoops.ViewModels.Panels
                         new HierarchicalExpanderColumn<ITreeItem>(
                             new TemplateColumn<ITreeItem>(null, new FuncDataTemplate<ITreeItem>((val, namescope) =>
                             {
-                                return GetItemPanel(val);
+                                return val?.GetDisplay();
                             }), cellEditingTemplate: new FuncDataTemplate<ITreeItem>((val, namescope) =>
                             {
                                 // Eventually we can maybe do rename logic here
-                                return GetItemPanel(val);
+                                return val?.GetDisplay();
                             }), options: new() { BeginEditGestures = BeginEditGestures.F2 }),
                             i => i.Children
                         )
@@ -56,29 +56,6 @@ namespace SerialLoops.ViewModels.Panels
                     Source.CollapseAll();
                 }
             }
-        }
-
-        private StackPanel GetItemPanel(ITreeItem val)
-        {
-            if (val is null)
-            {
-                return null;
-            }
-            StackPanel panel = new()
-            {
-                Orientation = Avalonia.Layout.Orientation.Horizontal,
-                Spacing = 3,
-            };
-            if (val.Icon is not null)
-            {
-                if (val.Icon.Parent is not null)
-                {
-                    ((StackPanel)val.Icon.Parent).Children.Clear();
-                }
-                panel.Children.Add(val.Icon);
-            }
-            panel.Children.Add(new TextBlock { Text = val.Text });
-            return panel;
         }
 
         [Reactive]


### PR DESCRIPTION
Just a nice little feature to auto-update the display name of items in the tree view as well as the command previews in their tree view. Did it by binding the models directly to the `TreeItem`s, treating them as views and the models as view models. Works perfectly, it seems.