### PR TITLE
Fixup subtitle position radio buttons in voiced line editor

### DIFF
--- a/src/SerialLoops/App.axaml
+++ b/src/SerialLoops/App.axaml
@@ -141,6 +141,25 @@
                 </ControlTemplate>
             </Setter>
         </Style>
+
+        <!--From https://github.com/AvaloniaUI/Avalonia/issues/3016-->
+        <!--Use Classes="RadioButtonListBox" in any ListBox to represent its items as RadioButtons-->
+        <Style Selector="ListBox.RadioButtonListBox">
+            <Setter Property="BorderBrush" Value="Transparent"/>
+        </Style>
+        <Style Selector="ListBox.RadioButtonListBox ListBoxItem">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate x:DataType="ListBoxItem">
+                        <Border Background="Transparent" >
+                            <RadioButton Content="{TemplateBinding ContentPresenter.Content}"
+                                         VerticalAlignment="Center"
+                                         IsChecked="{Binding Path=IsSelected,RelativeSource={RelativeSource TemplatedParent},Mode=TwoWay}"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Application.Styles>
 
     <Application.Resources>

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -8650,6 +8650,42 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Above Bottom.
+        /// </summary>
+        public static string Y_ABOVE_BOTTOM {
+            get {
+                return ResourceManager.GetString("Y_ABOVE_BOTTOM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Below Top.
+        /// </summary>
+        public static string Y_BELOW_TOP {
+            get {
+                return ResourceManager.GetString("Y_BELOW_TOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bottom.
+        /// </summary>
+        public static string Y_BOTTOM {
+            get {
+                return ResourceManager.GetString("Y_BOTTOM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Top.
+        /// </summary>
+        public static string Y_TOP {
+            get {
+                return ResourceManager.GetString("Y_TOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Yellow.
         /// </summary>
         public static string YELLOW {

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3074,4 +3074,16 @@ This action is irreversible.</value>
   <data name="Normalize" xml:space="preserve">
     <value>Normalize</value><comment>As in "normalize the audio volume so that max volume is similar to all other audio volumes"</comment>
   </data>
+  <data name="Y_TOP" xml:space="preserve">
+    <value>Top</value>
+  </data>
+  <data name="Y_BELOW_TOP" xml:space="preserve">
+    <value>Below Top</value>
+  </data>
+  <data name="Y_ABOVE_BOTTOM" xml:space="preserve">
+    <value>Above Bottom</value>
+  </data>
+  <data name="Y_BOTTOM" xml:space="preserve">
+    <value>Bottom</value>
+  </data>
 </root>

--- a/src/SerialLoops/ViewModels/Editors/VoicedLineEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/VoicedLineEditorViewModel.cs
@@ -102,61 +102,18 @@ public class VoicedLineEditorViewModel : EditorViewModel
     }
 
     private VoiceMapEntry.YPosition _yPos;
+    public ObservableCollection<LocalizedSubtitlePosition> SubtitlePositions { get; } =
+        new(Enum.GetValues<VoiceMapEntry.YPosition>().Select(p => new LocalizedSubtitlePosition(p)));
 
-    public bool TopY
+    public LocalizedSubtitlePosition SubtitlePosition
     {
-        get => _yPos == VoiceMapEntry.YPosition.TOP;
+        get => SubtitlePositions.FirstOrDefault(p => p.Position == _yPos);
         set
         {
-            if (_voiceMapEntry is not null && value)
-            {
-                _yPos = VoiceMapEntry.YPosition.TOP;
-                _voiceMapEntry.YPos = _yPos;
-                UpdatePreview();
-                Description.UnsavedChanges = true;
-            }
-        }
-    }
-    public bool BelowTopY
-    {
-        get => _yPos == VoiceMapEntry.YPosition.BELOW_TOP;
-        set
-        {
-            if (_voiceMapEntry is not null && value)
-            {
-                _yPos = VoiceMapEntry.YPosition.BELOW_TOP;
-                _voiceMapEntry.YPos = _yPos;
-                UpdatePreview();
-                Description.UnsavedChanges = true;
-            }
-        }
-    }
-    public bool AboveBottomY
-    {
-        get => _yPos == VoiceMapEntry.YPosition.ABOVE_BOTTOM;
-        set
-        {
-            if (_voiceMapEntry is not null && value)
-            {
-                _yPos = VoiceMapEntry.YPosition.ABOVE_BOTTOM;
-                _voiceMapEntry.YPos = _yPos;
-                UpdatePreview();
-                Description.UnsavedChanges = true;
-            }
-        }
-    }
-    public bool BottomY
-    {
-        get => _yPos == VoiceMapEntry.YPosition.BOTTOM;
-        set
-        {
-            if (_voiceMapEntry is not null && value)
-            {
-                _yPos = VoiceMapEntry.YPosition.BOTTOM;
-                _voiceMapEntry.YPos = _yPos;
-                UpdatePreview();
-                Description.UnsavedChanges = true;
-            }
+            _yPos = value.Position;
+            _voiceMapEntry.YPos = _yPos;
+            UpdatePreview();
+            Description.UnsavedChanges = true;
         }
     }
 
@@ -321,4 +278,12 @@ public class LocalizedDialogueColor(DialogueColor color) : ReactiveObject
     public DialogueColor Color { get; set; } = color;
 
     public string DisplayText => Strings.ResourceManager.GetString(Color.ToString());
+}
+
+public class LocalizedSubtitlePosition(VoiceMapEntry.YPosition position) : ReactiveObject
+{
+    [Reactive]
+    public VoiceMapEntry.YPosition Position { get; set; } = position;
+
+    public override string ToString() => Strings.ResourceManager.GetString($"Y_{Position}");
 }

--- a/src/SerialLoops/Views/Editors/VoicedLineEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/VoicedLineEditorView.axaml
@@ -6,6 +6,7 @@
              xmlns:assets="using:SerialLoops.Assets"
              xmlns:controls="using:SerialLoops.Controls"
              xmlns:utility="using:SerialLoops.Utility"
+             xmlns:system="using:System"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:VoicedLineEditorViewModel"
              x:Class="SerialLoops.Views.Editors.VoicedLineEditorView">
@@ -44,12 +45,9 @@
                     <CheckBox Content="{x:Static assets:Strings.Force_Drop_Shadow}" IsChecked="{Binding ForceDropShadow}"/>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="3">
                         <TextBlock Text="{x:Static assets:Strings.Screen_Position}"/>
-                        <StackPanel Orientation="Vertical" Spacing="2">
-                            <RadioButton GroupName="YPos"  IsChecked="{Binding TopY, Mode=TwoWay}" Content="{x:Static assets:Strings.Top}"/>
-                            <RadioButton GroupName="YPos" IsChecked="{Binding BelowTopY, Mode=TwoWay}" Content="{x:Static assets:Strings.Below_Top}"/>
-                            <RadioButton GroupName="YPos" IsChecked="{Binding AboveBottomY, Mode=TwoWay}" Content="{x:Static assets:Strings.Above_Bottom}"/>
-                            <RadioButton GroupName="YPos" IsChecked="{Binding BottomY, Mode=TwoWay}" Content="{x:Static assets:Strings.Bottom}"/>
-                        </StackPanel>
+                        <ListBox ItemsSource="{Binding SubtitlePositions}"
+                                 SelectedItem="{Binding SubtitlePosition}"
+                                 Classes="RadioButtonListBox"/>
                     </StackPanel>
                 </StackPanel>
             </StackPanel>


### PR DESCRIPTION
Previously, these radio buttons wouldn't properly fire as their values changed. I changed them to be a styled ListBox and now they work perfectly.

Fixes #457.