### PR TITLE
Fixup app crash on Linux (maybe Mac too?)

### DIFF
--- a/src/SerialLoops/App.axaml
+++ b/src/SerialLoops/App.axaml
@@ -63,6 +63,11 @@
                     <Setter Property="Margin" Value="10 5 0 0"/>
                 </Style>
             </OnPlatform.Windows>
+            <OnPlatform.Default>
+                <Style Selector="NativeMenuBar">
+                    <Setter Property="Margin" Value="0"/>
+                </Style>
+            </OnPlatform.Default>
         </OnPlatform>
 
         <!-- Text styling -->


### PR DESCRIPTION
Turns out if you don't have an `OnPlatform.Default` definition, you get a null reference when attempting to load the app. Very cool and difficult to debug! Anyway, this fixes that.