### PR TITLE
Add working project migration to Avalonia branch

### DIFF
--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -133,7 +133,7 @@ public partial class Project
             Directory.CreateDirectory(BaseDirectory);
             Directory.CreateDirectory(IterativeDirectory);
             Directory.CreateDirectory(Path.Combine(MainDirectory, "font"));
-            File.Copy(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "charset.json"), Path.Combine(MainDirectory, "font", "charset.json"));
+            File.Copy(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "charset.json"), Path.Combine(MainDirectory, "font", "charset.json"), overwrite: true);
         }
         catch (Exception ex)
         {
@@ -1038,7 +1038,7 @@ public partial class Project
         Items.Where(i => i.Type == ItemType.Script).Cast<ScriptItem>().ToList().ForEach(s => s.UpdateEventTableInfo(EventTableFile.EvtTbl));
     }
 
-    public void MigrateProject(string newRom, ILogger log, IProgressTracker tracker)
+    public void MigrateProject(string newRom, Config config, ILogger log, IProgressTracker tracker)
     {
         log.Log($"Attempting to migrate base ROM to {newRom}");
 
@@ -1049,6 +1049,8 @@ public partial class Project
         IO.CopyFiles(Path.Combine(tempDir, "data", "vce"), Path.Combine(BaseDirectory, "original", "vce"), log, "*.bin");
         IO.CopyFiles(Path.Combine(tempDir, "overlay"), Path.Combine(BaseDirectory, "original", "overlay"), log, "*.bin");
         IO.CopyFiles(Path.Combine(tempDir, "data", "movie"), Path.Combine(BaseDirectory, "rom", "data", "movie"), log, "*.mods");
+
+        Build.BuildBase(this, config, log, tracker);
 
         Directory.Delete(tempDir, true);
     }

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -4583,6 +4583,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Migrate.
+        /// </summary>
+        public static string Migrate {
+            get {
+                return ResourceManager.GetString("Migrate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Migrate Project.
         /// </summary>
         public static string Migrate_Project {

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3074,4 +3074,7 @@ This action is irreversible.</value>
   <data name="Normalize" xml:space="preserve">
     <value>Normalize</value><comment>As in "normalize the audio volume so that max volume is similar to all other audio volumes"</comment>
   </data>
+  <data name="Migrate" xml:space="preserve">
+    <value>Migrate</value>
+  </data>
 </root>

--- a/src/SerialLoops/ViewModels/Dialogs/ProjectCreationDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/ProjectCreationDialogViewModel.cs
@@ -26,17 +26,23 @@ public partial class ProjectCreationDialogViewModel : ViewModelBase
     [Reactive]
     public string RomPath { get; set; } = Strings.None_Selected;
 
+    public bool Migrate { get; set; }
+
+    public string Title => Migrate ? Strings.Migrate_Project : Strings.Create_New_Project;
+    public string ButtonText => Migrate ? Strings.Migrate : Strings.Create;
+
     public ICommand PickRomCommand { get; set; }
     public ICommand CreateCommand { get; set; }
     public ICommand CancelCommand { get; set; }
 
-    public ProjectCreationDialogViewModel(Config config, MainWindowViewModel mainWindow, ILogger log)
+    public ProjectCreationDialogViewModel(Config config, MainWindowViewModel mainWindow, ILogger log, bool migrate = false)
     {
         _log = log;
         _mainWindow = mainWindow;
         _config = config;
+        Migrate = migrate;
         PickRomCommand = ReactiveCommand.CreateFromTask(PickRom);
-        CreateCommand = ReactiveCommand.CreateFromTask<ProjectCreationDialog>(CreateProject);
+        CreateCommand = Migrate ? ReactiveCommand.Create<ProjectCreationDialog>(dialog => dialog.Close((RomPath, LanguageTemplateCode))) : ReactiveCommand.CreateFromTask<ProjectCreationDialog>(CreateProject);
         CancelCommand = ReactiveCommand.Create<ProjectCreationDialog>((dialog) => dialog.Close());
     }
 

--- a/src/SerialLoops/Views/Dialogs/ProjectCreationDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/ProjectCreationDialog.axaml
@@ -14,7 +14,7 @@
         x:DataType="vm:ProjectCreationDialogViewModel"
         x:Class="SerialLoops.Views.Dialogs.ProjectCreationDialog"
         Icon="/Assets/serial-loops.ico"
-        Title="{x:Static assets:Strings.Create_New_Project}"
+        Title="{Binding Title}"
         Name="PcDialog">
     <Panel>
         <controls:AcrylicBorderHandler/>
@@ -22,7 +22,7 @@
         <StackPanel Spacing="10" HorizontalAlignment="Center" Margin="10 30">
             <HeaderedContentControl Header="{x:Static assets:Strings.Project_Options}" MinWidth="300" MinHeight="100">
                 <StackPanel Spacing="10" VerticalAlignment="Center" Orientation="Vertical">
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" Spacing="10">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" Spacing="10" IsVisible="{Binding !Migrate}">
                         <TextBlock Text="{x:Static assets:Strings.Name}"/>
                         <TextBox Name="NameBox" Watermark="Haroohie" Width="150" Text="{Binding ProjectName}"/>
                     </StackPanel>
@@ -54,7 +54,7 @@
                 </StackPanel>
             </HeaderedContentControl>
             <StackPanel Orientation="Horizontal" Margin="5" Spacing="10">
-                <Button Content="{x:Static assets:Strings.Create}" Command="{Binding CreateCommand}" CommandParameter="{Binding #PcDialog}"
+                <Button Content="{Binding ButtonText}" Command="{Binding CreateCommand}" CommandParameter="{Binding #PcDialog}"
                         Name="CreateButton"/>
                 <Button Content="{x:Static assets:Strings.Cancel}" Command="{Binding CancelCommand}" CommandParameter="{Binding #PcDialog}"
                         Name="CancelButton"/>


### PR DESCRIPTION
Fixes #351.

Project migration was broken in the Eto branch. This gets it working in Avalonia. Made some changes to make the project creation dialog reusable by project migration so that we can also allow migrating ROMs across languages as well.