### PR TITLE
Fix error with saving chess script files 

### DIFF
--- a/src/SerialLoops.Lib/Util/Extensions.cs
+++ b/src/SerialLoops.Lib/Util/Extensions.cs
@@ -248,6 +248,10 @@ public static class Extensions
         {
             for (short i = 0; i < evt.ConditionalsSection.Objects.Count; i++)
             {
+                if (evt.ConditionalsSection.Objects[i] is null)
+                {
+                    continue;
+                }
                 if (!conditionalUsedIndices.Select(idx => idx.Index).Contains(i))
                 {
                     evt.ConditionalsSection.Objects.RemoveAt(i);

--- a/src/SerialLoops/Utility/SLConverters.cs
+++ b/src/SerialLoops/Utility/SLConverters.cs
@@ -166,7 +166,7 @@ public class GapClipMaskConverter : IMultiValueConverter
 {
     public static readonly GapClipMaskConverter Instance = new();
 
-    public object Convert(IList<object?> values, Type targetType, object? parameter,
+    public object Convert(IList<object> values, Type targetType, object parameter,
         CultureInfo culture)
     {
         if (values is not [Rect bounds, Rect gap]

--- a/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml
+++ b/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml
@@ -48,7 +48,7 @@
                     Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center">
             <Image Source="{DynamicResource ColoredIconPath}" Opacity="0.65" Width="250" Height="250" />
             <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="7">
-                <TextBlock Classes="secondary" Text="{x:Static assets:Strings.Open_an_item_using_the_explorer_to_start_editing_}" />
+                <TextBlock Classes="secondary" Text="{x:Static assets:Strings.Open_an_item_using_the_explorer_to_start_editing_}" HorizontalAlignment="Center" />
                 <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto" HorizontalAlignment="Center">
                     <TextBlock Margin="5 3" Grid.Column="0" Grid.Row="0" Classes="secondary" HorizontalAlignment="Right" Text="{x:Static assets:Strings.Save_Project}" />
                     <StackPanel Margin="5 3" Grid.Column="1" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="4">


### PR DESCRIPTION
Fixes #400.

The issue was garbage collection removing a conditional that shouldn't have been removed, it seems. This makes it so that null conditionals (which should never be created by the user) don't get removed.

Also adds fixes for two warnings that popped up.