### PR TITLE
Add AppImage release artifact

### DIFF
--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -119,13 +119,13 @@ jobs:
         run: |
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
           pushd ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish
-          tar -czvf ../SerialLoops-x64.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
+          tar -czvf ../SerialLoops.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
           popd
       - name: Upload x64 tarball
         uses: actions/upload-artifact@v4
         with:
           name: linux-x64-tarball
-          path: src/SerialLoops/bin/Release/net8.0/linux-x64/SerialLoops-x64.tar.gz
+          path: src/SerialLoops/bin/Release/net8.0/linux-x64/SerialLoops.tar.gz
           retention-days: 1
       - name: Create deb package
         shell: pwsh
@@ -170,30 +170,6 @@ jobs:
         with:
           name: linux-x64-rpm
           path: SerialLoops.rpm
-          retention-days: 1
-
-  linux-tarball-univ:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4.1.0
-        with:
-          dotnet-version: '8.0.x'
-      - name: Build & Publish Serial Loops
-        run: dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 --no-self-contained /p:DebugType=None /p:DebugSymbols=false
-      - name: Create tarball
-        run: |
-          chmod +x ./src/SerialLoops/bin/Release/net8.0/publish/SerialLoops
-          pushd ./src/SerialLoops/bin/Release/net8.0/publish
-          tar -czvf ../SerialLoops-univ.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
-          popd
-      - name: Upload universal tarball
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-univ-tarball
-          path: src/SerialLoops/bin/Release/net8.0/SerialLoops-univ.tar.gz
           retention-days: 1
 
   macos-pkg:
@@ -270,7 +246,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [ linux-flatpak, linux-appimage, linux-dpkg-tarball, linux-rpm, linux-tarball-univ, macos-pkg, windows ]
+    needs: [ linux-flatpak, linux-appimage, linux-dpkg-tarball, linux-rpm, macos-pkg, windows ]
     steps:
       - name: Download Linux flatpak
         uses: actions/download-artifact@v4.1.8
@@ -280,14 +256,10 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: linux-x64-appimage
-      - name: Download Linux full tarball
+      - name: Download Linux tarball
         uses: actions/download-artifact@v4.1.8
         with:
           name: linux-x64-tarball
-      - name: Download Linux universal tarball
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: linux-univ-tarball
       - name: Download Linux dpkg
         uses: actions/download-artifact@v4.1.8
         with:
@@ -319,8 +291,7 @@ jobs:
           Get-ChildItem .
           Move-Item -Path SerialLoops.flatpak -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).flatpak
           Move-Item -Path SerialLoops.AppImage -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).AppImage
-          Move-Item -Path SerialLoops-x64.tar.gz -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).tar.gz
-          Move-Item -Path SerialLoops-univ.tar.gz -Destination release/SerialLoops-linux-univ-v$($env:SLVersion).tar.gz
+          Move-Item -Path SerialLoops.tar.gz -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).tar.gz
           Move-Item -Path SerialLoops.deb -Destination release/SerialLoops-linux-x64-$($env:SLVersion).deb
           Move-Item -Path SerialLoops.rpm -Destination release/SerialLoops-linux-x64-$($env:SLVersion)-1.fc39.x86_64.rpm
           Move-Item -Path SerialLoops-osx-arm64.pkg -Destination release/SerialLoops-macOS-arm-v$($env:SLVersion)-installer.pkg
