### PR TITLE
Make flatpak sandbox patch & devkitARM pull more maintainable

### DIFF
--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -49,7 +49,7 @@ jobs:
           image: devkitpro/devkitarm:latest
           options: -v ${{ github.workspace }}:/work -w /work
           run: tar -czvf devkitarm.tar.gz /opt/devkitpro/devkitARM
-      - name: Upload devkitARM zip
+      - name: Publish devkitARM tarball
         uses: actions/upload-artifact@v4
         with:
           name: devkitARM

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -43,6 +43,18 @@ jobs:
           name: nuget-sources
           path: nuget-sources.json
           retention-days: 1
+      - name: Export devkitARM latest
+        uses: addnab/docker-run-action@v3
+        with:
+          image: devkitpro/devkitarm:latest
+          options: -v ${{ github.workspace }}:/work -w /work
+          run: tar -czvf devkitarm.tar.gz /opt/devkitpro/devkitARM
+      - name: Upload devkitARM zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: devkitARM
+          path: devkitarm.tar.gz
+          retention-days: 1
   linux-flatpak:
     needs: linux-flatpak-setup
     runs-on: ubuntu-latest
@@ -56,6 +68,11 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: nuget-sources
+          path: install/linux/flatpak/
+      - name: Download devkitARM
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: devkitARM
           path: install/linux/flatpak/
       - name: Export version
         run: echo $SLVersion > install/linux/flatpak/VERSION

--- a/install/linux/flatpak/club.haroohie.SerialLoops.desktop
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0
+Version=#VERSION#
 Name=Serial Loops
 Comment=Editor for Suzumiya Haruhi no Chokuretsu
 Exec=SerialLoops

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -68,7 +68,7 @@ modules:
         path: VERSION
     build-commands:
       - mkdir -p ${FLATPAK_DEST}/opt/
-      - tar -xvf devkitarm.tar.gz -C ${FLATPAK_DEST}/
+      - tar -xvf ./devkitarm.tar.gz -C ${FLATPAK_DEST}/
       - export SLVersion=$(cat VERSION)
       - export SLAssemblyVersion=$(sed -n 's/pre/9999/p' VERSION)
       - dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 --no-self-contained --source ./nuget-sources

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -55,8 +55,8 @@ modules:
         url: https://github.com/haroohie-club/SerialLoops.git
         branch: Avalonia
       - ./nuget-sources.json
-      # - type: patch
-      #   path: patches/sandbox.patch
+      - type: patch
+        path: patches/sandbox.patch
       - type: file
         path: club.haroohie.SerialLoops.metainfo.xml
       - type: file

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -55,7 +55,6 @@ modules:
         url: https://github.com/haroohie-club/SerialLoops.git
         branch: Avalonia
       - ./nuget-sources.json
-      - ./devkitarm.tar.gz
       - type: patch
         path: patches/sandbox.patch
       - type: file
@@ -66,10 +65,9 @@ modules:
         path: ../../../src/SerialLoops/Assets/Icons/AppIcon.svg
       - type: file
         path: VERSION
+      - type: file
+        path: devkitarm.tar.gz
     build-commands:
-      - ls -l
-      - ls -l ..
-      - ls -l ../..
       - tar -xvf devkitarm.tar.gz -C ${FLATPAK_DEST}/
       - export SLVersion=$(cat VERSION)
       - export SLAssemblyVersion=$(sed -n 's/pre/9999/p' VERSION)

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -55,8 +55,8 @@ modules:
         url: https://github.com/haroohie-club/SerialLoops.git
         branch: Avalonia
       - ./nuget-sources.json
-      - type: patch
-        path: patches/sandbox.patch
+      # - type: patch
+      #   path: patches/sandbox.patch
       - type: file
         path: club.haroohie.SerialLoops.metainfo.xml
       - type: file

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -67,8 +67,10 @@ modules:
       - type: file
         path: VERSION
     build-commands:
-      - mkdir -p ${FLATPAK_DEST}/opt/
-      - tar -xvf ./devkitarm.tar.gz -C ${FLATPAK_DEST}/
+      - ls -l
+      - ls -l ..
+      - ls -l ../..
+      - tar -xvf devkitarm.tar.gz -C ${FLATPAK_DEST}/
       - export SLVersion=$(cat VERSION)
       - export SLAssemblyVersion=$(sed -n 's/pre/9999/p' VERSION)
       - dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 --no-self-contained --source ./nuget-sources

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -31,16 +31,6 @@ modules:
     build-commands:
     - /usr/lib/sdk/dotnet8/bin/install.sh
 
