### PR TITLE
Improve group selection editor

### DIFF
--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -558,7 +558,7 @@ public class ScriptItem : Item
                     try
                     {
                         character = (CharacterItem)project.Items.First(i =>
-                            i.Type == ItemDescription.ItemType.Character &&
+                            i.Type == ItemType.Character &&
                             i.DisplayName ==
                             $"CHR_{project.Characters[(int)((DialogueScriptParameter)command.Parameters[0]).Line.Speaker].Name}");
                     }
@@ -1011,7 +1011,7 @@ public class ScriptItem : Item
                 SKColor dialogueBoxColor = project.DialogueBitmap.GetPixel(0, 28);
                 canvas.DrawRect(0, verticalOffset + 164, 256, 28, new() { Color = dialogueBoxColor });
                 canvas.DrawBitmap(project.DialogueBitmap, new(0, 37, 32, 64),
-                    new SKRect(224, 356, verticalOffset + 64, verticalOffset + 192));
+                    new SKRect(224, verticalOffset + 165, 256, verticalOffset + 192));
                 canvas.DrawBitmap(project.SpeakerBitmap,
                     new(0, 16 * ((int)line.Speaker - 1), 64, 16 * ((int)line.Speaker)),
                     new SKRect(0, verticalOffset + 140, 64, verticalOffset + 156));
@@ -1048,30 +1048,6 @@ public class ScriptItem : Item
             flyoutCanvas.Flush();
 
             canvas.DrawBitmap(topicFlyout, 256 - topicFlyout.Width, verticalOffset + 128);