@@ -360,9 +331,7 @@ jobs:
             You can also install the official [melonDS Flatpak from Flathub](https://flathub.org/apps/net.kuribo64.melonDS) to use as your emulator. We recommend installing it from the [flathub-beta](https://docs.flathub.org/docs/for-users/installation/#flathub-beta-repository) repository as that is where the most up-to-date versions tend to be pushed.
 
             The main benefit of the Flatpak is that it is packaged with devkitARM for ease of use. However, if you already have devkitARM installed or would like to use something more lightweight, we also provide the following options (all of which require [installing devkitARM yourself](https://devkitpro.org/wiki/Getting_Started)):
-            * The AppImage is designed to run on all Linux distros and is an easy option for
+            * The AppImage is designed to run on all Linux distros and is an easy, click-once option.
             * The `.deb` package is intended for Debian-based distros (e.g. Ubuntu). Install it with `sudo apt install -f ./SerialLoops-linux-x64-${{ env.SLVersion }}.deb`.
             * The `.rpm` package is intended for Red Hat distros (e.g. Fedora). Install it with `sudo dnf install ./SerialLoops-linux-x64-${{ env.SLVersion }}-1.fc39.x86_64.rpm`.
-            * You may also opt to simply use the binaries packaged in one of the `.tar.gz` archives; when doing so, ensure you install the OpenAL binaries so audio playback works.
-              - The "x64" `.tar.gz` includes the dotnet binary and thus only requires installing OpenAL.
-              - The "univ" `.tar.gz` can run on several different architectures (notably ARM64) as it does not include dotnet. Be sure to install [dotnet](https://dot.net/) for your distribution & architecture before running it.
+            * You may also opt to simply use the binaries packaged in the `.tar.gz` archive; when doing so, ensure you install the OpenAL binaries so audio playback works.

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -86,16 +86,16 @@ jobs:
       - name: Set up AppDir
         run: |
           sed -i "s/#VERSION#/$SLVersion/g" ./install/linux/appimage/AppImageBuilder.yml
-          mkdir -p ./AppDir/usr/bin
+          mkdir -p ./install/linux/appimage/AppDir/usr/bin
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
-          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./AppDir/usr/bin/
-          mkdir -p ./AppDir/usr/share/icons/default/scalable/apps/
-          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
+          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./install/linux/appimage/AppDir/usr/bin/
+          mkdir -p ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/
+          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
       - name: Build AppImage
         uses: addnab/docker-run-action@v3
         with:
-          image: appimagecrafters/appimage-builder:1.1.0
-          options: -v ${{ github.workspace }}:/work -w /work -e "SLVersion" -e "SLAssemblyVersion"
+          image: ghcr.io/haroohie-club/appimage-builder:main
+          options: -v ${{ github.workspace }}:/work -w /work
           run: appimage-builder --recipe=./install/linux/appimage/AppImageBuilder.yml --skip-tests
       - name: Upload AppImage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build AppImage
         uses: addnab/docker-run-action@v3
         with:
-          image: appimagecrafters/appimage-builder:latest
+          image: appimagecrafters/appimage-builder:1.1.0
           options: -v ${{ github.workspace }}:/work -w /work -e "SLVersion" -e "SLAssemblyVersion"
           run: appimage-builder --recipe=./install/linux/appimage/AppImageBuilder.yml --skip-tests
       - name: Upload AppImage

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -86,11 +86,11 @@ jobs:
       - name: Set up AppDir
         run: |
           sed -i "s/#VERSION#/$SLVersion/g" ./install/linux/appimage/AppImageBuilder.yml
-          mkdir -p ./install/linux/appimage/AppDir/usr/bin
+          mkdir -p ./AppDir/usr/bin
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
-          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./install/linux/appimage/AppDir/usr/bin/
-          mkdir -p ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/
-          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
+          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./AppDir/usr/bin/
+          mkdir -p ./AppDir/usr/share/icons/default/scalable/apps/
+          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
       - name: Build AppImage
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -86,15 +86,21 @@ jobs:
       - name: Set up AppDir
         run: |
           sed -i "s/#VERSION#/$SLVersion/g" ./install/linux/appimage/AppImageBuilder.yml
-          mkdir -p ./install/linux/appimage/AppDir/usr/bin
+          mkdir -p ./AppDir/usr/bin
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
-          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./install/linux/appimage/AppDir/usr/bin/
-          mkdir -p ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/
-          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
+          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./AppDir/usr/bin/
+          mkdir -p ./AppDir/usr/share/icons/default/scalable/apps/
+          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage@master
         with:
           recipe: "./install/linux/appimage/AppImageBuilder.yml"
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64-appimage
+          path: SerialLoops.AppImage
+          retention-days: 1
 
   linux-dpkg-tarball:
     runs-on: ubuntu-latest
@@ -238,12 +244,16 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [ linux-flatpak, linux-dpkg-tarball, linux-rpm, macos-pkg, windows ]
+    needs: [ linux-flatpak, linux-appimage, linux-dpkg-tarball, linux-rpm, macos-pkg, windows ]
     steps:
       - name: Download Linux flatpak
         uses: actions/download-artifact@v4.1.8
         with:
           name: linux-x64-flatpak
+      - name: Download Linux AppImage
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: linux-x64-appimage
       - name: Download Linux tarball
         uses: actions/download-artifact@v4.1.8
         with:
@@ -278,6 +288,7 @@ jobs:
           New-Item -Type Directory -Path release
           Get-ChildItem .
           Move-Item -Path SerialLoops.flatpak -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).flatpak
+          Move-Item -Path SerialLoops.AppImage -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).AppImage
           Move-Item -Path SerialLoops.tar.gz -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).tar.gz
           Move-Item -Path SerialLoops.deb -Destination release/SerialLoops-linux-x64-$($env:SLVersion).deb
           Move-Item -Path SerialLoops.rpm -Destination release/SerialLoops-linux-x64-$($env:SLVersion)-1.fc39.x86_64.rpm

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -121,7 +121,7 @@ jobs:
           pushd ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish
           tar -czvf ../SerialLoops.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
           popd
-      - name: Upload x64 tarball
+      - name: Upload tarball
         uses: actions/upload-artifact@v4
         with:
           name: linux-x64-tarball

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -85,6 +85,7 @@ jobs:
         run: dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 -r linux-x64 --self-contained /p:DebugType=None /p:DebugSymbols=false /p:PublishSingleFile=true
       - name: Set up AppDir
         run: |
+          sed -i "s/#VERSION#/$SLVersion/g" ./install/linux/appimage/AppImageBuilder.yml
           mkdir -p ./install/linux/appimage/AppDir/usr/bin
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
           mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./install/linux/appimage/AppDir/usr/bin/

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -104,7 +104,7 @@ jobs:
           path: SerialLoops.AppImage
           retention-days: 1
 
-  linux-dpkg-tarball:
+  linux-dpkg-tarball-full:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -119,13 +119,13 @@ jobs:
         run: |
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
           pushd ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish
-          tar -czvf ../SerialLoops.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
+          tar -czvf ../SerialLoops-full.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
           popd
-      - name: Upload tarball
+      - name: Upload full tarball
         uses: actions/upload-artifact@v4
         with:
-          name: linux-x64-tarball
-          path: src/SerialLoops/bin/Release/net8.0/linux-x64/SerialLoops.tar.gz
+          name: linux-x64-tarball-full
+          path: src/SerialLoops/bin/Release/net8.0/linux-x64/SerialLoops-full.tar.gz
           retention-days: 1
       - name: Create deb package
         shell: pwsh
@@ -170,6 +170,30 @@ jobs:
         with:
           name: linux-x64-rpm
           path: SerialLoops.rpm
+          retention-days: 1
+
+  linux-tarball-light:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build & Publish Serial Loops
+        run: dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 /p:DebugType=None /p:DebugSymbols=false /p:PublishSingleFile=true
+      - name: Create tarball
+        run: |
+          chmod +x ./src/SerialLoops/bin/Release/net8.0/publish/SerialLoops
+          pushd ./src/SerialLoops/bin/Release/net8.0/publish
+          tar -czvf ../SerialLoops-light.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
+          popd
+      - name: Upload light tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-univ-tarball-light
+          path: src/SerialLoops/bin/Release/net8.0/SerialLoops-light.tar.gz
           retention-days: 1
 
   macos-pkg:
@@ -246,7 +270,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [ linux-flatpak, linux-appimage, linux-dpkg-tarball, linux-rpm, macos-pkg, windows ]
+    needs: [ linux-flatpak, linux-appimage, linux-dpkg-tarball-full, linux-rpm, linux-tarball-light, macos-pkg, windows ]
     steps:
       - name: Download Linux flatpak
         uses: actions/download-artifact@v4.1.8
@@ -256,10 +280,14 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: linux-x64-appimage
-      - name: Download Linux tarball
+      - name: Download Linux full tarball
         uses: actions/download-artifact@v4.1.8
         with:
-          name: linux-x64-tarball
+          name: linux-x64-tarball-full
+      - name: Download Linux light tarball
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: linux-univ-tarball-light
       - name: Download Linux dpkg
         uses: actions/download-artifact@v4.1.8
         with:
@@ -291,7 +319,8 @@ jobs:
           Get-ChildItem .
           Move-Item -Path SerialLoops.flatpak -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).flatpak
           Move-Item -Path SerialLoops.AppImage -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).AppImage
