### PR TITLE
Upgrade to NitroPacker v3

### DIFF
--- a/src/SerialLoops.Lib/Build.cs
+++ b/src/SerialLoops.Lib/Build.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using HaroohieClub.NitroPacker.Core;
+using HaroohieClub.NitroPacker;
 using HaruhiChokuretsuLib.Archive;
 using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Archive.Event;
@@ -103,7 +103,7 @@ public static class Build
             log.LogException("Failed to write include files to disk.", exc);
             return false;
         }
-        tracker.Finished+= 4;
+        tracker.Finished += 4;
 
         // Replace files
         string[] files = Directory.GetFiles(Path.Combine(directory, "assets"), "*.*", SearchOption.AllDirectories);
@@ -182,14 +182,14 @@ public static class Build
         {
             return false;
         }
-        tracker.Finished+= 3;
+        tracker.Finished += 3;
 
         // Save project file to disk
-        string ndsProjectFile = Path.Combine(directory, "rom", $"{project.Name}.xml");
+        string ndsProjectFile = Path.Combine(directory, "rom", $"{project.Name}.json");
         tracker.Focus("Writing NitroPacker Project File", 1);
         try
         {
-            File.WriteAllBytes(ndsProjectFile, project.Settings.File.Write());
+            project.Settings.File.Serialize(ndsProjectFile);
         }
         catch (IOException exc)
         {
@@ -227,7 +227,7 @@ public static class Build
         {
             log.LogException($"Failed to copy newly built archives to the iterative originals directory", exc);
         }
-        tracker.Finished+= 3;
+        tracker.Finished += 3;
     }
 
     private static void ReplaceSingleGraphicsFile(ArchiveFile<GraphicsFile> grp, string filePath, int index, Func<string, string> localize, ILogger log)

--- a/src/SerialLoops.Lib/IO.cs
+++ b/src/SerialLoops.Lib/IO.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using HaroohieClub.NitroPacker.Core;
+using HaroohieClub.NitroPacker;
 using HaruhiChokuretsuLib.Util;
 using SerialLoops.Lib.Util;
 