-        }
-
-        // Draw select choices
-        if (preview.CurrentChocies?.Count > 0)
-        {
-            List<SKBitmap> choiceGraphics = [];
-            foreach (string choice in preview.CurrentChocies)
-            {
-                SKBitmap choiceGraphic = new(218, 18);
-                SKCanvas choiceCanvas = new(choiceGraphic);
-                choiceCanvas.DrawRect(1, 1, 216, 16, new() { Color = new(146, 146, 146) });
-                choiceCanvas.DrawRect(2, 2, 214, 14, new() { Color = new(69, 69, 69) });
-                int choiceWidth = project.LangCode.Equals("ja") ? choice.Length * 14 : choice.Sum(c => project.FontReplacement.ReverseLookup(c).Offset);
-                choiceCanvas.DrawHaroohieText(choice, DialogueScriptParameter.Paint00, project, (218 - choiceWidth) / 2, 2);
-                choiceCanvas.Flush();
-                choiceGraphics.Add(choiceGraphic);
-            }
-
-            int graphicY = (192 - (choiceGraphics.Count * 18 + (choiceGraphics.Count - 1) * 8)) / 2 + 184;
-            foreach (SKBitmap choiceGraphic in choiceGraphics)
-            {
-                canvas.DrawBitmap(choiceGraphic, 19, graphicY);
-                graphicY += 26;
-            }
         }
 
         // Draw select choices

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -850,10 +850,12 @@ public partial class Project
         try
         {
             LayoutFiles.Clear();
-            LayoutFiles.Add(0xC45, Grp.GetFileByIndex(0xC45));
-
             tracker.Focus("Layouts", 22);
-            List <GraphicsFile> graphics = [
+
+            // Puzzle phase layouts
+            LayoutFiles.Add(0xC45, Grp.GetFileByIndex(0xC45));
+            List <GraphicsFile> puzzlePhaseGraphics =
+            [
                 Grp.GetFileByIndex(0xC48),
                 Grp.GetFileByIndex(0xC4A),
                 Grp.GetFileByIndex(0xC4C),
@@ -877,47 +879,47 @@ public partial class Project
                 Grp.GetFileByIndex(0xC67),
             ];
 
-            Items.Add(new LayoutItem(0xC45, graphics, 54, 13, "LYT_ACCIDENT_OUTBREAK", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 54, 13, "LYT_ACCIDENT_OUTBREAK", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 67, 5, "LYT_MAIN_TOPIC_DELAYED", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 67, 5, "LYT_MAIN_TOPIC_DELAYED", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 72, 12, "LYT_DELAY_CHANCE", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 72, 12, "LYT_DELAY_CHANCE", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 84, 2, "LYT_TOPIC_CHOOSE", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 84, 2, "LYT_TOPIC_CHOOSE", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 122, 8, "LYT_READY", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 122, 8, "LYT_READY", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 130, 3, "LYT_GO", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 130, 3, "LYT_GO", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 134, 4, "LYT_TIME_RESULT", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 134, 4, "LYT_TIME_RESULT", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 138, 2, "LYT_ACCIDENT_RESULT", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 138, 2, "LYT_ACCIDENT_RESULT", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 140, 2, "LYT_POWER_UP_RESULT", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 140, 2, "LYT_POWER_UP_RESULT", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 142, 2, "LYT_BASE_TIME_LIMIT", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 142, 2, "LYT_BASE_TIME_LIMIT", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 148, 2, "LYT_HRH_DISTRACTION_BONUS", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 148, 2, "LYT_HRH_DISTRACTION_BONUS", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 154, 5, "LYT_TOTAL_SCORE", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 154, 5, "LYT_TOTAL_SCORE", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 163, 3, "LYT_MAIN_TOPICS_OBTAINED", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 163, 3, "LYT_MAIN_TOPICS_OBTAINED", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 163, 3, "LYT_ACCIDENT_BUTTON", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 163, 3, "LYT_ACCIDENT_BUTTON", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 175, 2, "LYT_MAIN_TOPIC", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 175, 2, "LYT_MAIN_TOPIC", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 177, 1, "LYT_COUNTER", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 177, 1, "LYT_COUNTER", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 199, 27, "LYT_CHARACTER_TOPICS_OBTAINED", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 199, 27, "LYT_CHARACTER_TOPICS_OBTAINED", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 226, 4, "LYT_TIME_LIMIT", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 226, 4, "LYT_TIME_LIMIT", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 235, 2, "LYT_ACCIDENT_AVOIDED", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 235, 2, "LYT_ACCIDENT_AVOIDED", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 286, 2, "LYT_SEARCH_BUTTON", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 286, 2, "LYT_SEARCH_BUTTON", this));
             tracker.Finished++;
-            Items.Add(new LayoutItem(0xC45, graphics, 307, 1, "LYT_MIN_ERASED_GOAL", this));
+            Items.Add(new LayoutItem(0xC45, puzzlePhaseGraphics, 307, 1, "LYT_MIN_ERASED_GOAL", this));
             tracker.Finished++;
         }
         catch (Exception ex)

--- a/src/SerialLoops/ViewModels/Dialogs/ImageCropResizeDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/ImageCropResizeDialogViewModel.cs
@@ -6,7 +6,6 @@ using Avalonia.Skia.Helpers;
 using HaruhiChokuretsuLib.Util;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
-using SerialLoops.Models;
 using SerialLoops.Views.Dialogs;
 using SkiaSharp;
 

--- a/src/SerialLoops/ViewModels/Editors/GroupSelectionEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/GroupSelectionEditorViewModel.cs
@@ -8,6 +8,7 @@ using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Script.Parameters;
 using SerialLoops.Lib.Util;
 using SerialLoops.ViewModels.Panels;
 using SkiaSharp;
@@ -114,6 +115,17 @@ public class ScenarioActivityViewModel : ViewModelBase
         CanvasWidth = canvasPos.Width;
         CanvasHeight = canvasPos.Height;
         Letter = GetLetter(index);
+
+        TitlePlateSlope = new(16, 16);
+        TitlePlateMain = new(16, 32);
+        _layoutSource.ExtractSubset(TitlePlateSlope, new(32, 48, 48, 64));
+        _layoutSource.ExtractSubset(TitlePlateMain, new(48, 32, 64, 64));
+
+        TitlePlateText = new(68, 16);
+        using SKCanvas titlePlateCanvas = new(TitlePlateText);
+        titlePlateCanvas.DrawHaroohieText(activity.Title, DialogueScriptParameter.Paint00, selection.OpenProject, 0, 0);
+        titlePlateCanvas.Flush();
+        TitlePlateMain.Resize(new SKSizeI(136, 32), SKSamplingOptions.Default);
     }
 
     // Drawing properties
@@ -133,6 +145,11 @@ public class ScenarioActivityViewModel : ViewModelBase
 
     [Reactive]
     public SKBitmap Letter { get; private set; }