-          Move-Item -Path SerialLoops.tar.gz -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).tar.gz
+          Move-Item -Path SerialLoops-full.tar.gz -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).tar.gz
+          Move-Item -Path SerialLoops-light.tar.gz -Destination release/SerialLoops-linux-univ-light-v$($env:SLVersion).tar.gz
           Move-Item -Path SerialLoops.deb -Destination release/SerialLoops-linux-x64-$($env:SLVersion).deb
           Move-Item -Path SerialLoops.rpm -Destination release/SerialLoops-linux-x64-$($env:SLVersion)-1.fc39.x86_64.rpm
           Move-Item -Path SerialLoops-osx-arm64.pkg -Destination release/SerialLoops-macOS-arm-v$($env:SLVersion)-installer.pkg
@@ -328,9 +357,12 @@ jobs:
             ### Linux
             We recommend using the provided Flatpak as it is the easiest to use. First, install [Flatpak](https://flatpak.org/setup/) if you haven't already. Then, download the Serial Loops Flatpak artifact and double click it or run `flatpak install` on it from the terminal. It will then install itself, bringing all the necessary dependencies with it.
 
-            You can also install the official [melonDS Flatpak from Flathub](https://flathub.org/apps/net.kuribo64.melonDS) to use as your emulator. We reocmmend installing it from the [flathub-beta](https://docs.flathub.org/docs/for-users/installation/#flathub-beta-repository) repository as that is where the most up-to-date versions tend to be pushed.
+            You can also install the official [melonDS Flatpak from Flathub](https://flathub.org/apps/net.kuribo64.melonDS) to use as your emulator. We recommend installing it from the [flathub-beta](https://docs.flathub.org/docs/for-users/installation/#flathub-beta-repository) repository as that is where the most up-to-date versions tend to be pushed.
 
-            If you would rather manually install, follow the below instructions:
+            The main benefit of the Flatpak is that it is packaged with devkitARM for ease of use. However, if you already have devkitARM installed or would like to use something more lightweight, we also provide the following options (all of which require [installing devkitARM yourself](https://devkitpro.org/wiki/Getting_Started)):
+            * The AppImage is designed to run on all Linux distros and is an easy option for
             * The `.deb` package is intended for Debian-based distros (e.g. Ubuntu). Install it with `sudo apt install -f ./SerialLoops-linux-x64-${{ env.SLVersion }}.deb`.
             * The `.rpm` package is intended for Red Hat distros (e.g. Fedora). Install it with `sudo dnf install ./SerialLoops-linux-x64-${{ env.SLVersion }}-1.fc39.x86_64.rpm`.
-            * For other Linux distros, please use the binaries packaged in the `.tar.gz` archive; when doing so, ensure you install the OpenAL binaries so audio playback works.
+            * You may also opt to simply use the binaries packaged in one of the `.tar.gz` archives; when doing so, ensure you install the OpenAL binaries so audio playback works.
+              - The "x64" `.tar.gz` includes the dotnet binary and thus only requires installing OpenAL.
+              - The "univ-light" `.tar.gz` does not include dotnet and thus has the smallest footprint. Be sure to install [dotnet](https://dot.net/) for your distribution before running it. This release is the only Linux release compatible with ARM64 machines.

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Build & Publish Serial Loops
-        run: dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 /p:DebugType=None /p:DebugSymbols=false /p:PublishSingleFile=true
+        run: dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 --no-self-contained /p:DebugType=None /p:DebugSymbols=false
       - name: Create tarball
         run: |
           chmod +x ./src/SerialLoops/bin/Release/net8.0/publish/SerialLoops

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -72,6 +72,29 @@ jobs:
           path: SerialLoops.flatpak
           retention-days: 1
 
+  linux-appimage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build & Publish Serial Loops
+        run: dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 -r linux-x64 --self-contained /p:DebugType=None /p:DebugSymbols=false /p:PublishSingleFile=true
+      - name: Set up AppDir
+        run: |
+          mkdir -p ./install/linux/appimage/AppDir/usr/bin
+          chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
+          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./install/linux/appimage/AppDir/usr/bin/
+          mkdir -p ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/
+          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
+      - name: Build AppImage
+        uses: AppImageCrafters/build-appimage@master
+        with:
+          recipe: "./install/linux/appimage/AppImageBuilder.yml"
+
   linux-dpkg-tarball:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -86,11 +86,11 @@ jobs:
       - name: Set up AppDir
         run: |
           sed -i "s/#VERSION#/$SLVersion/g" ./install/linux/appimage/AppImageBuilder.yml
-          mkdir -p ./AppDir/usr/bin
+          mkdir -p ./install/linux/appimage/AppDir/usr/bin
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
-          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./AppDir/usr/bin/
-          mkdir -p ./AppDir/usr/share/icons/default/scalable/apps/
-          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
+          mv ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/* ./install/linux/appimage/AppDir/usr/bin/
+          mkdir -p ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/
+          cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./install/linux/appimage/AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
       - name: Build AppImage
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -318,7 +318,7 @@ jobs:
             Simply download the Windows installer application and run it. It will walk you through installation, including installing the necessary dependencies. Alternatively, you can download the zip file for a portable application; however, dependencies are not included with this option.
 
             ### macOS
-            Pick the macOS pkg installer that fits your computer's architecture. Before executing it, you will need to open the Terminal application and run `xattr -cr /User/yourusernamehere/Downloads/pkginstallernamehere.pkg`, replacing "yourusernamehere" with your username and "pkginstallernamehere.pkg" with the appropriate pkg installer filename. Running this command makes it so that the pkg installer is runnable even though we don't codesign it.
+            Pick the macOS pkg installer that fits your computer's architecture. Before executing it, you will need to open the Terminal application and run `xattr -cr /User/yourusernamehere/Downloads/pkginstallernamehere.pkg`, replacing "yourusernamehere" with your username and "pkginstallernamehere.pkg" with the appropriate pkg installer filename. This is required because we currently don't codesign the installer, meaning macOS will refuse to run it without explicit approval from you.
 
             The pkg installer will guide you through installing Serial Loops and will automatically install the dependencies devkitARM and make if necessary.
 

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -104,7 +104,7 @@ jobs:
           path: SerialLoops.AppImage
           retention-days: 1
 
-  linux-dpkg-tarball-full:
+  linux-dpkg-tarball:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -119,13 +119,13 @@ jobs:
         run: |
           chmod +x ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish/SerialLoops
           pushd ./src/SerialLoops/bin/Release/net8.0/linux-x64/publish
-          tar -czvf ../SerialLoops-full.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
+          tar -czvf ../SerialLoops-x64.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
           popd
-      - name: Upload full tarball
+      - name: Upload x64 tarball
         uses: actions/upload-artifact@v4
         with:
-          name: linux-x64-tarball-full
-          path: src/SerialLoops/bin/Release/net8.0/linux-x64/SerialLoops-full.tar.gz
+          name: linux-x64-tarball
+          path: src/SerialLoops/bin/Release/net8.0/linux-x64/SerialLoops-x64.tar.gz
           retention-days: 1
       - name: Create deb package
         shell: pwsh
@@ -172,7 +172,7 @@ jobs:
           path: SerialLoops.rpm
           retention-days: 1
 
-  linux-tarball-light:
+  linux-tarball-univ:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -187,13 +187,13 @@ jobs:
         run: |
           chmod +x ./src/SerialLoops/bin/Release/net8.0/publish/SerialLoops
           pushd ./src/SerialLoops/bin/Release/net8.0/publish
-          tar -czvf ../SerialLoops-light.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
+          tar -czvf ../SerialLoops-univ.tar.gz --transform "s,^\.\/,SerialLoops-$SLVersion/," .
           popd
-      - name: Upload light tarball
+      - name: Upload universal tarball
         uses: actions/upload-artifact@v4
         with:
-          name: linux-univ-tarball-light
-          path: src/SerialLoops/bin/Release/net8.0/SerialLoops-light.tar.gz
+          name: linux-univ-tarball
+          path: src/SerialLoops/bin/Release/net8.0/SerialLoops-univ.tar.gz
           retention-days: 1
 
   macos-pkg:
@@ -270,7 +270,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [ linux-flatpak, linux-appimage, linux-dpkg-tarball-full, linux-rpm, linux-tarball-light, macos-pkg, windows ]
+    needs: [ linux-flatpak, linux-appimage, linux-dpkg-tarball, linux-rpm, linux-tarball-univ, macos-pkg, windows ]
     steps:
       - name: Download Linux flatpak
         uses: actions/download-artifact@v4.1.8
@@ -283,11 +283,11 @@ jobs:
       - name: Download Linux full tarball
         uses: actions/download-artifact@v4.1.8
         with:
-          name: linux-x64-tarball-full
-      - name: Download Linux light tarball
+          name: linux-x64-tarball
+      - name: Download Linux universal tarball
         uses: actions/download-artifact@v4.1.8
         with:
-          name: linux-univ-tarball-light
+          name: linux-univ-tarball
       - name: Download Linux dpkg
         uses: actions/download-artifact@v4.1.8
         with:
@@ -319,8 +319,8 @@ jobs:
           Get-ChildItem .
           Move-Item -Path SerialLoops.flatpak -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).flatpak
           Move-Item -Path SerialLoops.AppImage -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).AppImage
-          Move-Item -Path SerialLoops-full.tar.gz -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).tar.gz
-          Move-Item -Path SerialLoops-light.tar.gz -Destination release/SerialLoops-linux-univ-light-v$($env:SLVersion).tar.gz
+          Move-Item -Path SerialLoops-x64.tar.gz -Destination release/SerialLoops-linux-x64-v$($env:SLVersion).tar.gz
+          Move-Item -Path SerialLoops-univ.tar.gz -Destination release/SerialLoops-linux-univ-v$($env:SLVersion).tar.gz
           Move-Item -Path SerialLoops.deb -Destination release/SerialLoops-linux-x64-$($env:SLVersion).deb
           Move-Item -Path SerialLoops.rpm -Destination release/SerialLoops-linux-x64-$($env:SLVersion)-1.fc39.x86_64.rpm
           Move-Item -Path SerialLoops-osx-arm64.pkg -Destination release/SerialLoops-macOS-arm-v$($env:SLVersion)-installer.pkg
@@ -365,4 +365,4 @@ jobs:
             * The `.rpm` package is intended for Red Hat distros (e.g. Fedora). Install it with `sudo dnf install ./SerialLoops-linux-x64-${{ env.SLVersion }}-1.fc39.x86_64.rpm`.
             * You may also opt to simply use the binaries packaged in one of the `.tar.gz` archives; when doing so, ensure you install the OpenAL binaries so audio playback works.
               - The "x64" `.tar.gz` includes the dotnet binary and thus only requires installing OpenAL.
-              - The "univ-light" `.tar.gz` does not include dotnet and thus has the smallest footprint. Be sure to install [dotnet](https://dot.net/) for your distribution before running it. This release is the only Linux release compatible with ARM64 machines.
+              - The "univ" `.tar.gz` can run on several different architectures (notably ARM64) as it does not include dotnet. Be sure to install [dotnet](https://dot.net/) for your distribution & architecture before running it.

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -92,9 +92,11 @@ jobs:
           mkdir -p ./AppDir/usr/share/icons/default/scalable/apps/
           cp ./src/SerialLoops/Assets/Icons/AppIcon.svg ./AppDir/usr/share/icons/default/scalable/apps/club.haroohie.SerialLoops.svg
       - name: Build AppImage
-        uses: AppImageCrafters/build-appimage@master
+        uses: addnab/docker-run-action@v3
         with:
-          recipe: "./install/linux/appimage/AppImageBuilder.yml"
+          image: appimagecrafters/appimage-builder:latest
+          options: -v ${{ github.workspace }}:/work -e "SLVersion" -e "SLAssemblyVersion"
+          run: appimage-builder --recipe=./install/linux/appimage/AppImageBuilder.yml --skip-tests
       - name: Upload AppImage
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -95,7 +95,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: appimagecrafters/appimage-builder:latest
-          options: -v ${{ github.workspace }}:/work -e "SLVersion" -e "SLAssemblyVersion"
+          options: -v ${{ github.workspace }}:/work -w /work -e "SLVersion" -e "SLAssemblyVersion"
           run: appimage-builder --recipe=./install/linux/appimage/AppImageBuilder.yml --skip-tests
       - name: Upload AppImage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -318,7 +318,7 @@ jobs:
             Simply download the Windows installer application and run it. It will walk you through installation, including installing the necessary dependencies. Alternatively, you can download the zip file for a portable application; however, dependencies are not included with this option.
 
             ### macOS
-            Pick the macOS pkg installer that fits your computer's architecture. Before executing it, you will need to open the Terminal application and run `xattr -cr /User/yourusernamehere/Downloads/pkginstallernamehere.pkg`, replacing "yourusernamehere" with your username and "pkginstallernamehere.pkg" with the appropriate pkg installer filename. This is required because we currently don't codesign the installer, meaning macOS will refuse to run it without explicit approval from you.
+            Pick the macOS pkg installer that fits your computer's architecture. Before executing it, you will need to open the Terminal application and run `xattr -cr /User/yourusernamehere/Downloads/SerialLoops-macOS-[arm|x64]-${{ env.SLVersion }}-installer.pkg`, replacing "yourusernamehere" with your username and choosing between `arm` or `x64` as appropriate for the filename. This is required because we currently don't codesign the installer, meaning macOS will refuse to run it without explicit approval from you.
 
             The pkg installer will guide you through installing Serial Loops and will automatically install the dependencies devkitARM and make if necessary.
 

--- a/install/linux/appimage/AppImageBuilder.yml
+++ b/install/linux/appimage/AppImageBuilder.yml
@@ -58,5 +58,6 @@ AppDir:
       use_host_x: true
 AppImage:
   arch: x86_64
+  comp: gzip
   update-information: guess
   file_name: SerialLoops.AppImage

--- a/install/linux/appimage/AppImageBuilder.yml
+++ b/install/linux/appimage/AppImageBuilder.yml
@@ -59,3 +59,4 @@ AppDir:
 AppImage:
   arch: x86_64
   update-information: guess
+  file_name: SerialLoops.AppImage

--- a/install/linux/appimage/AppImageBuilder.yml
+++ b/install/linux/appimage/AppImageBuilder.yml
@@ -1,0 +1,61 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+AppDir:
+  path: /work/install/linux/appimage/AppDir
+  app_info:
+    id: club.haroohie.SerialLoops
+    name: Serial Loops
+    icon: club.haroohie.SerialLoops
+    version: 0.3.0
+    exec: usr/bin/SerialLoops
+    exec_args: $@
+  apt:
+    arch:
+    - amd64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic main restricted
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic universe
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-updates universe
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic multiverse
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-updates multiverse
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted
+        universe multiverse
+    - sourceline: deb http://security.ubuntu.com/ubuntu/ bionic-security main restricted
+    - sourceline: deb http://security.ubuntu.com/ubuntu/ bionic-security universe
+    - sourceline: deb http://security.ubuntu.com/ubuntu/ bionic-security multiverse
+    include:
+    - libc6:amd64
+  files:
+    include: []
+    exclude:
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*
+  test:
+    fedora-30:
+      image: appimagecrafters/tests-env:fedora-30
+      command: ./AppRun
+      use_host_x: true
+    debian-stable:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+      use_host_x: true
+    archlinux-latest:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+      use_host_x: true
+    centos-7:
+      image: appimagecrafters/tests-env:centos-7
+      command: ./AppRun
+      use_host_x: true
+    ubuntu-xenial:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+      use_host_x: true
+AppImage:
+  arch: x86_64
+  update-information: guess

--- a/install/linux/appimage/AppImageBuilder.yml
+++ b/install/linux/appimage/AppImageBuilder.yml
@@ -1,7 +1,7 @@
 # appimage-builder recipe see https://appimage-builder.readthedocs.io for details
 version: 1
 AppDir:
-  path: /work/install/linux/appimage/AppDir
+  path: install/linux/appimage/AppDir
   app_info:
     id: club.haroohie.SerialLoops
     name: Serial Loops

--- a/install/linux/appimage/AppImageBuilder.yml
+++ b/install/linux/appimage/AppImageBuilder.yml
@@ -27,6 +27,8 @@ AppDir:
     - sourceline: deb http://security.ubuntu.com/ubuntu/ bionic-security multiverse
     include:
     - libc6:amd64
+    - libopenal-dev:amd64
+    - make:amd64
   files:
     include: []
     exclude:

--- a/install/linux/appimage/AppImageBuilder.yml
+++ b/install/linux/appimage/AppImageBuilder.yml
@@ -6,7 +6,7 @@ AppDir:
     id: club.haroohie.SerialLoops
     name: Serial Loops
     icon: club.haroohie.SerialLoops
-    version: 0.3.0
+    version: #VERSION#
     exec: usr/bin/SerialLoops
     exec_args: $@
   apt:

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -100,9 +100,6 @@
     <Compile Update="Controls\SoundPlayerPanel.axaml.cs">
       <DependentUpon>SoundPlayerPanel.axaml</DependentUpon>
     </Compile>
-    <Compile Update="Program.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Compile>
     <Compile Update="Views\Dialogs\ProjectSettingsDialog.axaml.cs">
       <DependentUpon>ProjectSettingsDialog.axaml</DependentUpon>
       <SubType>Code</SubType>


### PR DESCRIPTION
This PR adds an AppImage artifact to the official release build. It's a neat one-click alternative to the tarballs and seems to work pretty well!

Closes #465.