### PR TITLE
Add reopening workspace functionality to Avalonia branch and improve tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,18 +34,11 @@ jobs:
       arguments: -f $(targetFramework)
     displayName: Build project
 
-  - pwsh: |
-      Invoke-WebRequest -Uri https://haroohie.nyc3.cdn.digitaloceanspaces.com/bootstrap/serial-loops/test-assets.zip -OutFile $(Build.ArtifactStagingDirectory)/test-assets.zip
-      Expand-Archive -Path $(Build.ArtifactStagingDirectory)/test-assets.zip -DestinationPath $(Build.ArtifactStagingDirectory)/test-assets
-    displayName: Download test assets
-
   - task: DotNetCoreCLI@2
     inputs:
       command: 'test'
       projects: $(Build.SourcesDirectory)/test/SerialLoops.Tests.Headless/SerialLoops.Tests.Headless.csproj
       arguments: -f $(targetFramework) --filter "Name !~ BackgroundMusicEditor_ReplacementAndRestoreWork"
       publishTestResults: true
-    env:
-      ASSETS_DIRECTORY: $(Build.ArtifactStagingDirectory)/test-assets/
     displayName: Run tests
     condition: eq(variables.imageName, 'windows-latest')

--- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
@@ -77,8 +77,6 @@ public class ConfigFactory : IConfigFactory
             devkitArmDir = "";
         }
 
-        // TODO: Probably make a way of defining "presets" of common emulator install paths on different platforms.
-        // Ideally this should be as painless as possible.
         bool emulatorExists = false;
         string emulatorPath = string.Empty;
         string emulatorFlatpak = string.Empty;

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -1078,6 +1078,7 @@ public partial class Project
         {
             return null;
         }
+
         return Items.FirstOrDefault(i => i.DisplayName == name);
     }
 

--- a/src/SerialLoops/ViewModels/Dialogs/UpdateAvailableDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/UpdateAvailableDialogViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Drawing;
 using System.Windows.Input;
 using HaruhiChokuretsuLib.Util;
 using ReactiveUI;

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -14,6 +14,7 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using HaruhiChokuretsuLib.Archive;
 using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Archive.Event;
@@ -226,9 +227,41 @@ public partial class MainWindowViewModel : ViewModelBase
 
         Title = $"{BASE_TITLE} - {project.Name}";
 
-        //LoadCachedData(project, tracker);
+        LoadCachedData();
 
         Window.MainContent.Content = ProjectPanel;
+    }
+
+    private void LoadCachedData()
+    {
+        try
+        {
+            if (!CurrentConfig.RememberProjectWorkspace ||
+                !ProjectsCache.RecentWorkspaces.TryGetValue(OpenProject.ProjectFile, out RecentWorkspace previousWorkspace))
+            {
+                return;
+            }
+
+            foreach (ItemDescription item in previousWorkspace.Tabs.Select(itemName => OpenProject.FindItem(itemName)))
+            {
+                if (item is not null)
+                {
+                    Dispatcher.UIThread.Invoke(() => EditorTabs.OpenTab(item));
+                }
+            }
+
+            if (EditorTabs.Tabs.Count > 0)
+            {
+                EditorTabs.SelectedTab = EditorTabs.Tabs[previousWorkspace.SelectedTabIndex];
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogException(Strings.Failed_to_load_cached_data, ex);
+            ProjectsCache.RecentWorkspaces.Remove(OpenProject.ProjectFile);
+            ProjectsCache.RecentProjects.Remove(OpenProject.ProjectFile);
+            ProjectsCache.Save(Log);
+        }
     }
 
     public async Task<bool> CloseProject_Executed(WindowClosingEventArgs e)
@@ -280,11 +313,11 @@ public partial class MainWindowViewModel : ViewModelBase
             }
 
             // Record open items
-            List<string> openItems = EditorTabs.Tabs.Cast<EditorViewModel>()
-                .Select(e => e.Description)
-                .Select(i => i.Name)
+            List<string> openItems = EditorTabs.Tabs
+                .Select(t => t.Description)
+                .Select(i => i.DisplayName)
                 .ToList();
-            ProjectsCache.CacheRecentProject(OpenProject.ProjectFile, openItems);
+            ProjectsCache.CacheRecentProject(OpenProject.ProjectFile, openItems, EditorTabs.Tabs.IndexOf(EditorTabs.SelectedTab));
             ProjectsCache.HadProjectOpenOnLastClose = true;
             ProjectsCache.Save(Log);
         }