+
+    public SKBitmap TitlePlateSlope { get; }
+    public SKBitmap TitlePlateMain { get; }
+    [Reactive]
+    public SKBitmap TitlePlateText { get; set; }
 
     private static Rect GetCanvasPos(int index)
     {

--- a/src/SerialLoops/ViewModels/Editors/GroupSelectionEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/GroupSelectionEditorViewModel.cs
@@ -119,7 +119,7 @@ public class ScenarioActivityViewModel : ViewModelBase
         get => _pastDesc.GetSubstitutedString(_selection.OpenProject);
         set
         {
-            this.RaiseAndSetIfChanged(ref _pastDesc, value.GetSubstitutedString(_selection.OpenProject));
+            this.RaiseAndSetIfChanged(ref _pastDesc, value.GetOriginalString(_selection.OpenProject));
             Activity.PastDesc = _pastDesc;
             SetSelectedDescriptionImage(_pastDesc);
             _selection.GroupSelection.UnsavedChanges = true;

--- a/src/SerialLoops/ViewModels/Editors/GroupSelectionEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/GroupSelectionEditorViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Media;
+using DynamicData;
 using HaruhiChokuretsuLib.Archive.Event;
 using HaruhiChokuretsuLib.Util;
 using ReactiveUI;
@@ -46,6 +47,9 @@ public class GroupSelectionEditorViewModel : EditorViewModel
 
             CharacterPortraits.Add(speaker, characterPortrait);
         }
+        SKBitmap anyPortrait = new(24, 24);
+        characterPortraitImage.ExtractSubset(anyPortrait, new(96, 96, 120, 120));
+        CharacterPortraits.Add(Speaker.INFO, anyPortrait);
 
         // We don't do the Where in advance because we need the index to be accurate
         Activities = new(groupSelection.Selection.Activities.Select((a, i) => a is not null ? new ScenarioActivityViewModel(this, a, i) : null)
@@ -166,6 +170,23 @@ public class ScenarioActivityViewModel : ViewModelBase
         });
         SelectFutureDescCommand = ReactiveCommand.Create(() => SetSelectedDescriptionImage(_futureDesc));
         SelectPastDescCommand = ReactiveCommand.Create(() => SetSelectedDescriptionImage(_pastDesc));
+
+        LockedIcons = [];
+        if (Activity.RequiredBrigadeMember != ScenarioActivity.BrigadeMember.NONE)
+        {
+            LockedIcons.Add(Activity.RequiredBrigadeMember switch
+            {
+                ScenarioActivity.BrigadeMember.MIKURU => _selection.CharacterPortraits[Speaker.MIKURU].Resize(new SKSizeI(48, 48), SKSamplingOptions.Default),
+                ScenarioActivity.BrigadeMember.NAGATO => _selection.CharacterPortraits[Speaker.NAGATO].Resize(new SKSizeI(48, 48), SKSamplingOptions.Default),
+                ScenarioActivity.BrigadeMember.KOIZUMI => _selection.CharacterPortraits[Speaker.KOIZUMI].Resize(new SKSizeI(48, 48), SKSamplingOptions.Default),
+                ScenarioActivity.BrigadeMember.ANY => _selection.CharacterPortraits[Speaker.INFO].Resize(new SKSizeI(48, 48), SKSamplingOptions.Default),
+                _ => null,
+            });
+        }
+        if (Activity.HaruhiPresent)
+        {
+            LockedIcons.Add(_selection.CharacterPortraits[Speaker.HARUHI].Resize(new SKSizeI(24, 24), SKSamplingOptions.Default));
+        }
     }
 
     // Drawing properties
@@ -190,6 +211,8 @@ public class ScenarioActivityViewModel : ViewModelBase
     public SKBitmap TitlePlateMain { get; }
     [Reactive]
     public SKBitmap TitlePlateText { get; set; }
+
+    public ObservableCollection<SKBitmap> LockedIcons { get; }
 
     private static Rect GetCanvasPos(int index)
     {

--- a/src/SerialLoops/ViewModels/Editors/PuzzleEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/PuzzleEditorViewModel.cs
@@ -98,7 +98,7 @@ public class PuzzleEditorViewModel : EditorViewModel
         set
         {
             this.RaiseAndSetIfChanged(ref _accompanyingCharacter, value);
-            _puzzle.Puzzle.Settings.AccompanyingCharacter = _accompanyingCharacter?.Character.MessageInfo.Character ?? 0;
+            _puzzle.Puzzle.Settings.AccompanyingCharacter = _accompanyingCharacter?.Character?.MessageInfo.Character ?? 0;
             _puzzle.UnsavedChanges = true;
         }
     }