@@ -81,7 +81,7 @@ public static class IO
                 new("vce", [], []),
             ],
             [
-                new(Path.Combine(project.BaseDirectory, "rom", $"{project.Name}.xml")),
+                new(Path.Combine(project.BaseDirectory, "rom", $"{project.Name}.json")),
             ]);
         IODirectory srcDirectoryTree = new("src",
             [

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -1096,7 +1096,7 @@ public partial class Project
             tracker.Finished++;
 
             // If we detect an old NP format, auto-migrate it
-            if (!File.Exists(Path.Combine(config.ProjectsDirectory, project.Name, "base", $"{project.Name}.json")))
+            if (!File.Exists(Path.Combine(config.ProjectsDirectory, project.Name, "base", "rom", $"{project.Name}.json")))
             {
                 NdsProjectFile.ConvertProjectFile(Path.Combine(config.ProjectsDirectory, project.Name, "base", "rom", $"{project.Name}.xml"));
                 NdsProjectFile.ConvertProjectFile(Path.Combine(config.ProjectsDirectory, project.Name, "iterative", "rom", $"{project.Name}.xml"));
@@ -1140,7 +1140,7 @@ public partial class Project
             using FileStream slzipFs = File.Create(slzipFile);
             using ZipArchive slzip = new(slzipFs, ZipArchiveMode.Create);
             log.Log($"Adding '{ProjectFile}' to slzip...");
-            slzip.CreateEntryFromFile(ProjectFile, Path.GetFileName(ProjectFile));
+            slzip.CreateEntryFromFile(ProjectFile, Path.GetFileName(ProjectFile)!);
             slzip.Comment = BaseRomHash;
             log.Log("Adding charset.json to slzip...");
             slzip.CreateEntryFromFile(Path.Combine(MainDirectory, "font", "charset.json"), Path.Combine("font", "charset.json"));
@@ -1160,6 +1160,7 @@ public partial class Project
                 slzip.CreateEntryFromFile(file, Path.GetRelativePath(MainDirectory, file));
             }
             slzip.CreateEntryFromFile(Path.Combine(BaseDirectory, "rom", $"{Name}.json"), Path.Combine("base", "rom", $"{Name}.json"));
+            slzip.CreateEntryFromFile(Path.Combine(BaseDirectory, "rom", "banner.bin"), Path.Combine("base", "rom", "banner.bin"));
             foreach (string file in Directory.GetFiles(Path.Combine(BaseDirectory, "rom", "data", "bgm"), "*"))
             {
                 log.Log($"Adding '{file}' to slzip...");

--- a/src/SerialLoops.Lib/ProjectSettings.cs
+++ b/src/SerialLoops.Lib/ProjectSettings.cs
@@ -19,7 +19,7 @@ public class ProjectSettings(NdsProjectFile file, ILogger log)
         get => _banner.GameName[0];
         set
         {
-            string name = value.Length > 128 ? value[..63] : value;
+            string name = value.Length > 128 ? value[..128] : value;
             for (int i = 0; i < _banner.GameName.Length; i++)
             {
                 _banner.GameName[i] = name.Replace("\r\n", "\n");
@@ -34,7 +34,7 @@ public class ProjectSettings(NdsProjectFile file, ILogger log)
             Rgba8Bitmap bitmap = _banner.GetIcon();
             return new(bitmap.Width, bitmap.Height)
             {
-                Pixels = bitmap.Pixels.Select(p => new SKColor(p)).ToArray()
+                Pixels = bitmap.Pixels.Select(p => new SKColor(p)).ToArray(),
             };
         }
         set
@@ -42,10 +42,10 @@ public class ProjectSettings(NdsProjectFile file, ILogger log)
             GraphicsFile grp = new()
             {
                 Name = "ICON",
-                PixelData = new(),
-                PaletteData = new(),
+                PixelData = [],
+                PaletteData = [],
             };
-            grp.Initialize(Array.Empty<byte>(), 0, log);
+            grp.Initialize([], 0, log);
             grp.FileFunction = GraphicsFile.Function.SHTX;
             grp.ImageForm = GraphicsFile.Form.TILE;
             grp.ImageTileForm = GraphicsFile.TileForm.GBA_4BPP;

--- a/src/SerialLoops.Lib/ProjectSettings.cs
+++ b/src/SerialLoops.Lib/ProjectSettings.cs
@@ -1,28 +1,28 @@
 ﻿using System;
 using System.Linq;
-using HaroohieClub.NitroPacker.Core;
+using HaroohieClub.NitroPacker;
+using HaroohieClub.NitroPacker.Nitro.Card.Banners;
 using HaroohieClub.NitroPacker.Nitro.Gx;
 using HaruhiChokuretsuLib.Archive.Graphics;
 using HaruhiChokuretsuLib.Util;
 using SkiaSharp;
-using static HaroohieClub.NitroPacker.Nitro.Card.Rom.RomBanner;
 
 namespace SerialLoops.Lib;
 
 public class ProjectSettings(NdsProjectFile file, ILogger log)
 {
     public NdsProjectFile File { get; } = file;
-    private BannerV1 Banner => File.RomInfo.Banner.Banner;
-    private readonly ILogger _log = log;
+    private BannerV1 _banner => (BannerV1)File.RomInfo.Banner.Banner;
 
-    public string Name {
-        get => Banner.GameName[0];
+    public string Name
+    {
+        get => _banner.GameName[0];
         set
         {
             string name = value.Length > 128 ? value[..63] : value;
-            for (int i = 0; i < Banner.GameName.Length; i++)
+            for (int i = 0; i < _banner.GameName.Length; i++)
             {
-                Banner.GameName[i] = name.Replace("\r\n", "\n");
+                _banner.GameName[i] = name.Replace("\r\n", "\n");
             }
         }
     }
@@ -31,7 +31,7 @@ public class ProjectSettings(NdsProjectFile file, ILogger log)
     {
         get
         {
-            Rgba8Bitmap bitmap = Banner.GetIcon();
+            Rgba8Bitmap bitmap = _banner.GetIcon();
             return new(bitmap.Width, bitmap.Height)
             {
                 Pixels = bitmap.Pixels.Select(p => new SKColor(p)).ToArray()
@@ -45,7 +45,7 @@ public class ProjectSettings(NdsProjectFile file, ILogger log)
                 PixelData = new(),
                 PaletteData = new(),
             };
-            grp.Initialize(Array.Empty<byte>(), 0, _log);
+            grp.Initialize(Array.Empty<byte>(), 0, log);
             grp.FileFunction = GraphicsFile.Function.SHTX;
             grp.ImageForm = GraphicsFile.Form.TILE;
             grp.ImageTileForm = GraphicsFile.TileForm.GBA_4BPP;
@@ -54,8 +54,8 @@ public class ProjectSettings(NdsProjectFile file, ILogger log)
             grp.Palette = new(new SKColor[16]);
             grp.SetImage(value, setPalette: true, transparentIndex: 0, newSize: true);
 
-            Banner.Image = grp.PixelData.ToArray();
-            Banner.Pltt = grp.PaletteData.ToArray();
+            _banner.Image = grp.PixelData.ToArray();
+            _banner.Palette = grp.PaletteData.ToArray();
         }
     }
 }

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="BunLabs.NAudio.Flac" Version="2.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.0.1" />
+    <PackageReference Include="HaroohieClub.NitroPacker" Version="3.1.4" />
     <PackageReference Include="HaruhiChokuretsuLib" Version="0.50.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-    <PackageReference Include="NitroPacker.Core" Version="2.6.0" />
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />

--- a/src/SerialLoops/ViewModels/Dialogs/AsmHacksDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/AsmHacksDialogViewModel.cs
@@ -229,8 +229,8 @@ public class AsmHacksDialogViewModel : ViewModelBase
         // Get the overlays
         List<Overlay> overlays = [];
         string originalOverlaysDir = Path.Combine(_project.BaseDirectory, "original", "overlay");
-        string romInfoPath = Path.Combine(_project.BaseDirectory, "original", $"{_project.Name}.xml");
-        string newRomInfoPath = Path.Combine(_project.BaseDirectory, "rom", $"{_project.Name}.xml");
+        string romInfoPath = Path.Combine(_project.BaseDirectory, "original", $"{_project.Name}.json");
+        string newRomInfoPath = Path.Combine(_project.BaseDirectory, "rom", $"{_project.Name}.json");
 
         foreach (string file in Directory.GetFiles(originalOverlaysDir))
         {

--- a/src/SerialLoops/ViewModels/Dialogs/ProjectSettingsDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/ProjectSettingsDialogViewModel.cs
@@ -35,7 +35,7 @@ public class ProjectSettingsDialogViewModel : ViewModelBase
 
     private ProjectSettings _settings;
     public ILogger Log { get; set; }
-    public bool Applied { get; set; }
+
     private ProjectSettingsDialog _settingsDialog;
 
     public void Initialize(ProjectSettingsDialog settingsDialog, ProjectSettings settings, ILogger log)
@@ -90,7 +90,6 @@ public class ProjectSettingsDialogViewModel : ViewModelBase
             _settings.Icon = _icon;
         }
 
-        Applied = true;
         _settingsDialog.Close();
     }
 }

--- a/src/SerialLoops/Views/Dialogs/ProjectSettingsDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/ProjectSettingsDialog.axaml
@@ -34,7 +34,7 @@
                                 </StackPanel>
                                 <StackPanel Orientation="Vertical" Spacing="5" HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <TextBlock Text="{x:Static assets:Strings.Game_Title}" />
-                                    <TextBox IsEnabled="True" Text="{Binding GameTitle}"
+                                    <TextBox Text="{Binding GameTitle}" AcceptsReturn="True"
                                              MaxLines="3" MinLines="3" Width="350" MaxWidth="350" />
                                 </StackPanel>
                             </StackPanel>


### PR DESCRIPTION
This PR upgrades us to NitroPacker v3. There's not a lot of direct benefit for us in the upgrade itself, but it will be good to be on the official version of NitroPacker for future updates and also to use nuget.org rather than our private feed.

Since NitroPacker v3 comes with `banner.bin` being store separate from the NDS project file, this PR does some management of the `ProjectSettings` class. One alarming fact I realized was that since we only edit project settings in the iterative directory and we package exported projects from the base directory, user changes to the banner would never propagate to their created slzip! So now on build we copy from one directory to the other (and also make sure to package banner.bin now that that's a thing).

Additionally, this PR introduces a very simple function to detect the lack of a NPv3 project file and then silently runs a migration to the new project format. This only occurs on project open, *not on project import* &ndash; the reason for this is that project import/export does not exist in the official release of Serial Loops yet, so I don't think it's super necessary to include extra logic that we could trip over for no real reason.

Otherwise, this also includes a few minor bugfixes and a bunch of `.xml` &rarr; `.json` lol

Closes #455.