--- a/test/SerialLoops.Tests.Headless/ConfigFactoryMock.cs
+++ b/test/SerialLoops.Tests.Headless/ConfigFactoryMock.cs
@@ -23,6 +23,7 @@ public class ConfigFactoryMock(string configPath) : IConfigFactory
         else
         {
             Config newConfig = ConfigFactory.GetDefault(log);
+            newConfig.RememberProjectWorkspace = false;
             newConfig.ConfigPath = _configPath;
             newConfig.CurrentCultureName = "en-US"; // there's a chance that the locale will be something we don't recognize (like Invariant culture) so we force this for tests
             newConfig.InitializeHacks(log);

--- a/test/SerialLoops.Tests.Headless/Controls/ItemLinkTests.cs
+++ b/test/SerialLoops.Tests.Headless/Controls/ItemLinkTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
@@ -27,8 +28,9 @@ public class ItemLinkTests
     private Project _project;
     private ExtraFile _extra;
 
-    [SetUp]
-    public void Setup()
+    // TODO: once https://github.com/AvaloniaUI/Avalonia/pull/18306 merges, put this attribute back and remove the direct call
+    // [SetUp]
+    public async Task Setup()
     {
         _log = new();
         if (Path.Exists("ui_vals.json"))
@@ -37,7 +39,7 @@ public class ItemLinkTests
         }
         else
         {
-            _uiVals = new() { AssetsDirectory = Environment.GetEnvironmentVariable("ASSETS_DIRECTORY")!, };
+            _uiVals = await UiVals.DownloadTestAssets();
         }
 
         Mock<Project> projectMock = new();
@@ -55,8 +57,10 @@ public class ItemLinkTests
     }
 
     [AvaloniaTest]
-    public void ItemLink_ClickOpensTab()
+    public async Task ItemLink_ClickOpensTab()
     {
+        await Setup();
+
         EditorTabsPanelViewModel tabs = new(_mainWindowViewModel, _project, _log);
         BackgroundItem bg = new("BG_TEST");
         ItemLink link = new() { Tabs = tabs, Item = bg };

--- a/test/SerialLoops.Tests.Headless/Controls/ItemLinkTests.cs
+++ b/test/SerialLoops.Tests.Headless/Controls/ItemLinkTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Avalonia.Controls;

--- a/test/SerialLoops.Tests.Headless/Editors/BackgroundEditorTests.cs
+++ b/test/SerialLoops.Tests.Headless/Editors/BackgroundEditorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
@@ -37,23 +38,23 @@ public class BackgroundEditorTests
     private ExtraFile _extra;
 
     [OneTimeSetUp]
-    public void OneTimeSetup()
+    public async Task OneTimeSetup()
     {
         _log = new();
         if (Path.Exists("ui_vals.json"))
         {
-            _uiVals = JsonSerializer.Deserialize<UiVals>(File.ReadAllText("ui_vals.json"));
+            _uiVals = JsonSerializer.Deserialize<UiVals>(await File.ReadAllTextAsync("ui_vals.json"));
         }
         else
         {
-            _uiVals = UiVals.DownloadTestAssets().GetAwaiter().GetResult();
+            _uiVals = await UiVals.DownloadTestAssets();
         }
 
         _extra = new();
-        _extra.Initialize(File.ReadAllBytes(Path.Combine(_uiVals.AssetsDirectory, "EXTRA.bin")), 0, _log);
+        _extra.Initialize(await File.ReadAllBytesAsync(Path.Combine(_uiVals.AssetsDirectory, "EXTRA.bin")), 0, _log);
 
         _bgTableFile = new();
-        _bgTableFile.Initialize(File.ReadAllBytes(Path.Combine(_uiVals.AssetsDirectory, "BGTBL.bin")), 1, _log);
+        _bgTableFile.Initialize(await File.ReadAllBytesAsync(Path.Combine(_uiVals.AssetsDirectory, "BGTBL.bin")), 1, _log);
     }
 
     [SetUp]

--- a/test/SerialLoops.Tests.Headless/Editors/BackgroundEditorTests.cs
+++ b/test/SerialLoops.Tests.Headless/Editors/BackgroundEditorTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
@@ -47,10 +48,7 @@ public class BackgroundEditorTests
         }
         else
         {
-            _uiVals = new()
-            {
-                AssetsDirectory = Environment.GetEnvironmentVariable("ASSETS_DIRECTORY")!,
-            };
+            _uiVals = UiVals.DownloadTestAssets().GetAwaiter().GetResult();
         }
 
         _extra = new();

--- a/test/SerialLoops.Tests.Headless/Editors/BackgroundEditorTests.cs
+++ b/test/SerialLoops.Tests.Headless/Editors/BackgroundEditorTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;

--- a/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
+++ b/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
@@ -36,20 +37,20 @@ public class BackgroundMusicEditorTests
     private ExtraFile _extra;
 
     [OneTimeSetUp]