@@ -109,7 +109,7 @@ public class PuzzleEditorViewModel : EditorViewModel
         set
         {
             this.RaiseAndSetIfChanged(ref _powerCharacter1, value);
-            _puzzle.Puzzle.Settings.PowerCharacter1 = _powerCharacter1?.Character.MessageInfo.Character ?? 0;
+            _puzzle.Puzzle.Settings.PowerCharacter1 = _powerCharacter1?.Character?.MessageInfo.Character ?? 0;
             _puzzle.UnsavedChanges = true;
         }
     }
@@ -120,7 +120,7 @@ public class PuzzleEditorViewModel : EditorViewModel
         set
         {
             this.RaiseAndSetIfChanged(ref _powerCharacter2, value);
-            _puzzle.Puzzle.Settings.PowerCharacter1 = _powerCharacter2?.Character.MessageInfo.Character ?? 0;
+            _puzzle.Puzzle.Settings.PowerCharacter1 = _powerCharacter2?.Character?.MessageInfo.Character ?? 0;
             _puzzle.UnsavedChanges = true;
         }
     }

--- a/src/SerialLoops/ViewModels/Panels/EditorTabsPanelViewModel.cs
+++ b/src/SerialLoops/ViewModels/Panels/EditorTabsPanelViewModel.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Util;
 using MsBox.Avalonia.Enums;
 using ReactiveUI;

--- a/src/SerialLoops/Views/Dialogs/AsmHackCreationDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/AsmHackCreationDialog.axaml.cs
@@ -1,6 +1,4 @@
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace SerialLoops.Views.Dialogs;
 

--- a/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml.cs
@@ -1,8 +1,5 @@
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Interactivity;
-using Avalonia.Media;
-using Avalonia.Skia.Helpers;
 
 namespace SerialLoops.Views.Dialogs;
 

--- a/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
@@ -3,12 +3,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vm="using:SerialLoops.ViewModels.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:assets="using:SerialLoops.Assets"
-             xmlns:controls="using:SerialLoops.Controls"
-             xmlns:utility="using:SerialLoops.Utility"
-             xmlns:gbox="using:GroupBox.Avalonia.Controls"
-             xmlns:items="using:SerialLoops.Lib.Items"
-             xmlns:editors="clr-namespace:SerialLoops.Views.Editors"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:GroupSelectionEditorViewModel"
              x:Class="SerialLoops.Views.Editors.GroupSelectionEditorView">
@@ -17,71 +11,11 @@
         <ItemsControl ItemsSource="{Binding Activities}">
             <ItemsControl.DataTemplates>
                 <DataTemplate DataType="vm:ScenarioActivityViewModel">