-  - name: devkitARM
-    buildsystem: simple
-    sources:
-      - type: archive
-        url: https://haroohie.nyc3.cdn.digitaloceanspaces.com/bootstrap/serial-loops/dkp.zip
-        sha256: 91d9d524d5150ae892de4457c4cbb7eaa5edcb2449a85366def678242b1f60e2
-    build-commands:
-      - mkdir -p ${FLATPAK_DEST}/opt/
-      - cp -r ./* ${FLATPAK_DEST}/opt/
-
   - name: make
     buildsystem: autotools
     sources:
@@ -65,6 +55,7 @@ modules:
         url: https://github.com/haroohie-club/SerialLoops.git
         branch: Avalonia
       - ./nuget-sources.json
+      - ./devkitarm.tar.gz
       - type: patch
         path: patches/sandbox.patch
       - type: file
@@ -76,6 +67,8 @@ modules:
       - type: file
         path: VERSION
     build-commands:
+      - mkdir -p ${FLATPAK_DEST}/opt/
+      - tar -xvf devkitarm.tar.gz -C ${FLATPAK_DEST}/
       - export SLVersion=$(cat VERSION)
       - export SLAssemblyVersion=$(sed -n 's/pre/9999/p' VERSION)
       - dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 --no-self-contained --source ./nuget-sources

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -81,6 +81,7 @@ modules:
       - dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 --no-self-contained --source ./nuget-sources
       - mkdir -p ${FLATPAK_DEST}/bin
       - cp -r src/SerialLoops/bin/Release/net8.0/publish/* ${FLATPAK_DEST}/bin
+      - sed -i "s/#VERSION#/$SLVersion/g" club.haroohie.SerialLoops.desktop
       - install -Dm644 AppIcon.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/club.haroohie.SerialLoops.svg
       - install -Dm644 club.haroohie.SerialLoops.metainfo.xml ${FLATPAK_DEST}/share/metainfo/club.haroohie.SerialLoops.metainfo.xml
       - install -Dm644 club.haroohie.SerialLoops.desktop ${FLATPAK_DEST}/share/applications/club.haroohie.SerialLoops.desktop

--- a/install/linux/flatpak/patches/sandbox.patch
+++ b/install/linux/flatpak/patches/sandbox.patch
@@ -1,56 +1,15 @@
-diff --git a/src/SerialLoops.Lib/Factories/ConfigFactory.cs b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
-index 275c2c2..434b611 100644
---- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
-+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
-@@ -71,7 +71,7 @@ public class ConfigFactory : IConfigFactory
-             }
-             else
-             {
--                devkitArmDir = Path.Combine("/opt", "devkitpro", "devkitARM");
-+                devkitArmDir = Path.Combine("/app", "opt", "devkitpro", "devkitARM");
-             }
-         }
-         if (!Directory.Exists(devkitArmDir))
-@@ -96,7 +96,7 @@ public class ConfigFactory : IConfigFactory
-             {
-                 Process flatpakProc = new()
-                 {
--                    StartInfo = new ProcessStartInfo("flatpak", ["info", emulatorFlatpak])
-+                    StartInfo = new ProcessStartInfo("flatpak-spawn", ["--host", "flatpak", "info", emulatorFlatpak])
-                     {
-                         RedirectStandardError = true, RedirectStandardOutput = true
-                     }
-diff --git a/src/SerialLoops/ViewModels/MainWindowViewModel.cs b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
-index d866647..97c09f3 100644
---- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
-+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
-@@ -683,7 +683,7 @@ public partial class MainWindowViewModel : ViewModelBase
-                             string emulatorExecutable = CurrentConfig.EmulatorPath;
-                             if (!string.IsNullOrWhiteSpace(CurrentConfig.EmulatorFlatpak))
-                             {
--                                emulatorExecutable = "flatpak";
-+                                emulatorExecutable = "flatpak-spawn";
-                             }
-                             if (emulatorExecutable.EndsWith(".app"))
-                             {
-@@ -692,11 +692,11 @@ public partial class MainWindowViewModel : ViewModelBase
-                             }
-
-                             string[] emulatorArgs = [Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")];
--                            if (emulatorExecutable.Equals("flatpak"))
-+                            if (emulatorExecutable.Equals("flatpak-spawn"))
-                             {
-                                 emulatorArgs =
-                                 [
--                                    "run", CurrentConfig.EmulatorFlatpak,
-+                                    "--host", "flatpak", "run", CurrentConfig.EmulatorFlatpak,
-                                     Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")
-                                 ];
-                             }
-@@ -863,4 +863,4 @@ public partial class MainWindowViewModel : ViewModelBase
-             Icon = ControlGenerator.GetVectorIcon("Search", Log),
-         });
-     }
--}
-\ No newline at end of file
-+}
+diff --git a/src/SerialLoops.Lib/PatchableConstants.cs b/src/SerialLoops.Lib/PatchableConstants.cs
+index 4bbfb0c..5eb628b 100644
+--- a/src/SerialLoops.Lib/PatchableConstants.cs
++++ b/src/SerialLoops.Lib/PatchableConstants.cs
+@@ -6,7 +6,7 @@ namespace SerialLoops.Lib;
+ // go more smoothly
+ public static class PatchableConstants
+ {
+-    public static string UnixDefaultDevkitArmDir => Path.Combine("/opt", "devkitpro", "devkitARM");
+-    public const string FlatpakProcess = "flatpak";
+-    public static string[] FlatpakProcessBaseArgs => [];
++    public static string UnixDefaultDevkitArmDir => Path.Combine("/app", "opt", "devkitpro", "devkitARM");
++    public const string FlatpakProcess = "flatpak-spawn";
++    public static string[] FlatpakProcessBaseArgs => ["--host", "flatpak"];
+ }

--- a/src/SerialLoops.Lib/PatchableConstants.cs
+++ b/src/SerialLoops.Lib/PatchableConstants.cs
@@ -1,0 +1,12 @@
+using System.IO;
+
+namespace SerialLoops.Lib;
+
+// This class exists to separate the values that get patched during the flatpak build to make that build
+// go more smoothly
+public static class PatchableConstants
+{
+    public static string UnixDefaultDevkitArmDir => Path.Combine("/opt", "devkitpro", "devkitARM");
+    public const string FlatpakProcess = "flatpak";
+    public static string[] FlatpakProcessBaseArgs => [];
+}

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -1037,7 +1037,7 @@ public partial class MainWindowViewModel : ViewModelBase
                             string emulatorExecutable = CurrentConfig.EmulatorPath;
                             if (!string.IsNullOrWhiteSpace(CurrentConfig.EmulatorFlatpak))
                             {
-                                emulatorExecutable = "flatpak";
+                                emulatorExecutable = PatchableConstants.FlatpakProcess;
                             }
                             if (emulatorExecutable.EndsWith(".app"))
                             {
@@ -1046,12 +1046,12 @@ public partial class MainWindowViewModel : ViewModelBase
                             }
 
                             string[] emulatorArgs = [Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")];
-                            if (emulatorExecutable.Equals("flatpak"))
+                            if (emulatorExecutable.Equals(PatchableConstants.FlatpakProcess))
                             {
                                 emulatorArgs =
                                 [
-                                    "run", CurrentConfig.EmulatorFlatpak,
-                                    Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")
+                                    ..PatchableConstants.FlatpakProcessBaseArgs, "run", CurrentConfig.EmulatorFlatpak,
+                                    Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds"),
                                 ];
                             }
                             Process.Start(emulatorExecutable, emulatorArgs);


### PR DESCRIPTION
When we build the flatpak, we do some simple source patching to ensure that features like running the emulator and running devkitARM still work from within the flatpak sandbox. However, source patching has the flaw that your patch has to be updated whenever the source file is updated.

This PR obviates that by abstracting the values patched by the sandbox patch into a single static class that can be patched instead. This makes things much more maintainable going forward.

Additionally, this makes downloading devkitARM a bit simpler -- instead of pulling from a hosted archive, we simply pull the latest devkitARM docker container in the setup step, package up `/opt/devkitpro/devkitARM`, upload it as an artifact, download it as an artifact, and then untar that artifact as part of the build.

Closes #461.