-    public void OneTimeSetup()
+    public async Task OneTimeSetup()
     {
         _log = new();
         if (Path.Exists("ui_vals.json"))
         {
-            _uiVals = JsonSerializer.Deserialize<UiVals>(File.ReadAllText("ui_vals.json"));
+            _uiVals = JsonSerializer.Deserialize<UiVals>(await File.ReadAllTextAsync("ui_vals.json"));
         }
         else
         {
-            _uiVals = UiVals.DownloadTestAssets().GetAwaiter().GetResult();
+            _uiVals = await UiVals.DownloadTestAssets();
         }
 
         _extra = new();
-        _extra.Initialize(File.ReadAllBytes(Path.Combine(_uiVals.AssetsDirectory, "EXTRA.bin")), 0, _log);
+        _extra.Initialize(await File.ReadAllBytesAsync(Path.Combine(_uiVals.AssetsDirectory, "EXTRA.bin")), 0, _log);
     }
 
     [SetUp]

--- a/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
+++ b/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
@@ -46,10 +47,7 @@ public class BackgroundMusicEditorTests
         }
         else
         {
-            _uiVals = new()
-            {
-                AssetsDirectory = Environment.GetEnvironmentVariable("ASSETS_DIRECTORY")!,
-            };
+            _uiVals = UiVals.DownloadTestAssets().GetAwaiter().GetResult();
         }
 
         _extra = new();

--- a/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
+++ b/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;

--- a/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
+++ b/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
@@ -42,10 +42,7 @@ public class EditorTabsPanelTests
         }
         else
         {
-            _uiVals = new()
-            {
-                AssetsDirectory = Environment.GetEnvironmentVariable("ASSETS_DIRECTORY")!,
-            };
+            _uiVals = UiVals.DownloadTestAssets().GetAwaiter().GetResult();
         }
 
         _extra = new();

--- a/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
+++ b/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
@@ -32,23 +33,23 @@ public class EditorTabsPanelTests
     private ExtraFile _extra;
 
     [OneTimeSetUp]
-    public void OneTimeSetup()
+    public async Task OneTimeSetup()
     {
         _log = new();
         if (Path.Exists("ui_vals.json"))
         {
-            _uiVals = JsonSerializer.Deserialize<UiVals>(File.ReadAllText("ui_vals.json"));
+            _uiVals = JsonSerializer.Deserialize<UiVals>(await File.ReadAllTextAsync("ui_vals.json"));
         }
         else
         {
-            _uiVals = UiVals.DownloadTestAssets().GetAwaiter().GetResult();
+            _uiVals = await UiVals.DownloadTestAssets();
         }
 
         _extra = new();
-        _extra.Initialize(File.ReadAllBytes(Path.Combine(_uiVals.AssetsDirectory, "EXTRA.bin")), 0, _log);
+        _extra.Initialize(await File.ReadAllBytesAsync(Path.Combine(_uiVals.AssetsDirectory, "EXTRA.bin")), 0, _log);
 
         _bgTableFile = new();
-        _bgTableFile.Initialize(File.ReadAllBytes(Path.Combine(_uiVals.AssetsDirectory, "BGTBL.bin")), 1, _log);
+        _bgTableFile.Initialize(await File.ReadAllBytesAsync(Path.Combine(_uiVals.AssetsDirectory, "BGTBL.bin")), 1, _log);
     }
 
     [SetUp]

--- a/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
+++ b/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;

--- a/test/SerialLoops.Tests.Shared/UiVals.cs
+++ b/test/SerialLoops.Tests.Shared/UiVals.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/test/SerialLoops.Tests.Shared/UiVals.cs
+++ b/test/SerialLoops.Tests.Shared/UiVals.cs
@@ -1,6 +1,11 @@
 ﻿using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Reflection;
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace SerialLoops.Tests.Shared;
 
@@ -8,4 +13,16 @@ public class UiVals
 {
     public string AssetsDirectory { get; set; } = string.Empty;
     [JsonIgnore] public static string? BaseDirectory => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+    public static async Task<UiVals> DownloadTestAssets()
+    {
+        HttpClient client = new() { DefaultRequestHeaders = { Accept = { new("*/*") }}};
+        await using Stream zipStream = await client.GetStreamAsync(
+            "https://haroohie.nyc3.cdn.digitaloceanspaces.com/bootstrap/serial-loops/test-assets.zip");
+        ZipArchive archive = new(zipStream);
+        UiVals uiVals = new() { AssetsDirectory = Path.Join(BaseDirectory ?? string.Empty, "assets") };
+        archive.ExtractToDirectory(uiVals.AssetsDirectory);
+        await File.WriteAllTextAsync("ui_vals.json", JsonSerializer.Serialize(uiVals));
+        return uiVals;
+    }
 }


### PR DESCRIPTION
This is one of the last pieces of functionality to port over from Eto. I've also added a shiny new feature which is that it now stores the specific tab you had open when you closed the workspace and reopens to that specific tab. Spiffy!

Additionally, because the tests broke on this, I took the chance to improve our tests so that when you run them locally, they auto-download test assets. As a result, I found a bug in Avalonia's NUnit package that I fixed! Yay!