-                    <gbox:GroupBox Header="{Binding Title}" Theme="{StaticResource GroupBoxClassic}">
-                        <StackPanel Orientation="Vertical" Spacing="5" Margin="3">
-                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                <TextBlock Text="{x:Static assets:Strings.Haruhi_Present}"/>
-                                <CheckBox IsChecked="{Binding Activity.HaruhiPresent}"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                <TextBlock Text="{x:Static assets:Strings.Required_Brigade_Member}"/>
-                                <TextBlock Text="{Binding Activity.RequiredBrigadeMember}"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                <TextBlock Text="{x:Static assets:Strings.Future_Description}"/>
-                                <TextBox Height="50" Width="400" Text="{Binding FutureDesc}"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Spacing="5">
-                                <TextBlock Text="{x:Static assets:Strings.Past_Description}"/>
-                                <TextBox Height="50" Width="400" Text="{Binding PastDesc}"/>
-                            </StackPanel>
-                            <gbox:GroupBox Header="{x:Static assets:Strings.Optimal_Group}">
-                                <StackPanel Orientation="Horizontal" Spacing="5">
-                                    <TextBlock Text="{Binding Activity.OptimalGroup[0]}"/>
-                                    <TextBlock Text="{Binding Activity.OptimalGroup[1]}"/>
-                                    <TextBlock Text="{Binding Activity.OptimalGroup[2]}"/>
-                                </StackPanel>
-                            </gbox:GroupBox>
-                            <gbox:GroupBox Header="{x:Static assets:Strings.Worst_Group}" Theme="{StaticResource GroupBoxClassic}">
-                                <StackPanel Orientation="Horizontal" Spacing="5">
-                                    <TextBlock Text="{Binding Activity.WorstGroup[0]}"/>
-                                    <TextBlock Text="{Binding Activity.WorstGroup[1]}"/>
-                                    <TextBlock Text="{Binding Activity.WorstGroup[2]}"/>
-                                </StackPanel>
-                            </gbox:GroupBox>
-                            <gbox:GroupBox Header="{x:Static assets:Strings.Routes}" Theme="{StaticResource GroupBoxClassic}" Margin="10">
-                                <ItemsControl ItemsSource="{Binding Routes}">
-                                    <ItemsControl.DataTemplates>
-                                        <DataTemplate x:DataType="vm:ScenarioRouteViewModel">
-                                            <gbox:GroupBox Header="{Binding Title}" Theme="{StaticResource GroupBoxClassic}" Margin="5">
-                                                <StackPanel Orientation="Vertical" Spacing="3">
-                                                    <StackPanel Orientation="Horizontal" Spacing="5">
-                                                        <TextBlock Text="{x:Static assets:Strings.Script}"/>
-                                                        <controls:ItemLink Item="{Binding Script}" Tabs="{Binding $parent[editors:GroupSelectionEditorView].((vm:GroupSelectionEditorViewModel)DataContext).Tabs}"/>
-                                                    </StackPanel>
-                                                    <StackPanel Orientation="Horizontal" Spacing="5">
-                                                        <TextBlock Text="{x:Static assets:Strings.Characters_Involved}"/>
-                                                        <TextBlock Text="{Binding Route.CharactersInvolved, Converter={x:Static utility:SLConverters.ListDisplayConverter}}"/>
-                                                    </StackPanel>
-                                                    <gbox:GroupBox Header="{x:Static assets:Strings.Kyonless_Topics}" Theme="{StaticResource GroupBoxClassic}" Margin="3">
-                                                        <StackPanel Orientation="Vertical" Spacing="3">
-                                                            <ItemsControl ItemsSource="{Binding KyonlessTopics}">
-                                                                <ItemsControl.DataTemplates>
-                                                                    <DataTemplate x:DataType="items:TopicItem">
-                                                                        <controls:ItemLink Item="{Binding}" Tabs="{Binding $parent[editors:GroupSelectionEditorView].((vm:GroupSelectionEditorViewModel)DataContext).Tabs}"/>
-                                                                    </DataTemplate>
-                                                                </ItemsControl.DataTemplates>
-                                                            </ItemsControl>
-                                                        </StackPanel>
-                                                    </gbox:GroupBox>
-                                                </StackPanel>
-                                            </gbox:GroupBox>
-                                        </DataTemplate>
-                                    </ItemsControl.DataTemplates>
-                                </ItemsControl>
-                            </gbox:GroupBox>
-                        </StackPanel>
-                    </gbox:GroupBox>
+                    <Canvas Width="256" Height="192">
+                        <Rectangle Fill="{Binding BackgroundColor}" Canvas.Left="{Binding CanvasLeft}"
+                                   Canvas.Top="{Binding CanvasTop}" Width="{Binding CanvasWidth}"
+                                   Height="{Binding CanvasHeight}"/>
+                    </Canvas>
                 </DataTemplate>
             </ItemsControl.DataTemplates>
         </ItemsControl>

--- a/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
@@ -3,39 +3,120 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vm="using:SerialLoops.ViewModels.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:assets="using:SerialLoops.Assets"
+             xmlns:controls="using:SerialLoops.Controls"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:ia="using:Avalonia.Xaml.Interactions.Core"
+             xmlns:sk="using:SkiaSharp"
              xmlns:utility="using:SerialLoops.Utility"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:GroupSelectionEditorViewModel"
              x:Class="SerialLoops.Views.Editors.GroupSelectionEditorView">
 
     <ScrollViewer>
