### PR TITLE
Quick volume normalization fix

### DIFF
--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -573,7 +573,7 @@ public partial class Project
             {
                 tracker.Finished++;
                 BackgroundMusicItem bgmItem = new(bgm, i, this);
-                maxes.Add(bgmItem.GetWaveProvider(log, false).GetMaxAmplitude());
+                maxes.Add(bgmItem.GetWaveProvider(log, false).GetMaxAmplitude(log));
                 return bgmItem;
             }));
 

--- a/src/SerialLoops/ViewModels/Dialogs/BgmVolumePropertiesDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/BgmVolumePropertiesDialogViewModel.cs
@@ -68,7 +68,7 @@ public class BgmVolumePropertiesDialogViewModel : ViewModelBase
     private void Normalize()
     {
         VolumePreviewPlayer.Stop();
-        float volumeNormalizationFactor = _maxAmplitude / VolumePreview.Provider.GetMaxAmplitude();
+        float volumeNormalizationFactor = _maxAmplitude / VolumePreview.Provider.GetMaxAmplitude(_log);
         if (volumeNormalizationFactor < 1)
         {
             Volume *= volumeNormalizationFactor;


### PR DESCRIPTION
I observed a crash during project load when calculating the max volume. It seems rare enough to not worry about (for now). This fix at least keeps things from crashing.