### PR TITLE
Disable horizontal scrolling on ItemExplorerPanel

### DIFF
--- a/src/SerialLoops/App.axaml
+++ b/src/SerialLoops/App.axaml
@@ -37,7 +37,6 @@
         <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
         <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
-        <StyleInclude Source="avares://Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml" />
 
         <!-- Toolbar styling -->
         <Style Selector="Button.ToolbarButton">

--- a/src/SerialLoops/Views/Panels/ItemExplorerPanel.axaml
+++ b/src/SerialLoops/Views/Panels/ItemExplorerPanel.axaml
@@ -22,7 +22,7 @@
             <Button Command="{Binding SearchProjectCommand}" Width="30" Height="30">...</Button>
         </StackPanel>
         <TreeDataGrid Grid.Row="1" Margin="5" ShowColumnHeaders="False" CanUserResizeColumns="False" Name="Viewer" Source="{Binding Source}"
-                      KeyUp="Viewer_OnKeyUp">
+                      KeyUp="Viewer_OnKeyUp" Loaded="Viewer_OnLoaded">
             <i:Interaction.Behaviors>
                 <ia:EventTriggerBehavior EventName="DoubleTapped" SourceObject="{Binding #Viewer}">
                     <ia:InvokeCommandAction Command="{Binding OpenItemCommand}" CommandParameter="{Binding #Viewer}"/>

--- a/src/SerialLoops/Views/Panels/ItemExplorerPanel.axaml.cs
+++ b/src/SerialLoops/Views/Panels/ItemExplorerPanel.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using SerialLoops.ViewModels.Panels;
 
 namespace SerialLoops.Views.Panels;
@@ -26,5 +28,10 @@ public partial class ItemExplorerPanel : Panel
         {
             ((ItemExplorerPanelViewModel)DataContext)?.OpenItemCommand.Execute(Viewer);
         }
+    }
+
+    private void Viewer_OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ((ScrollViewer)Viewer.Scroll)!.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
     }
 }


### PR DESCRIPTION
There was an annoying thing where if you clicked an item with a long title, the item explorer panel would bump to the right. This disables horizontal scrolling on that panel, fixing this issue.