-        <ItemsControl ItemsSource="{Binding Activities}">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <Canvas Width="512" Height="394"/>
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.DataTemplates>
-                <DataTemplate DataType="vm:ScenarioActivityViewModel">
-                    <Canvas Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}"
-                            Background="{Binding BackgroundColor}">
-                        <Image Source="{Binding Letter, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
-                               Canvas.Left="134" Canvas.Top="22" Width="64" Height="64"/>
-                        <Image Source="{Binding TitlePlateSlope, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
-                               Canvas.Left="52" Canvas.Top="116" Width="32" Height="32"/>
-                        <Image Source="{Binding TitlePlateMain, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
-                               Canvas.Left="84" Canvas.Top="84" Width="136" Height="64" Stretch="Fill"/>
-                        <Image Source="{Binding TitlePlateText, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
-                               Canvas.Left="82" Canvas.Top="118" Width="136" Height="32"/>
-                    </Canvas>
-                </DataTemplate>
-            </ItemsControl.DataTemplates>
-            <ItemsControl.Styles>
-                <Style Selector="ItemsControl > ContentPresenter" x:DataType="vm:ScenarioActivityViewModel">
-                    <Setter Property="(Canvas.Left)" Value="{Binding CanvasLeft}"/>
-                    <Setter Property="(Canvas.Top)" Value="{Binding CanvasTop}"/>
-                </Style>
-            </ItemsControl.Styles>
-        </ItemsControl>
+        <DockPanel>
+            <ItemsControl ItemsSource="{Binding Activities}" DockPanel.Dock="Top">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <Canvas Width="512" Height="394"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.DataTemplates>
+                    <DataTemplate DataType="vm:ScenarioActivityViewModel">
+                        <Canvas Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}"
+                                Background="{Binding BackgroundColor}" Name="ScenarioActivityCanvas">
+                            <i:Interaction.Behaviors>
+                                <ia:EventTriggerBehavior EventName="Tapped" SourceObject="{Binding #ScenarioActivityCanvas}">
+                                    <ia:InvokeCommandAction Command="{Binding SelectActivityCommand}"/>
+                                </ia:EventTriggerBehavior>
+                            </i:Interaction.Behaviors>
+
+                            <Image Source="{Binding Letter, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                                   Canvas.Left="134" Canvas.Top="22" Width="64" Height="64"/>
+                            <Image Source="{Binding TitlePlateSlope, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                                   Canvas.Left="52" Canvas.Top="116" Width="32" Height="32"/>
+                            <Image Source="{Binding TitlePlateMain, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                                   Canvas.Left="84" Canvas.Top="84" Width="136" Height="64" Stretch="Fill"/>
+                            <Image Source="{Binding TitlePlateText, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                                   Canvas.Left="82" Canvas.Top="118" Width="136" Height="32"/>
+
+                            <Border Background="Transparent" BorderThickness="2" BorderBrush="Red" IsVisible="{Binding Selected}"
+                                    Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}"/>
+                        </Canvas>
+                    </DataTemplate>
+                </ItemsControl.DataTemplates>
+                <ItemsControl.Styles>
+                    <Style Selector="ItemsControl > ContentPresenter" x:DataType="vm:ScenarioActivityViewModel">
+                        <Setter Property="(Canvas.Left)" Value="{Binding CanvasLeft}"/>
+                        <Setter Property="(Canvas.Top)" Value="{Binding CanvasTop}"/>
+                    </Style>
+                </ItemsControl.Styles>
+            </ItemsControl>
+
+            <DockPanel DockPanel.Dock="Bottom" IsVisible="{Binding SelectedActivity, Converter={x:Static ObjectConverters.IsNotNull}}">
+                <StackPanel DataContext="{Binding SelectedActivity}" Orientation="Vertical" Spacing="20">
+                    <Image Source="{Binding SelectedDescriptionImage, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                           IsVisible="{Binding SelectedDescriptionImage, Converter={x:Static ObjectConverters.IsNotNull}}"
+                           Stretch="None"/>
+
+                    <StackPanel Orientation="Vertical" Spacing="5">
+                        <TextBlock Text="{x:Static assets:Strings.Title}" HorizontalAlignment="Center"/>
+                        <TextBox Text="{Binding Title}" Width="150"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Vertical" Spacing="5">
+                        <TextBlock Text="{x:Static assets:Strings.Future_Description}" HorizontalAlignment="Center"/>
+                        <TextBox Text="{Binding FutureDesc}" Width="350" Height="60" Name="FutureDescBox"
+                                 AcceptsReturn="True">
+                            <i:Interaction.Behaviors>
+                                <ia:EventTriggerBehavior EventName="GotFocus" SourceObject="{Binding #FutureDescBox}">
+                                    <ia:InvokeCommandAction Command="{Binding SelectFutureDescCommand}"/>
+                                </ia:EventTriggerBehavior>
+                            </i:Interaction.Behaviors>
+                        </TextBox>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Vertical" Spacing="5">
+                        <TextBlock Text="{x:Static assets:Strings.Past_Description}" HorizontalAlignment="Center"/>
+                        <TextBox Text="{Binding PastDesc}" Width="350" Height="60" Name="PastDescBox"
+                                 AcceptsReturn="True">
+                            <i:Interaction.Behaviors>
+                                <ia:EventTriggerBehavior EventName="GotFocus" SourceObject="{Binding #PastDescBox}">
+                                    <ia:InvokeCommandAction Command="{Binding SelectPastDescCommand}"/>
+                                </ia:EventTriggerBehavior>
+                            </i:Interaction.Behaviors>
+                        </TextBox>
+                    </StackPanel>
+
+                    <ItemsRepeater ItemsSource="{Binding Routes}" Height="300">
+                        <ItemsRepeater.Layout>
+                            <UniformGridLayout Orientation="Horizontal" MaximumRowsOrColumns="5" ItemsJustification="Center"
+                                               MinColumnSpacing="32" MinRowSpacing="32" MinItemWidth="150" MinItemHeight="112"/>
+                        </ItemsRepeater.Layout>
+                        <ItemsRepeater.ItemTemplate>
+                            <DataTemplate DataType="vm:ScenarioRouteViewModel">
+                                <StackPanel Orientation="Vertical" Spacing="16">
+                                    <TextBox Text="{Binding Title}" HorizontalAlignment="Center"/>
+                                    <controls:ItemLink Item="{Binding Script}" Tabs="{Binding Tabs}"
+                                                       HorizontalAlignment="Center"/>
+                                    <ItemsRepeater ItemsSource="{Binding CharacterIcons}" HorizontalAlignment="Center">
+                                        <ItemsRepeater.Layout>
+                                            <UniformGridLayout Orientation="Horizontal" MaximumRowsOrColumns="3"
+                                                               MinColumnSpacing="4" MinRowSpacing="4"
+                                                               MinItemWidth="32" MinItemHeight="32"/>
+                                        </ItemsRepeater.Layout>
+                                        <ItemsRepeater.ItemTemplate>
+                                            <DataTemplate DataType="sk:SKBitmap">
+                                                <Image Source="{Binding Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
+                                            </DataTemplate>
+                                        </ItemsRepeater.ItemTemplate>
+                                    </ItemsRepeater>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsRepeater.ItemTemplate>
+                    </ItemsRepeater>
+                </StackPanel>
+            </DockPanel>
+        </DockPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
@@ -3,21 +3,33 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vm="using:SerialLoops.ViewModels.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:utility="using:SerialLoops.Utility"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:GroupSelectionEditorViewModel"
              x:Class="SerialLoops.Views.Editors.GroupSelectionEditorView">
 
     <ScrollViewer>
         <ItemsControl ItemsSource="{Binding Activities}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <Canvas Width="512" Height="394"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
             <ItemsControl.DataTemplates>
                 <DataTemplate DataType="vm:ScenarioActivityViewModel">
-                    <Canvas Width="256" Height="192">
-                        <Rectangle Fill="{Binding BackgroundColor}" Canvas.Left="{Binding CanvasLeft}"
-                                   Canvas.Top="{Binding CanvasTop}" Width="{Binding CanvasWidth}"
-                                   Height="{Binding CanvasHeight}"/>
+                    <Canvas Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}"
+                            Background="{Binding BackgroundColor}">
+                        <Image Source="{Binding Letter, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                               Canvas.Left="134" Canvas.Top="22" Width="64" Height="64"/>
                     </Canvas>
                 </DataTemplate>
             </ItemsControl.DataTemplates>
+            <ItemsControl.Styles>
+                <Style Selector="ItemsControl > ContentPresenter" x:DataType="vm:ScenarioActivityViewModel">
+                    <Setter Property="(Canvas.Left)" Value="{Binding CanvasLeft}"/>
+                    <Setter Property="(Canvas.Top)" Value="{Binding CanvasTop}"/>
+                </Style>
+            </ItemsControl.Styles>
         </ItemsControl>
     </ScrollViewer>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
@@ -5,8 +5,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:assets="using:SerialLoops.Assets"
              xmlns:controls="using:SerialLoops.Controls"
+             xmlns:editors="using:SerialLoops.Views.Editors"
              xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:ia="using:Avalonia.Xaml.Interactions.Core"
+             xmlns:li="using:SerialLoops.Lib.Items"
              xmlns:sk="using:SkiaSharp"
              xmlns:utility="using:SerialLoops.Utility"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -100,15 +102,15 @@
                         </TextBox>
                     </StackPanel>
 
-                    <ItemsRepeater ItemsSource="{Binding Routes}" Height="300">
+                    <ItemsRepeater ItemsSource="{Binding Routes}" MinHeight="800">
                         <ItemsRepeater.Layout>
                             <UniformGridLayout Orientation="Horizontal" MaximumRowsOrColumns="5" ItemsJustification="Center"
-                                               MinColumnSpacing="32" MinRowSpacing="32" MinItemWidth="150" MinItemHeight="112"/>
+                                               MinColumnSpacing="32" MinRowSpacing="32" MinItemWidth="200" MinItemHeight="300"/>
                         </ItemsRepeater.Layout>
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate DataType="vm:ScenarioRouteViewModel">
                                 <StackPanel Orientation="Vertical" Spacing="16">
-                                    <TextBox Text="{Binding Title}" HorizontalAlignment="Center"/>
+                                    <TextBox Text="{Binding Title}" HorizontalAlignment="Center" Width="200"/>
                                     <controls:ItemLink Item="{Binding Script}" Tabs="{Binding Tabs}"
                                                        HorizontalAlignment="Center"/>
                                     <ItemsRepeater ItemsSource="{Binding CharacterIcons}" HorizontalAlignment="Center">
@@ -123,6 +125,17 @@
                                             </DataTemplate>
                                         </ItemsRepeater.ItemTemplate>
                                     </ItemsRepeater>
+                                    <StackPanel Orientation="Vertical" Spacing="5" HorizontalAlignment="Center">
+                                        <TextBlock Text="{x:Static assets:Strings.Kyonless_Topics}" HorizontalAlignment="Center"/>
+                                        <ListBox ItemsSource="{Binding KyonlessTopics}" HorizontalAlignment="Center"
+                                                 Height="160">
+                                            <ListBox.ItemTemplate>
+                                                <DataTemplate DataType="li:TopicItem">
+                                                    <TextBlock Text="{Binding DisplayName}"/>
+                                                </DataTemplate>
+                                            </ListBox.ItemTemplate>
+                                        </ListBox>
+                                    </StackPanel>
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsRepeater.ItemTemplate>

--- a/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
@@ -21,6 +21,12 @@
                             Background="{Binding BackgroundColor}">
                         <Image Source="{Binding Letter, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
                                Canvas.Left="134" Canvas.Top="22" Width="64" Height="64"/>
+                        <Image Source="{Binding TitlePlateSlope, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                               Canvas.Left="52" Canvas.Top="116" Width="32" Height="32"/>
+                        <Image Source="{Binding TitlePlateMain, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                               Canvas.Left="84" Canvas.Top="84" Width="136" Height="64" Stretch="Fill"/>
+                        <Image Source="{Binding TitlePlateText, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                               Canvas.Left="82" Canvas.Top="118" Width="136" Height="32"/>
                     </Canvas>
                 </DataTemplate>
             </ItemsControl.DataTemplates>

--- a/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/GroupSelectionEditorView.axaml
@@ -40,6 +40,18 @@
                             <Image Source="{Binding TitlePlateText, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
                                    Canvas.Left="82" Canvas.Top="118" Width="136" Height="32"/>
 
+                            <ItemsRepeater ItemsSource="{Binding LockedIcons}"
+                                           Canvas.Left="10" Canvas.Top="60">
+                                <ItemsRepeater.Layout>
+                                    <UniformGridLayout MinItemHeight="48" MinItemWidth="48" MinColumnSpacing="16" MaximumRowsOrColumns="2"/>
+                                </ItemsRepeater.Layout>
+                                <ItemsRepeater.ItemTemplate>
+                                    <DataTemplate DataType="sk:SKBitmap">
+                                        <Image Source="{Binding Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
+                                    </DataTemplate>
+                                </ItemsRepeater.ItemTemplate>
+                            </ItemsRepeater>
+
                             <Border Background="Transparent" BorderThickness="2" BorderBrush="Red" IsVisible="{Binding Selected}"
                                     Width="{Binding CanvasWidth}" Height="{Binding CanvasHeight}"/>
                         </Canvas>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6245c18a-1b00-4fa9-9763-73af5437a245)

This significantly improves the group selection editor and even allows them to be partially edited now! Neat.

The editor now reflects the appearance of the selections in-game. Clicking on an activity opens up its data and allows it to be edited. Previews for the title and two descriptions auto-update with typing. Neat!