### PR TITLE
Add self-documentation to editors and some dialogs

### DIFF
--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -385,7 +385,7 @@ jobs:
             The pkg installer will guide you through installing Serial Loops and will automatically install the dependencies devkitARM and make if necessary.
 
             #### Which macOS pkg installer should I choose?
-            If your Mac is newer, you will probably want the ARM installer. If it is older, you may want the x64 one. If unsure, download the ARM one first and attempt to run it &ndash; it will throw an error saying it can't be run on this computer if your computer is not able to run it. If that's the case, download the x64 one instead.
+            If your Mac is newer, you will probably want the ARM installer. If it is older, you may want the x64 one. To make sure, go to Settings → About and check your chip. If it is an Intel, you want the x64 installer. If it is an Apple chip, you want the ARM installer.
 
             ### Linux
             We recommend using the provided Flatpak as it is the easiest to use. First, install [Flatpak](https://flatpak.org/setup/) if you haven't already. Then, download the Serial Loops Flatpak artifact and double click it or run `flatpak install` on it from the terminal. It will then install itself, bringing all the necessary dependencies with it.

--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -516,7 +516,7 @@ public class ScriptItem : Item
                 continue;
             }
 
-            if (commands[i].Verb == CommandVerb.BG_SCROLL)
+            if (commands[i].Verb == CommandVerb.BG_SCROLL && bgScrollCommand is null)
             {
                 bgScrollCommand = commands[i];
                 continue;

--- a/src/SerialLoops.Lib/Items/SystemTextureItem.cs
+++ b/src/SerialLoops.Lib/Items/SystemTextureItem.cs
@@ -17,8 +17,9 @@ public class SystemTextureItem : Item
     public int Width { get; set; }
     public int Height { get; set; }
 
-    private const string COMMON_PALETTE = "#ff00f800,#fff00080,#ff80f000,#ff00f080,#ff00f800,#ff00f800,#ff00f800,#ff482828,#ff684038,#ff905850,#ffb88070,#ffc8a080,#ffd8b090,#ffe8c8a0,#fff8d8b0,#fff8e8c0,#fff00000,#fff02800,#fff04000,#fff05000,#fff06000,#fff07000,#fff08000,#fff09000,#fff0a000,#fff0b000,#fff0c000,#fff0d000,#fff0e000,#fff0f000,#ffe0f000,#ffd0f000,#ffc0f000,#ffb0f000,#ffa0f000,#ff90f000,#ff80f000,#ff68f000,#ff50f000,#ff30f000,#ff00f000,#ff00f040,#ff00f068,#ff00f090,#ff00f0b0,#ff00f0d0,#ff00f0f0,#ff00e0f0,#ff00d0f0,#ff00c0f0,#ff00b0f0,#ff00a0f0,#ff0090f0,#ff0080f0,#ff0070f0,#ff0060f0,#ff0050f0,#ff0040f0,#ff0030f0,#ff0020f0,#ff0000f0,#ff2000f0,#ff3000f0,#ff4000f0,#ff5000f0,#ff6000f0,#ff7000f0,#ff8000f0,#ff9000f0,#ffa000f0,#ffb000f0,#ffc000f0,#ffd000f0,#ffe000f0,#fff000f0,#fff000d0,#fff000b0,#fff00090,#fff00068,#fff00040,#fff8f8f8,#fff0f0f0,#ffe8e8e8,#ffe0e0e0,#ffd8d8d8,#ffd0d0d0,#ffc8c8c8,#ffc0c0c0,#ffb8b8b8,#ffb0b0b0,#ffa8a8a8,#ffa0a0a0,#ff989898,#ff909090,#ff888888,#ff808080,#ff787878,#ff707070,#ff686868,#ff606060,#ff585858,#ff505050,#ff484848,#ff404040,#ff383838,#ff303030,#ff282828,#ff202020,#ff181818,#ff101010,#ff080808,#ff000000,#ff281010,#ff502020,#ff783838,#ffa05050,#ffc86868,#fff08080,#fff8a0a0,#fff8c0c0,#fff8e0e0,#ff282810,#ff505020,#ff787838,#ffa0a050,#ffc8c868,#fff0f080,#fff8f8a0,#fff8f8c0,#fff8f8e0,#ff102810,#ff285028,#ff407840,#ff50a050,#ff68c868,#ff80f080,#ffa0f8a0,#ffc0f8c0,#ffe0f8e0,#ff102828,#ff205050,#ff387878,#ff50a0a0,#ff68c8c8,#ff80f0f0,#ffa0f8f8,#ffc0f8f8,#ffe0f8f8,#ff101028,#ff202050,#ff383878,#ff5050a0,#ff6868c8,#ff8080f0,#ffa0a0f8,#ffc0c0f8,#ffe0e0f8,#ff281028,#ff502050,#ff783878,#ffa050a0,#ffc868c8,#fff080f0,#fff8a0f8,#fff8c0f8,#fff8e0f8,#ff280010,#ff500020,#ff780038,#ffa00050,#ffc80068,#fff03898,#fff868b0,#fff898c8,#fff8c8e0,#ff281000,#ff502000,#ff783800,#ffa05000,#ffc86800,#fff09838,#fff8b068,#fff8c898,#fff8e0c8,#ff102800,#ff205000,#ff387800,#ff50a000,#ff68c800,#ff98f030,#ffb0f860,#ffc8f898,#ffe0f8c8,#ff002810,#ff005020,#ff007838,#ff00a050,#ff00c868,#ff30f098,#ff60f8b0,#ff98f8c8,#ffc8f8e0,#ff001028,#ff002050,#ff003878,#ff0050a0,#ff0068c8,#ff3098f0,#ff60b0f8,#ff98c8f8,#ffc8e0f8,#ff100028,#ff200050,#ff380078,#ff5000a0,#ff6800c8,#ff9830f0,#ffb060f8,#ffc898f8,#ffe0c8f8,#ff300000,#ff600000,#ff900000,#ffc00000,#fff03030,#fff86060,#ff303000,#ff606000,#ff909000,#ffc0c000,#fff0f030,#fff8f860,#ff003000,#ff006000,#ff009000,#ff00c000,#ff30f030,#ff60f860,#ff003030,#ff006060,#ff009090,#ff00c0c0,#ff30f0f0,#ff60f8f8,#ff000030,#ff000060,#ff000090,#ff0000c0,#ff3030f0,#ff6060f8,#ff300030,#ff600060,#ff900090,#ffc000c0,#fff030f0,#fff860f8";
-    private static SKColor TRANSPARENT = new(0, 248, 0);
+    private const string MainPalette = "#ff00f800,#fff00080,#ff80f000,#ff00f080,#ff00f800,#ff00f800,#ff00f800,#ff482828,#ff684038,#ff905850,#ffb88070,#ffc8a080,#ffd8b090,#ffe8c8a0,#fff8d8b0,#fff8e8c0,#fff00000,#fff02800,#fff04000,#fff05000,#fff06000,#fff07000,#fff08000,#fff09000,#fff0a000,#fff0b000,#fff0c000,#fff0d000,#fff0e000,#fff0f000,#ffe0f000,#ffd0f000,#ffc0f000,#ffb0f000,#ffa0f000,#ff90f000,#ff80f000,#ff68f000,#ff50f000,#ff30f000,#ff00f000,#ff00f040,#ff00f068,#ff00f090,#ff00f0b0,#ff00f0d0,#ff00f0f0,#ff00e0f0,#ff00d0f0,#ff00c0f0,#ff00b0f0,#ff00a0f0,#ff0090f0,#ff0080f0,#ff0070f0,#ff0060f0,#ff0050f0,#ff0040f0,#ff0030f0,#ff0020f0,#ff0000f0,#ff2000f0,#ff3000f0,#ff4000f0,#ff5000f0,#ff6000f0,#ff7000f0,#ff8000f0,#ff9000f0,#ffa000f0,#ffb000f0,#ffc000f0,#ffd000f0,#ffe000f0,#fff000f0,#fff000d0,#fff000b0,#fff00090,#fff00068,#fff00040,#fff8f8f8,#fff0f0f0,#ffe8e8e8,#ffe0e0e0,#ffd8d8d8,#ffd0d0d0,#ffc8c8c8,#ffc0c0c0,#ffb8b8b8,#ffb0b0b0,#ffa8a8a8,#ffa0a0a0,#ff989898,#ff909090,#ff888888,#ff808080,#ff787878,#ff707070,#ff686868,#ff606060,#ff585858,#ff505050,#ff484848,#ff404040,#ff383838,#ff303030,#ff282828,#ff202020,#ff181818,#ff101010,#ff080808,#ff000000,#ff281010,#ff502020,#ff783838,#ffa05050,#ffc86868,#fff08080,#fff8a0a0,#fff8c0c0,#fff8e0e0,#ff282810,#ff505020,#ff787838,#ffa0a050,#ffc8c868,#fff0f080,#fff8f8a0,#fff8f8c0,#fff8f8e0,#ff102810,#ff285028,#ff407840,#ff50a050,#ff68c868,#ff80f080,#ffa0f8a0,#ffc0f8c0,#ffe0f8e0,#ff102828,#ff205050,#ff387878,#ff50a0a0,#ff68c8c8,#ff80f0f0,#ffa0f8f8,#ffc0f8f8,#ffe0f8f8,#ff101028,#ff202050,#ff383878,#ff5050a0,#ff6868c8,#ff8080f0,#ffa0a0f8,#ffc0c0f8,#ffe0e0f8,#ff281028,#ff502050,#ff783878,#ffa050a0,#ffc868c8,#fff080f0,#fff8a0f8,#fff8c0f8,#fff8e0f8,#ff280010,#ff500020,#ff780038,#ffa00050,#ffc80068,#fff03898,#fff868b0,#fff898c8,#fff8c8e0,#ff281000,#ff502000,#ff783800,#ffa05000,#ffc86800,#fff09838,#fff8b068,#fff8c898,#fff8e0c8,#ff102800,#ff205000,#ff387800,#ff50a000,#ff68c800,#ff98f030,#ffb0f860,#ffc8f898,#ffe0f8c8,#ff002810,#ff005020,#ff007838,#ff00a050,#ff00c868,#ff30f098,#ff60f8b0,#ff98f8c8,#ffc8f8e0,#ff001028,#ff002050,#ff003878,#ff0050a0,#ff0068c8,#ff3098f0,#ff60b0f8,#ff98c8f8,#ffc8e0f8,#ff100028,#ff200050,#ff380078,#ff5000a0,#ff6800c8,#ff9830f0,#ffb060f8,#ffc898f8,#ffe0c8f8,#ff300000,#ff600000,#ff900000,#ffc00000,#fff03030,#fff86060,#ff303000,#ff606000,#ff909000,#ffc0c000,#fff0f030,#fff8f860,#ff003000,#ff006000,#ff009000,#ff00c000,#ff30f030,#ff60f860,#ff003030,#ff006060,#ff009090,#ff00c0c0,#ff30f0f0,#ff60f8f8,#ff000030,#ff000060,#ff000090,#ff0000c0,#ff3030f0,#ff6060f8,#ff300030,#ff600060,#ff900090,#ffc000c0,#fff030f0,#fff860f8";
+    private const string ChessPalette = "#ff00f800,#ff000000,#ff080808,#ff100818,#ff101008,#ff180820,#ff101010,#ff200810,#ff280028,#ff181010,#ff181020,#ff281010,#ff181818,#ff201028,#ff000090,#ff201810,#ff201818,#ff400040,#ff281818,#ff381018,#ff480818,#ff182020,#ff201838,#ff202020,#ff201858,#ff282020,#ff301840,#ff401818,#ff302018,#ff382018,#ff481818,#ff401838,#ff282828,#ff183030,#ff382030,#ff501820,#ff302050,#ff680068,#ff382820,#ff183830,#ff302068,#ff601820,#ff303030,#ff382848,#ff403008,#ff502818,#ff203848,#ff383038,#ff403020,#ff403028,#ff204030,#ff402860,#ff483028,#ff781828,#ffb80000,#ff383838,#ff583010,#ff602050,#ff702028,#ff403830,#ff204838,#ff403840,#ff503048,#ff583810,#ff384038,#ff403858,#ff503830,#ff5000f0,#ff683020,#ff980098,#ff802030,#ff205040,#ff483078,#ff404040,#ff583838,#ff484038,#ff504030,#ff604018,#ff404848,#ff504048,#ff882830,#ff584038,#ff285840,#ff484060,#ff484848,#ff783828,#ff504840,#ff604818,#ff504848,#ff583888,#ff684038,#ff504850,#ff903030,#ff286048,#ff604838,#ff385868,#ff505050,#ff585040,#ffa83018,#ff584870,#ff604858,#ffa03030,#ff4030d8,#ff804030,#fff80040,#ff485850,#ff785000,#ff605040,#ff605048,#ff685040,#ff605058,#ff486050,#fff80070,#ff585858,#ff605848,#ffa83838,#ff605850,#ff885018,#ff605080,#ffa03080,#ff685858,#ff706020,#ff785848,#ff406888,#ff606060,#ff905038,#ffb84040,#ffd83820,#ff885078,#ff706068,#fff83000,#ff806048,#ff686868,#ff985840,#ff407890,#ffa06018,#ff807020,#ff886848,#ff687078,#ff8858a0,#ff906060,#ff0090f0,#ff786888,#ff806870,#ff707078,#ff906858,#ffa86048,#ff787878,#ff907060,#ff4888a8,#ff887080,#ff908020,#ffa87810,#ffc06820,#ff6060f8,#ffb86850,#ff08c060,#ff987860,#ff808080,#ff907888,#ffb87050,#ffb88000,#ffb860a8,#ffb07858,#ff989028,#ff9870c8,#ff5898b8,#ff888888,#ffd07820,#ff988098,#ff988878,#ffb08068,#ffa88870,#ff909090,#ffd08818,#ffa08898,#ffc870b8,#ffa8a020,#ffd08060,#ffb088a0,#ff989898,#ffe09000,#ffb89070,#ff80a0b0,#ffa89878,#ffd89028,#ffa098a0,#ffd080b8,#ffe08868,#ff00e0f0,#ffb0a080,#ffc89878,#ffa8a0a8,#ffe8a000,#ffb898b8,#ffe0a030,#ff00f0f0,#ff88b8b0,#ffb8a888,#ffc0b820,#fff09070,#ffd890c0,#ff68c8c8,#ffb0a8b0,#ffd0a088,#ffe8a830,#fff0a830,#ffb0b0b8,#ffc0b090,#fff8b000,#ffc0a8c0,#ffd8a888,#ffd0c020,#ffc0a8d8,#ffb8c070,#ff98c0d0,#ffb8b8b8,#ffd8b090,#ffc8b0c8,#ffe8a0c8,#ffe0b880,#ffc8c098,#ffc0c0c0,#ffe0b8a0,#fff8a8d0,#ffd8b8d8,#ffc8c8c8,#ffe8c0a0,#ffc8c8d0,#ffe8d830,#ffd8d0a0,#ffe8c8b0,#ffd8d0c0,#ffd0d0d8,#fff8e038,#fff0d0a8,#fff0d0b0,#ffe8d8a0,#ffd8d8d8,#fff8d0b8,#fff8d0c0,#ff98f8f8,#ffe0d8e8,#fff0d8c0,#ffe8e0a8,#fff0f060,#ffe0e0e0,#ffe0e0e8,#ffe8e8d8,#ffc0f8f8,#ffe8e8e0,#ffe8e8e8,#fff8e8d0,#fff0f0f0,#ffe0f8f8,#fff8f8f8";
+    private static readonly SKColor s_transparent = new(0, 248, 0);
 
     public SystemTextureItem(SystemTexture sysTex, Project project, string name, int width = -1, int height = -1) : base(name, ItemType.System_Texture)
     {
@@ -77,7 +78,7 @@ public class SystemTextureItem : Item
             replacedPalette.Insert(0, SKColors.Transparent);
             Grp.SetPalette(replacedPalette);
         }
-        else if (Grp.Palette[0] == TRANSPARENT)
+        else if (Grp.Palette[0] == s_transparent)
         {
             Grp.Palette[0] = SKColors.Transparent;
         }
@@ -106,7 +107,7 @@ public class SystemTextureItem : Item
 
             Grp.SetImage(tileBitmap, newSize: true);
         }
-        Grp.Palette[0] = TRANSPARENT;
+        Grp.Palette[0] = s_transparent;
     }
 
     public void Write(Project project, ILogger log)
@@ -119,6 +120,17 @@ public class SystemTextureItem : Item
 
     public bool UsesCommonPalette()
     {
-        return COMMON_PALETTE.Equals(string.Join(',', Grp.Palette.Select(c => c.ToString())), StringComparison.OrdinalIgnoreCase);
+        string paletteString = string.Join(',', Grp.Palette.Select(c => c.ToString()));
+        return MainPalette.Equals(paletteString, StringComparison.OrdinalIgnoreCase)
+               || ChessPalette.Equals(paletteString, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool UsesMainPalette()
+    {
+        return MainPalette.Equals(string.Join(',', Grp.Palette.Select(c => c.ToString())), StringComparison.OrdinalIgnoreCase);
+    }
+    public bool UsesChessPalette()
+    {
+        return ChessPalette.Equals(string.Join(',', Grp.Palette.Select(c => c.ToString())), StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -698,6 +698,69 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A simple top-screen scrolling graphic, used in the base game to indicate time of day. Displayed with KBG_DISP..
+        /// </summary>
+        public static string BackgroundEditorHelpBgTypeKINETIC_SCREEN {
+            get {
+                return ResourceManager.GetString("BackgroundEditorHelpBgTypeKINETIC_SCREEN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A standard visual novel background used on the bottom screen, something that sprites would be displayed on top of. Displayed with BG_DISP or BG_FADE..
+        /// </summary>
+        public static string BackgroundEditorHelpBgTypeTEX_BG {
+            get {
+                return ResourceManager.GetString("BackgroundEditorHelpBgTypeTEX_BG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A standard CG (character graphic) that displays a scene on the bottom screen. Sprites would not be placed on top of this. Displayed with BG_DISPCG or BG_FADE..
+        /// </summary>
+        public static string BackgroundEditorHelpBgTypeTEX_CG {
+            get {
+                return ResourceManager.GetString("BackgroundEditorHelpBgTypeTEX_CG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A tall CG (character graphic) displayed across both screens. It is too tall to be viewed at once, so it can be scrolled up and down with BG_SCROLL. Displayed with BG_DISPCG..
+        /// </summary>
+        public static string BackgroundEditorHelpBgTypeTEX_CG_DUAL_SCREEN {
+            get {
+                return ResourceManager.GetString("BackgroundEditorHelpBgTypeTEX_CG_DUAL_SCREEN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A tall CG (character graphic) displayed on the bottom screen only. It can be scrolled up and down with BG_SCROLL. Displayed with BG_DISPCG..
+        /// </summary>
+        public static string BackgroundEditorHelpBgTypeTEX_CG_SINGLE {
+            get {
+                return ResourceManager.GetString("BackgroundEditorHelpBgTypeTEX_CG_SINGLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A wide CG (character graphic) displayed on the bottom screen. Can be scrolled left and right with BG_SCROLL. Displayed with BG_DISPCG..
+        /// </summary>
+        public static string BackgroundEditorHelpBgTypeTEX_CG_WIDE {
+            get {
+                return ResourceManager.GetString("BackgroundEditorHelpBgTypeTEX_CG_WIDE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The title of the CG as it will appear in the Extras mode&apos;s Album (CG viewer).
+        /// </summary>
+        public static string BackgroundEditorHelpCgName {
+            get {
+                return ResourceManager.GetString("BackgroundEditorHelpCgName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Backgrounds.
         /// </summary>
         public static string Backgrounds {
@@ -842,6 +905,24 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The audio format used by Chokuretsu encodes loop information into audio file itself, denoting where the track should loop from and to. Click this button to edit this information..
+        /// </summary>
+        public static string BgmEditorLoopInfoHelp {
+            get {
+                return ResourceManager.GetString("BgmEditorLoopInfoHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Click this button to adjust the volume of the track..
+        /// </summary>
+        public static string BgmEditorVolumeHelp {
+            get {
+                return ResourceManager.GetString("BgmEditorVolumeHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to adjust loop data for background music. Please check the logs and file an issue if this reoccurs..
         /// </summary>
         public static string BgmLoopErrorMessage {
@@ -856,6 +937,15 @@ namespace SerialLoops.Assets {
         public static string BGMs {
             get {
                 return ResourceManager.GetString("BGMs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Click this to normalize the volume to match the default volume of all other tracks in the game. Recommended..
+        /// </summary>
+        public static string BgmVolumeNormalizeHelp {
+            get {
+                return ResourceManager.GetString("BgmVolumeNormalizeHelp", resourceCulture);
             }
         }
         
@@ -1202,6 +1292,24 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The text timer represents how fast the character speaks. The higher the value, the slower the text will appear on screen..
+        /// </summary>
+        public static string CharacterEditorTextTimerHelp {
+            get {
+                return ResourceManager.GetString("CharacterEditorTextTimerHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The voice font is the sound effect that plays when there isn&apos;t a voiced line for this character (i.e. the little beeps).
+        /// </summary>
+        public static string CharacterEditorVoiceFontHelp {
+            get {
+                return ResourceManager.GetString("CharacterEditorVoiceFontHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Characters.
         /// </summary>
         public static string Characters {
@@ -1288,6 +1396,123 @@ namespace SerialLoops.Assets {
         public static string Chibi_frames_exported_ {
             get {
                 return ResourceManager.GetString("Chibi frames exported!", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default idle animation.
+        /// </summary>
+        public static string ChibiEditorAnim00Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim00Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Walk cycle animation.
+        /// </summary>
+        public static string ChibiEditorAnim01Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim01Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;Searching&quot; animation (puzzle phase).
+        /// </summary>
+        public static string ChibiEditorAnim02Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim02Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;Cleaning&quot; animation (puzzle phase).
+        /// </summary>
+        public static string ChibiEditorAnim03Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim03Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Lose animation (puzzle phase).
+        /// </summary>
+        public static string ChibiEditorAnim04Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim04Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Win animation (puzzle phase).
+        /// </summary>
+        public static string ChibiEditorAnim05Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim05Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Technique animation (puzzle phase).
+        /// </summary>
+        public static string ChibiEditorAnim06Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim06Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Technique failed animation (puzzle phase).
+        /// </summary>
+        public static string ChibiEditorAnim07Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim07Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running animation (unused).
+        /// </summary>
+        public static string ChibiEditorAnim08Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim08Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alternate idle animation (unused).
+        /// </summary>
+        public static string ChibiEditorAnim10Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim10Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Still pose for &quot;good&quot; group selection result.
+        /// </summary>
+        public static string ChibiEditorAnim97Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim97Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Still pose for &quot;neutral&quot; group selection result.
+        /// </summary>
+        public static string ChibiEditorAnim98Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim98Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Still pose for &quot;bad&quot; group selection result.
+        /// </summary>
+        public static string ChibiEditorAnim99Help {
+            get {
+                return ResourceManager.GetString("ChibiEditorAnim99Help", resourceCulture);
             }
         }
         
@@ -7001,6 +7226,132 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This loads a companion selection screen, allowing the player to select which Brigade member will accompany Haruhi during the puzzle phase..
+        /// </summary>
+        public static string ScenarioVerbHelpCOMPANION_SELECT {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpCOMPANION_SELECT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ends the scenario and returns to the title screen..
+        /// </summary>
+        public static string ScenarioVerbHelpEND {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpEND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command loads a particular script file..
+        /// </summary>
+        public static string ScenarioVerbHelpLOAD_SCENE {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpLOAD_SCENE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command defines where the &quot;New Game&quot; menu item takes the player. For example, if NEW_GAME 5 defines where selecting New Game → Episode 5 will take the player..
+        /// </summary>
+        public static string ScenarioVerbHelpNEW_GAME {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpNEW_GAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Does nothing..
+        /// </summary>
+        public static string ScenarioVerbHelpNOP {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpNOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plays a video; 0 plays the OP and 1 plays the ED..
+        /// </summary>
+        public static string ScenarioVerbHelpPLAY_VIDEO {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpPLAY_VIDEO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command starts a particular puzzle phase..
+        /// </summary>
+        public static string ScenarioVerbHelpPUZZLE_PHASE {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpPUZZLE_PHASE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command starts a particular group selection..
+        /// </summary>
+        public static string ScenarioVerbHelpROUTE_SELECT {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpROUTE_SELECT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command prompts the user to save the game, creating a checkpoint save. Typically, the first save in an episode is denoted by setting the parameter to 2 and incrementing it for each checkpoint after that..
+        /// </summary>
+        public static string ScenarioVerbHelpSAVE {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpSAVE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command also prompts the user to save the game. While the precise mechanical differences between this and SAVE are not well understood, it is known that it is used after the UNLOCK command and before the NEW_GAME or END commands. This implies that it interacts more directly with the common save than do checkpoint saves. Its parameter is always 0..
+        /// </summary>
+        public static string ScenarioVerbHelpSAVE2 {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpSAVE2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command stops the game. It is not actually used..
+        /// </summary>
+        public static string ScenarioVerbHelpSTOP {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpSTOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command displays which topics the player has collected over the previous scene(s) following group selection..
+        /// </summary>
+        public static string ScenarioVerbHelpTOPICS {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpTOPICS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unlocks particular functionality. The exact mapping between the parameter specified and which functionality is unlocked is currently unknown..
+        /// </summary>
+        public static string ScenarioVerbHelpUNLOCK {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpUNLOCK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command unlocks a character ending scene based on the friendship levels. Used at the end of the game..
+        /// </summary>
+        public static string ScenarioVerbHelpUNLOCK_ENDINGS {
+            get {
+                return ResourceManager.GetString("ScenarioVerbHelpUNLOCK_ENDINGS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Scene.
         /// </summary>
         public static string Scene {
@@ -8010,6 +8361,42 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This system texture uses the common main palette, so palette replacement has been disabled..
+        /// </summary>
+        public static string SystemTexturePaletteReplacementDisabled {
+            get {
+                return ResourceManager.GetString("SystemTexturePaletteReplacementDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This system texture uses the common chess palette, so palette replacement has been disabled..
+        /// </summary>
+        public static string SystemTexturePaletteReplacementDisabledChess {
+            get {
+                return ResourceManager.GetString("SystemTexturePaletteReplacementDisabledChess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Click this button to replace the texture WITHOUT changing the existing palette. This means that you will want to design the replacement to have the colors displayed below for maximum fidelity. We recommend using this option only if palette replacement is disabled..
+        /// </summary>
+        public static string SystemTextureReplaceHelp {
+            get {
+                return ResourceManager.GetString("SystemTextureReplaceHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Click this button to replace the texture AND the texture&apos;s palette. This will adapt the palette to match the new image you upload, preserving color as much as possible. If this option is available, we recommend using it..
+        /// </summary>
+        public static string SystemTextureReplaceWithPaletteHelp {
+            get {
+                return ResourceManager.GetString("SystemTextureReplaceWithPaletteHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Target Number.
         /// </summary>
         public static string Target_Number {
@@ -8222,16 +8609,6 @@ namespace SerialLoops.Assets {
         public static string This_script_is_not_included_in_the_event_table_ {
             get {
                 return ResourceManager.GetString("This script is not included in the event table.", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to This system texture uses a common palette, so palette replacement has been disabled.
-        /// </summary>
-        public static string This_system_texture_uses_a_common_palette__so_palette_replacement_has_been_disabled {
-            get {
-                return ResourceManager.GetString(("This system texture uses a common palette, so palette replacement has been disabl" +
-                        "ed"), resourceCulture);
             }
         }
         
@@ -8481,11 +8858,29 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All main topics have a second &quot;hidden&quot; ID in addition to their main one. This is displayed for internal accounting and is generally not interesting to you as a user..
+        /// </summary>
+        public static string TopicEditorHiddenIdHelp {
+            get {
+                return ResourceManager.GetString("TopicEditorHiddenIdHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Topics.
         /// </summary>
         public static string Topics {
             get {
                 return ResourceManager.GetString("Topics", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to These times represent the amount of time gained in the puzzle phase when using this topic. The character accompanying Haruhi applies a percentage modifier to the base time gain to result in the amounts seen in-game and in the right-hand column..
+        /// </summary>
+        public static string TopicTimesHelp {
+            get {
+                return ResourceManager.GetString("TopicTimesHelp", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7433,6 +7433,568 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Displays the &quot;Main Topic → Avoid&quot; graphics..
+        /// </summary>
+        public static string ScriptCommandVerbHelpAVOID_DISP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpAVOID_DISP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When used in the initial script section, starts execution to the first script block. Otherwise, makes the script return to whatever called it (e.g. the puzzle phase) or returns you to the investigation phase..
+        /// </summary>
+        public static string ScriptCommandVerbHelpBACK {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBACK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displays a background image on the lower screen. The background image can only be of type TEX_BG..
+        /// </summary>
+        public static string ScriptCommandVerbHelpBG_DISP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBG_DISP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The same as BG_DISP. Use that command instead..
+        /// </summary>
+        public static string ScriptCommandVerbHelpBG_DISP2 {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBG_DISP2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to BG_DISPCG works as BG_DISP but can display a larger variety of textures – namely, TEX_CG, TEX_CG_DUAL_SCREEN, TEX_CG_WIDE, and TEX_CG_SINGLE BGs. Notably, these are all CGs as opposed to VN backgrounds. Before displaying a standard BG after calling BG_DISPCG, one should call BG_REVERT..
+        /// </summary>
+        public static string ScriptCommandVerbHelpBG_DISPCG {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBG_DISPCG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Like the other BG display commands but crossfades the background rather than just displaying it..
+        /// </summary>
+        public static string ScriptCommandVerbHelpBG_FADE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBG_FADE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reverts the background to the last call of BG_DISP (i.e. undoes any BG_FADE or BG_DISPCG calls). This is required before returning to displaying standard TEX_BG BGs. Note that if reverting a TEX_CG_DUAL_SCREEN BG, SET_PLACE must have been used to set the place location and have it displayed.
+        ///
+        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, consider  [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string ScriptCommandVerbHelpBG_REVERT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBG_REVERT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When a background that is larger than the screen is shown (such as TEX_CG_DUAL_SCREEN, TEX_CG_WIDE, and TEX_CG_SINGLE), scrolls the background in a defined direction..
+        /// </summary>
+        public static string ScriptCommandVerbHelpBG_SCROLL {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBG_SCROLL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plays or stops background music..
+        /// </summary>
+        public static string ScriptCommandVerbHelpBGM_PLAY {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpBGM_PLAY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clears all chessboard annotations. Unused..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_CLEAR_ANNOTATIONS {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_CLEAR_ANNOTATIONS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loads a chess file into memory and (if the chess overlay is loaded) places it on the chessboard..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_LOAD {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_LOAD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Moves a piece (or pieces) on the chessboard..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_MOVE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_MOVE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resets the chessboard to its original state..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_RESET {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_RESET", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Crosses out spaces on the chessboard with a red X. If a space is already crossed out, this command uncrosses it out..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_TOGGLE_CROSS {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_TOGGLE_CROSS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Highlights the potential moves of a piece in red. If a piece has already been highlighted, this command unhighlights it. Optionally, can specify to clear all guides currently on the board..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_TOGGLE_GUIDE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_TOGGLE_GUIDE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Highlights spaces on the chessboard in yellow. If a space is already highlighted, this command unhighlights it..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_TOGGLE_HIGHLIGHT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_TOGGLE_HIGHLIGHT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Monitors for the end of the chess game and then jumps to a specified script block depending on the outcome..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHESS_VGOTO {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHESS_VGOTO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This command displays an emote in a speech bubble above a chibi figure on the top screen..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHIBI_EMOTE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHIBI_EMOTE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies a chibi figure to enter or exit the top screen. To be used by this command, a chibi must have a walk cycle (animation 01) in addition to its default idle animation (animation 00)..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCHIBI_ENTEREXIT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCHIBI_ENTEREXIT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displays falling confetti on the top screen..
+        /// </summary>
+        public static string ScriptCommandVerbHelpCONFETTI {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpCONFETTI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displays a line of dialogue and/or manipulates character sprites. Can optionally play a voiced line..
+        /// </summary>
+        public static string ScriptCommandVerbHelpDIALOGUE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpDIALOGUE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sets the upper screen to be an episode title texture..
+        /// </summary>
+        public static string ScriptCommandVerbHelpEPHEADER {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpEPHEADER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sets or clears a flag..
+        /// </summary>
+        public static string ScriptCommandVerbHelpFLAG {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpFLAG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sets a global variable to a specified value. Only used in one place so it&apos;s difficult to determine what it affects..
+        /// </summary>
+        public static string ScriptCommandVerbHelpGLOBAL2D {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpGLOBAL2D", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Jumps to a particular script section..
+        /// </summary>
+        public static string ScriptCommandVerbHelpGOTO {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpGOTO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Modifies the value of the Haruhi Meter. The meter minimum is 0 (corresponding to 10%) and the meter maximum is 9 (corresponding to 100%)..
+        /// </summary>
+        public static string ScriptCommandVerbHelpHARUHI_METER {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpHARUHI_METER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adds to the Haruhi Meter without showing the Haruhi Meter UI (the sound effects are still played). Unused in the game..
+        /// </summary>
+        public static string ScriptCommandVerbHelpHARUHI_METER_NOSHOW {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpHARUHI_METER_NOSHOW", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stops script execution until input is received from the player..
+        /// </summary>
+        public static string ScriptCommandVerbHelpHOLD {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpHOLD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Seems to initialize read flags for the current script; however, it&apos;s utility is unknown as it is unused in the game..
+        /// </summary>
+        public static string ScriptCommandVerbHelpINIT_READ_FLAG {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpINIT_READ_FLAG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ends investigation mode and returns to the main visual novel format of the game. Automatically fades screen to black..
+        /// </summary>
+        public static string ScriptCommandVerbHelpINVEST_END {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpINVEST_END", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starts investigation mode. Automatically clears most of the screen UI and then fades screen out to black and then back in from black..
+        /// </summary>
+        public static string ScriptCommandVerbHelpINVEST_START {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpINVEST_START", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displays the specified item image. The item system is entirely unused in the game, so this command goes unused as well..
+        /// </summary>
+        public static string ScriptCommandVerbHelpITEM_DISPIMG {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpITEM_DISPIMG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displays a particular &quot;kinetic&quot; (my word) background on the top screen. Must be of type KINETIC_SCREEN..
+        /// </summary>
+        public static string ScriptCommandVerbHelpKBG_DISP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpKBG_DISP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loads an isometric map for usage by INVEST_START..
+        /// </summary>
+        public static string ScriptCommandVerbHelpLOAD_ISOMAP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpLOAD_ISOMAP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Modifies a character&apos;s &quot;Friendship Level&quot; by adding a particular value to it. The value can be positive or negative. Friendship levels start at 1, have a max of 64, and persist throughout a playthrough..
+        /// </summary>
+        public static string ScriptCommandVerbHelpMODIFY_FRIENDSHIP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpMODIFY_FRIENDSHIP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ends the scene and moves to the next one as listed in the Scenario item..
+        /// </summary>
+        public static string ScriptCommandVerbHelpNEXT_SCENE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpNEXT_SCENE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Does nothing..
+        /// </summary>
+        public static string ScriptCommandVerbHelpNOOP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpNOOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Suppresses the top screen UI, shows BG_KBG04 on the top screen, disables dialogue skipping, and marks the center of the screen as the position the Kyon chibi walks to, and sends the Kyon chibi out. Used only in the opening text crawl..
+        /// </summary>
+        public static string ScriptCommandVerbHelpOP_MODE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpOP_MODE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Changes the color of currently displayed UI elements using a specified filter..
+        /// </summary>
+        public static string ScriptCommandVerbHelpPALEFFECT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpPALEFFECT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Draws a dialogue line as monologue over all other dialogue. Undone by completing a chess game..
+        /// </summary>
+        public static string ScriptCommandVerbHelpPIN_MNL {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpPIN_MNL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removed in the final version of the game (not referenced in any scripts.).
+        /// </summary>
+        public static string ScriptCommandVerbHelpREMOVED {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpREMOVED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Goes to a particular scene. Note that this scene cannot be just any script file; it must be contained within the event table..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSCENE_GOTO {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSCENE_GOTO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Behaves as SCENE_GOTO except that it&apos;s used to go to scripts that contain chess puzzles..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSCENE_GOTO_CHESS {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSCENE_GOTO_CHESS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Causes the screen to fade in..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSCREEN_FADEIN {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSCREEN_FADEIN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Causes the screen to fade out..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSCREEN_FADEOUT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSCREEN_FADEOUT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Flashes the screen a specified color for a specified amount of time..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSCREEN_FLASH {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSCREEN_FLASH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shakes the bottom screen..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSCREEN_SHAKE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSCREEN_SHAKE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stops screen shaking from a SCREEN_SHAKE command. (Used when the Duration parameter of said SCREEN_SHAKE is set to -1)..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSCREEN_SHAKE_STOP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSCREEN_SHAKE_STOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Presents the player with a series of choices that branch the dialogue tree. Choices are defined in their own section and have IDs that correspond to labels set in the labels section. When a choice is chosen, this ID is used to select which script block will be jumped to.
+        ///
+        ///SELECT cannot be used in the initial, unnamed script block..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSELECT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSELECT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Modifies the displayed place name..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSET_PLACE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSET_PLACE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sets up the NEXT_SCENE command to skip a specified number of scenes as defined in the Scenario..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSKIP_SCENE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSKIP_SCENE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plays a sound from the SDAT snd.bin..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSND_PLAY {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSND_PLAY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stops the currently playing sound. Unused in game..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSND_STOP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSND_STOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stops script execution and soft locks the game. Unused..
+        /// </summary>
+        public static string ScriptCommandVerbHelpSTOP {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpSTOP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shows/hides the dialogue box. Note that plenty of other commands already do one of these (e.g., DIALOGUE automatically shows the dialogue box)..
+        /// </summary>
+        public static string ScriptCommandVerbHelpTOGGLE_DIALOGUE {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpTOGGLE_DIALOGUE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Gives the player a particular topic..
+        /// </summary>
+        public static string ScriptCommandVerbHelpTOPIC_GET {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpTOPIC_GET", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plays a transition from black into the scene..
+        /// </summary>
+        public static string ScriptCommandVerbHelpTRANS_IN {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpTRANS_IN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plays a transition to black..
+        /// </summary>
+        public static string ScriptCommandVerbHelpTRANS_OUT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpTRANS_OUT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plays a voice file..
+        /// </summary>
+        public static string ScriptCommandVerbHelpVCE_PLAY {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpVCE_PLAY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Goes to a specified script section if a specified conditional is true..
+        /// </summary>
+        public static string ScriptCommandVerbHelpVGOTO {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpVGOTO", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Waits a particular number of frames..
+        /// </summary>
+        public static string ScriptCommandVerbHelpWAIT {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpWAIT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A command nearly identical to WAIT, but allows for the wait to be canceled with a button press or screen tap..
+        /// </summary>
+        public static string ScriptCommandVerbHelpWAIT_CANCEL {
+            get {
+                return ResourceManager.GetString("ScriptCommandVerbHelpWAIT_CANCEL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Scripts.
         /// </summary>
         public static string Scripts {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7442,6 +7442,33 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If set, the text box will not be cleared and the next text will be displayed immediately. This allows for cool effects where you can change things like the text entrance effect, voice font, etc. in the same box..
+        /// </summary>
+        public static string ScriptCommandParameterHelpDontClearText {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpDontClearText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The speed at which the background scrolls; higher is faster. Default is 1..
+        /// </summary>
+        public static string ScriptCommandParameterHelpScrollSpeed {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpScrollSpeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &quot;layer&quot; on which to display the sprite -- this determines which sprites appear on top of the others. Higher numbers will display on top of higher numbers..
+        /// </summary>
+        public static string ScriptCommandParameterHelpSpriteLayer {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpSpriteLayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Displays the &quot;Main Topic → Avoid&quot; graphics..
         /// </summary>
         public static string ScriptCommandVerbHelpAVOID_DISP {
@@ -7597,7 +7624,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This command displays an emote in a speech bubble above a chibi figure on the top screen..
+        ///   Looks up a localized string similar to Displays an emote in a speech bubble above a chibi figure on the top screen..
         /// </summary>
         public static string ScriptCommandVerbHelpCHIBI_EMOTE {
             get {
@@ -7905,7 +7932,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plays a sound from the SDAT snd.bin..
+        ///   Looks up a localized string similar to Plays a sound effect..
         /// </summary>
         public static string ScriptCommandVerbHelpSND_PLAY {
             get {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7451,6 +7451,33 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The the color type to use. Except for special transitions, it is generally recommended to use Custom Color as it provides the most flexibility..
+        /// </summary>
+        public static string ScriptCommandParameterHelpFadeColor {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpFadeColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This color will only be applied if you have selected &quot;Custom Color&quot; for the &quot;Color&quot; property below..
+        /// </summary>
+        public static string ScriptCommandParameterHelpFadeCustomColor {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpFadeCustomColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The screen to apply the fade to. Except for the initial fade in SCRIPT00, you must use Custom Color to fade both screens..
+        /// </summary>
+        public static string ScriptCommandParameterHelpFadeLocation {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpFadeLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The speed at which the background scrolls; higher is faster. Default is 1..
         /// </summary>
         public static string ScriptCommandParameterHelpScrollSpeed {
@@ -7460,11 +7487,47 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If this is -1, this option is always shown. If it is a value 0 or above, this option is shown until the flag of that value is set..
+        /// </summary>
+        public static string ScriptCommandParameterHelpSelectDisplayFlag {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpSelectDisplayFlag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set to -1 to shake the screen until the SCREEN_SHAKE_STOP command is executed.
+        /// </summary>
+        public static string ScriptCommandParameterHelpShakeDuration {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpShakeDuration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This must be checked when a sound is played initially. If a sound plays for a long time and you want to change its volume, uncheck this and set the crossfade time instead..
+        /// </summary>
+        public static string ScriptCommandParameterHelpSoundLoad {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpSoundLoad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &quot;layer&quot; on which to display the sprite -- this determines which sprites appear on top of the others. Higher numbers will display on top of higher numbers..
         /// </summary>
         public static string ScriptCommandParameterHelpSpriteLayer {
             get {
                 return ResourceManager.GetString("ScriptCommandParameterHelpSpriteLayer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Should be the same as the previous SCREEN_FADEOUT command.
+        /// </summary>
+        public static string ScriptCommandScreenFadeInParamWarning {
+            get {
+                return ResourceManager.GetString("ScriptCommandScreenFadeInParamWarning", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7433,6 +7433,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to By default, tall CGs will display from the top. If this is checked, it will instead display from the bottom..
+        /// </summary>
+        public static string ScriptCommandParameterHelpDisplayFromBottom {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpDisplayFromBottom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Displays the &quot;Main Topic → Avoid&quot; graphics..
         /// </summary>
         public static string ScriptCommandVerbHelpAVOID_DISP {

--- a/src/SerialLoops/Assets/Strings.en-GB.resx
+++ b/src/SerialLoops/Assets/Strings.en-GB.resx
@@ -2331,8 +2331,8 @@
   <data name="Project exported successfully!" xml:space="preserve">
     <value>Project exported successfully!</value>
   </data>
-  <data name="This system texture uses a common palette, so palette replacement has been disabled" xml:space="preserve">
-    <value>This system texture uses a common palette, so palette replacement has been disabled</value>
+  <data name="SystemTexturePaletteReplacementDisabled" xml:space="preserve">
+    <value>This system texture uses a common palette, so palette replacement has been disabled.</value>
   </data>
   <data name="Add to Event Table" xml:space="preserve">
     <value>Add to Event Table</value>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3566,4 +3566,25 @@ SELECT cannot be used in the initial, unnamed script block.</value>
   <data name="ScriptCommandParameterHelpDontClearText" xml:space="preserve">
     <value>If set, the text box will not be cleared and the next text will be displayed immediately. This allows for cool effects where you can change things like the text entrance effect, voice font, etc. in the same box.</value><comment>Help tooltip for the "Don't Clear Text" parameter of the DIALOGUE command</comment>
   </data>
+  <data name="ScriptCommandScreenFadeInParamWarning" xml:space="preserve">
+    <value>Should be the same as the previous SCREEN_FADEOUT command</value>
+  </data>
+  <data name="ScriptCommandParameterHelpFadeColor" xml:space="preserve">
+    <value>The the color type to use. Except for special transitions, it is generally recommended to use Custom Color as it provides the most flexibility.</value>
+  </data>
+  <data name="ScriptCommandParameterHelpFadeCustomColor" xml:space="preserve">
+    <value>This color will only be applied if you have selected "Custom Color" for the "Color" property below.</value>
+  </data>
+  <data name="ScriptCommandParameterHelpFadeLocation" xml:space="preserve">
+    <value>The screen to apply the fade to. Except for the initial fade in SCRIPT00, you must use Custom Color to fade both screens.</value>
+  </data>
+  <data name="ScriptCommandParameterHelpShakeDuration" xml:space="preserve">
+    <value>Set to -1 to shake the screen until the SCREEN_SHAKE_STOP command is executed</value>
+  </data>
+  <data name="ScriptCommandParameterHelpSelectDisplayFlag" xml:space="preserve">
+    <value>If this is -1, this option is always shown. If it is a value 0 or above, this option is shown until the flag of that value is set.</value>
+  </data>
+  <data name="ScriptCommandParameterHelpSoundLoad" xml:space="preserve">
+    <value>This must be checked when a sound is played initially. If a sound plays for a long time and you want to change its volume, uncheck this and set the crossfade time instead.</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3554,4 +3554,7 @@ SELECT cannot be used in the initial, unnamed script block.</value>
   <data name="ScriptCommandVerbHelpBACK" xml:space="preserve">
     <value>When used in the initial script section, starts execution to the first script block. Otherwise, makes the script return to whatever called it (e.g. the puzzle phase) or returns you to the investigation phase.</value>
   </data>
+  <data name="ScriptCommandParameterHelpDisplayFromBottom" xml:space="preserve">
+    <value>By default, tall CGs will display from the top. If this is checked, it will instead display from the bottom.</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -2292,8 +2292,8 @@ If you wish to ignore this, please check the "Ignore Hash" checkbox.</value>
   <data name="This script is not included in the event table." xml:space="preserve">
     <value>This script is not included in the event table.</value>
   </data>
-  <data name="This system texture uses a common palette, so palette replacement has been disabled" xml:space="preserve">
-    <value>This system texture uses a common palette, so palette replacement has been disabled</value>
+  <data name="SystemTexturePaletteReplacementDisabled" xml:space="preserve">
+    <value>This system texture uses the common main palette, so palette replacement has been disabled.</value>
   </data>
   <data name="Time (Frames)" xml:space="preserve">
     <value>Transition Time (Frames)</value>
@@ -3231,5 +3231,137 @@ All hacks have been rolled back to preserve state.</value>
   </data>
   <data name="BgmLoopErrorMessage" xml:space="preserve">
     <value>Failed to adjust loop data for background music. Please check the logs and file an issue if this reoccurs.</value>
+  </data>
+  <data name="BackgroundEditorHelpBgTypeTEX_BG" xml:space="preserve">
+    <value>A standard visual novel background used on the bottom screen, something that sprites would be displayed on top of. Displayed with BG_DISP or BG_FADE.</value>
+  </data>
+  <data name="BackgroundEditorHelpBgTypeKINETIC_SCREEN" xml:space="preserve">
+    <value>A simple top-screen scrolling graphic, used in the base game to indicate time of day. Displayed with KBG_DISP.</value>
+  </data>
+  <data name="BackgroundEditorHelpBgTypeTEX_CG" xml:space="preserve">
+    <value>A standard CG (character graphic) that displays a scene on the bottom screen. Sprites would not be placed on top of this. Displayed with BG_DISPCG or BG_FADE.</value>
+  </data>
+  <data name="BackgroundEditorHelpBgTypeTEX_CG_DUAL_SCREEN" xml:space="preserve">
+    <value>A tall CG (character graphic) displayed across both screens. It is too tall to be viewed at once, so it can be scrolled up and down with BG_SCROLL. Displayed with BG_DISPCG.</value>
+  </data>
+  <data name="BackgroundEditorHelpBgTypeTEX_CG_WIDE" xml:space="preserve">
+    <value>A wide CG (character graphic) displayed on the bottom screen. Can be scrolled left and right with BG_SCROLL. Displayed with BG_DISPCG.</value>
+  </data>
+  <data name="BackgroundEditorHelpBgTypeTEX_CG_SINGLE" xml:space="preserve">
+    <value>A tall CG (character graphic) displayed on the bottom screen only. It can be scrolled up and down with BG_SCROLL. Displayed with BG_DISPCG.</value>
+  </data>
+  <data name="BackgroundEditorHelpCgName" xml:space="preserve">
+    <value>The title of the CG as it will appear in the Extras mode's Album (CG viewer)</value>
+  </data>
+  <data name="BgmEditorLoopInfoHelp" xml:space="preserve">
+    <value>The audio format used by Chokuretsu encodes loop information into audio file itself, denoting where the track should loop from and to. Click this button to edit this information.</value>
+  </data>
+  <data name="BgmEditorVolumeHelp" xml:space="preserve">
+    <value>Click this button to adjust the volume of the track.</value>
+  </data>
+  <data name="BgmVolumeNormalizeHelp" xml:space="preserve">
+    <value>Click this to normalize the volume to match the default volume of all other tracks in the game. Recommended.</value>
+  </data>
+  <data name="CharacterEditorVoiceFontHelp" xml:space="preserve">
+    <value>The voice font is the sound effect that plays when there isn't a voiced line for this character (i.e. the little beeps)</value>
+  </data>
+  <data name="CharacterEditorTextTimerHelp" xml:space="preserve">
+    <value>The text timer represents how fast the character speaks. The higher the value, the slower the text will appear on screen.</value>
+  </data>
+  <data name="ChibiEditorAnim00Help" xml:space="preserve">
+    <value>Default idle animation</value>
+  </data>
+  <data name="ChibiEditorAnim01Help" xml:space="preserve">
+    <value>Walk cycle animation</value>
+  </data>
+  <data name="ChibiEditorAnim02Help" xml:space="preserve">
+    <value>"Searching" animation (puzzle phase)</value>
+  </data>
+  <data name="ChibiEditorAnim03Help" xml:space="preserve">
+    <value>"Cleaning" animation (puzzle phase)</value>
+  </data>
+  <data name="ChibiEditorAnim04Help" xml:space="preserve">
+    <value>Lose animation (puzzle phase)</value>
+  </data>
+  <data name="ChibiEditorAnim05Help" xml:space="preserve">
+    <value>Win animation (puzzle phase)</value>
+  </data>
+  <data name="ChibiEditorAnim06Help" xml:space="preserve">
+    <value>Technique animation (puzzle phase)</value>
+  </data>
+  <data name="ChibiEditorAnim07Help" xml:space="preserve">
+    <value>Technique failed animation (puzzle phase)</value>
+  </data>
+  <data name="ChibiEditorAnim08Help" xml:space="preserve">
+    <value>Running animation (unused)</value>
+  </data>
+  <data name="ChibiEditorAnim10Help" xml:space="preserve">
+    <value>Alternate idle animation (unused)</value>
+  </data>
+  <data name="ChibiEditorAnim97Help" xml:space="preserve">
+    <value>Still pose for "good" group selection result</value>
+  </data>
+  <data name="ChibiEditorAnim98Help" xml:space="preserve">
+    <value>Still pose for "neutral" group selection result</value>
+  </data>
+  <data name="ChibiEditorAnim99Help" xml:space="preserve">
+    <value>Still pose for "bad" group selection result</value>
+  </data>
+  <data name="ScenarioVerbHelpNEW_GAME" xml:space="preserve">
+    <value>This command defines where the "New Game" menu item takes the player. For example, if NEW_GAME 5 defines where selecting New Game → Episode 5 will take the player.</value>
+  </data>
+  <data name="ScenarioVerbHelpSAVE" xml:space="preserve">
+    <value>This command prompts the user to save the game, creating a checkpoint save. Typically, the first save in an episode is denoted by setting the parameter to 2 and incrementing it for each checkpoint after that.</value>
+  </data>
+  <data name="ScenarioVerbHelpLOAD_SCENE" xml:space="preserve">
+    <value>This command loads a particular script file.</value>
+  </data>
+  <data name="ScenarioVerbHelpPUZZLE_PHASE" xml:space="preserve">
+    <value>This command starts a particular puzzle phase.</value>
+  </data>
+  <data name="ScenarioVerbHelpROUTE_SELECT" xml:space="preserve">
+    <value>This command starts a particular group selection.</value>
+  </data>
+  <data name="ScenarioVerbHelpSTOP" xml:space="preserve">
+    <value>This command stops the game. It is not actually used.</value>
+  </data>
+  <data name="ScenarioVerbHelpSAVE2" xml:space="preserve">
+    <value>This command also prompts the user to save the game. While the precise mechanical differences between this and SAVE are not well understood, it is known that it is used after the UNLOCK command and before the NEW_GAME or END commands. This implies that it interacts more directly with the common save than do checkpoint saves. Its parameter is always 0.</value>
+  </data>
+  <data name="ScenarioVerbHelpTOPICS" xml:space="preserve">
+    <value>This command displays which topics the player has collected over the previous scene(s) following group selection.</value>
+  </data>
+  <data name="ScenarioVerbHelpCOMPANION_SELECT" xml:space="preserve">
+    <value>This loads a companion selection screen, allowing the player to select which Brigade member will accompany Haruhi during the puzzle phase.</value>
+  </data>
+  <data name="ScenarioVerbHelpPLAY_VIDEO" xml:space="preserve">
+    <value>Plays a video; 0 plays the OP and 1 plays the ED.</value>
+  </data>
+  <data name="ScenarioVerbHelpNOP" xml:space="preserve">
+    <value>Does nothing.</value>
+  </data>
+  <data name="ScenarioVerbHelpUNLOCK_ENDINGS" xml:space="preserve">
+    <value>This command unlocks a character ending scene based on the friendship levels. Used at the end of the game.</value>
+  </data>
+  <data name="ScenarioVerbHelpUNLOCK" xml:space="preserve">
+    <value>Unlocks particular functionality. The exact mapping between the parameter specified and which functionality is unlocked is currently unknown.</value>
+  </data>
+  <data name="ScenarioVerbHelpEND" xml:space="preserve">
+    <value>Ends the scenario and returns to the title screen.</value>
+  </data>
+  <data name="SystemTextureReplaceHelp" xml:space="preserve">
+    <value>Click this button to replace the texture WITHOUT changing the existing palette. This means that you will want to design the replacement to have the colors displayed below for maximum fidelity. We recommend using this option only if palette replacement is disabled.</value>
+  </data>
+  <data name="SystemTextureReplaceWithPaletteHelp" xml:space="preserve">
+    <value>Click this button to replace the texture AND the texture's palette. This will adapt the palette to match the new image you upload, preserving color as much as possible. If this option is available, we recommend using it.</value>
+  </data>
+  <data name="SystemTexturePaletteReplacementDisabledChess" xml:space="preserve">
+    <value>This system texture uses the common chess palette, so palette replacement has been disabled.</value>
+  </data>
+  <data name="TopicTimesHelp" xml:space="preserve">
+    <value>These times represent the amount of time gained in the puzzle phase when using this topic. The character accompanying Haruhi applies a percentage modifier to the base time gain to result in the amounts seen in-game and in the right-hand column.</value>
+  </data>
+  <data name="TopicEditorHiddenIdHelp" xml:space="preserve">
+    <value>All main topics have a second "hidden" ID in addition to their main one. This is displayed for internal accounting and is generally not interesting to you as a user.</value>
   </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3415,7 +3415,7 @@ BG_REVERT does something odd to previously displayed CGs that makes attempting t
     <value>Monitors for the end of the chess game and then jumps to a specified script block depending on the outcome.</value>
   </data>
   <data name="ScriptCommandVerbHelpCHIBI_EMOTE" xml:space="preserve">
-    <value>This command displays an emote in a speech bubble above a chibi figure on the top screen.</value>
+    <value>Displays an emote in a speech bubble above a chibi figure on the top screen.</value>
   </data>
   <data name="ScriptCommandVerbHelpCHIBI_ENTEREXIT" xml:space="preserve">
     <value>Specifies a chibi figure to enter or exit the top screen. To be used by this command, a chibi must have a walk cycle (animation 01) in addition to its default idle animation (animation 00).</value>
@@ -3519,7 +3519,7 @@ SELECT cannot be used in the initial, unnamed script block.</value>
     <value>Sets up the NEXT_SCENE command to skip a specified number of scenes as defined in the Scenario.</value>
   </data>
   <data name="ScriptCommandVerbHelpSND_PLAY" xml:space="preserve">
-    <value>Plays a sound from the SDAT snd.bin.</value>
+    <value>Plays a sound effect.</value>
   </data>
   <data name="ScriptCommandVerbHelpSND_STOP" xml:space="preserve">
     <value>Stops the currently playing sound. Unused in game.</value>
@@ -3556,5 +3556,14 @@ SELECT cannot be used in the initial, unnamed script block.</value>
   </data>
   <data name="ScriptCommandParameterHelpDisplayFromBottom" xml:space="preserve">
     <value>By default, tall CGs will display from the top. If this is checked, it will instead display from the bottom.</value>
+  </data>
+  <data name="ScriptCommandParameterHelpScrollSpeed" xml:space="preserve">
+    <value>The speed at which the background scrolls; higher is faster. Default is 1.</value>
+  </data>
+  <data name="ScriptCommandParameterHelpSpriteLayer" xml:space="preserve">
+    <value>The "layer" on which to display the sprite -- this determines which sprites appear on top of the others. Higher numbers will display on top of higher numbers.</value>
+  </data>
+  <data name="ScriptCommandParameterHelpDontClearText" xml:space="preserve">
+    <value>If set, the text box will not be cleared and the next text will be displayed immediately. This allows for cool effects where you can change things like the text entrance effect, voice font, etc. in the same box.</value><comment>Help tooltip for the "Don't Clear Text" parameter of the DIALOGUE command</comment>
   </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3364,4 +3364,194 @@ All hacks have been rolled back to preserve state.</value>
   <data name="TopicEditorHiddenIdHelp" xml:space="preserve">
     <value>All main topics have a second "hidden" ID in addition to their main one. This is displayed for internal accounting and is generally not interesting to you as a user.</value>
   </data>
+  <data name="ScriptCommandVerbHelpAVOID_DISP" xml:space="preserve">
+    <value>Displays the "Main Topic → Avoid" graphics.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBG_DISP" xml:space="preserve">
+    <value>Displays a background image on the lower screen. The background image can only be of type TEX_BG.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBG_DISP2" xml:space="preserve">
+    <value>The same as BG_DISP. Use that command instead.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBG_DISPCG" xml:space="preserve">
+    <value>BG_DISPCG works as BG_DISP but can display a larger variety of textures – namely, TEX_CG, TEX_CG_DUAL_SCREEN, TEX_CG_WIDE, and TEX_CG_SINGLE BGs. Notably, these are all CGs as opposed to VN backgrounds. Before displaying a standard BG after calling BG_DISPCG, one should call BG_REVERT.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBG_FADE" xml:space="preserve">
+    <value>Like the other BG display commands but crossfades the background rather than just displaying it.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBG_REVERT" xml:space="preserve">
+    <value>Reverts the background to the last call of BG_DISP (i.e. undoes any BG_FADE or BG_DISPCG calls). This is required before returning to displaying standard TEX_BG BGs. Note that if reverting a TEX_CG_DUAL_SCREEN BG, SET_PLACE must have been used to set the place location and have it displayed.
+
+BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, consider using BG_FADE.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBG_SCROLL" xml:space="preserve">
+    <value>When a background that is larger than the screen is shown (such as TEX_CG_DUAL_SCREEN, TEX_CG_WIDE, and TEX_CG_SINGLE), scrolls the background in a defined direction.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBGM_PLAY" xml:space="preserve">
+    <value>Plays or stops background music.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_CLEAR_ANNOTATIONS" xml:space="preserve">
+    <value>Clears all chessboard annotations. Unused.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_LOAD" xml:space="preserve">
+    <value>Loads a chess file into memory and (if the chess overlay is loaded) places it on the chessboard.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_MOVE" xml:space="preserve">
+    <value>Moves a piece (or pieces) on the chessboard.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_RESET" xml:space="preserve">
+    <value>Resets the chessboard to its original state.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_TOGGLE_CROSS" xml:space="preserve">
+    <value>Crosses out spaces on the chessboard with a red X. If a space is already crossed out, this command uncrosses it out.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_TOGGLE_GUIDE" xml:space="preserve">
+    <value>Highlights the potential moves of a piece in red. If a piece has already been highlighted, this command unhighlights it. Optionally, can specify to clear all guides currently on the board.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_TOGGLE_HIGHLIGHT" xml:space="preserve">
+    <value>Highlights spaces on the chessboard in yellow. If a space is already highlighted, this command unhighlights it.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHESS_VGOTO" xml:space="preserve">
+    <value>Monitors for the end of the chess game and then jumps to a specified script block depending on the outcome.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHIBI_EMOTE" xml:space="preserve">
+    <value>This command displays an emote in a speech bubble above a chibi figure on the top screen.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCHIBI_ENTEREXIT" xml:space="preserve">
+    <value>Specifies a chibi figure to enter or exit the top screen. To be used by this command, a chibi must have a walk cycle (animation 01) in addition to its default idle animation (animation 00).</value>
+  </data>
+  <data name="ScriptCommandVerbHelpCONFETTI" xml:space="preserve">
+    <value>Displays falling confetti on the top screen.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpDIALOGUE" xml:space="preserve">
+    <value>Displays a line of dialogue and/or manipulates character sprites. Can optionally play a voiced line.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpEPHEADER" xml:space="preserve">
+    <value>Sets the upper screen to be an episode title texture.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpFLAG" xml:space="preserve">
+    <value>Sets or clears a flag.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpGLOBAL2D" xml:space="preserve">
+    <value>Sets a global variable to a specified value. Only used in one place so it's difficult to determine what it affects.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpGOTO" xml:space="preserve">
+    <value>Jumps to a particular script section.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpHARUHI_METER" xml:space="preserve">
+    <value>Modifies the value of the Haruhi Meter. The meter minimum is 0 (corresponding to 10%) and the meter maximum is 9 (corresponding to 100%).</value>
+  </data>
+  <data name="ScriptCommandVerbHelpHARUHI_METER_NOSHOW" xml:space="preserve">
+    <value>Adds to the Haruhi Meter without showing the Haruhi Meter UI (the sound effects are still played). Unused in the game.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpHOLD" xml:space="preserve">
+    <value>Stops script execution until input is received from the player.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpINIT_READ_FLAG" xml:space="preserve">
+    <value>Seems to initialize read flags for the current script; however, it's utility is unknown as it is unused in the game.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpINVEST_END" xml:space="preserve">
+    <value>Ends investigation mode and returns to the main visual novel format of the game. Automatically fades screen to black.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpINVEST_START" xml:space="preserve">
+    <value>Starts investigation mode. Automatically clears most of the screen UI and then fades screen out to black and then back in from black.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpITEM_DISPIMG" xml:space="preserve">
+    <value>Displays the specified item image. The item system is entirely unused in the game, so this command goes unused as well.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpKBG_DISP" xml:space="preserve">
+    <value>Displays a particular "kinetic" (my word) background on the top screen. Must be of type KINETIC_SCREEN.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpLOAD_ISOMAP" xml:space="preserve">
+    <value>Loads an isometric map for usage by INVEST_START.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpMODIFY_FRIENDSHIP" xml:space="preserve">
+    <value>Modifies a character's "Friendship Level" by adding a particular value to it. The value can be positive or negative. Friendship levels start at 1, have a max of 64, and persist throughout a playthrough.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpNEXT_SCENE" xml:space="preserve">
+    <value>Ends the scene and moves to the next one as listed in the Scenario item.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpNOOP" xml:space="preserve">
+    <value>Does nothing.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpOP_MODE" xml:space="preserve">
+    <value>Suppresses the top screen UI, shows BG_KBG04 on the top screen, disables dialogue skipping, and marks the center of the screen as the position the Kyon chibi walks to, and sends the Kyon chibi out. Used only in the opening text crawl.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpPALEFFECT" xml:space="preserve">
+    <value>Changes the color of currently displayed UI elements using a specified filter.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpPIN_MNL" xml:space="preserve">
+    <value>Draws a dialogue line as monologue over all other dialogue. Undone by completing a chess game.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpREMOVED" xml:space="preserve">
+    <value>Removed in the final version of the game (not referenced in any scripts.)</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSCENE_GOTO" xml:space="preserve">
+    <value>Goes to a particular scene. Note that this scene cannot be just any script file; it must be contained within the event table.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSCENE_GOTO_CHESS" xml:space="preserve">
+    <value>Behaves as SCENE_GOTO except that it's used to go to scripts that contain chess puzzles.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSCREEN_FADEIN" xml:space="preserve">
+    <value>Causes the screen to fade in.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSCREEN_FADEOUT" xml:space="preserve">
+    <value>Causes the screen to fade out.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSCREEN_FLASH" xml:space="preserve">
+    <value>Flashes the screen a specified color for a specified amount of time.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSCREEN_SHAKE" xml:space="preserve">
+    <value>Shakes the bottom screen.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSCREEN_SHAKE_STOP" xml:space="preserve">
+    <value>Stops screen shaking from a SCREEN_SHAKE command. (Used when the Duration parameter of said SCREEN_SHAKE is set to -1).</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSELECT" xml:space="preserve">
+    <value>Presents the player with a series of choices that branch the dialogue tree. Choices are defined in their own section and have IDs that correspond to labels set in the labels section. When a choice is chosen, this ID is used to select which script block will be jumped to.
+
+SELECT cannot be used in the initial, unnamed script block.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSET_PLACE" xml:space="preserve">
+    <value>Modifies the displayed place name.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSKIP_SCENE" xml:space="preserve">
+    <value>Sets up the NEXT_SCENE command to skip a specified number of scenes as defined in the Scenario.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSND_PLAY" xml:space="preserve">
+    <value>Plays a sound from the SDAT snd.bin.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSND_STOP" xml:space="preserve">
+    <value>Stops the currently playing sound. Unused in game.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpSTOP" xml:space="preserve">
+    <value>Stops script execution and soft locks the game. Unused.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpTOGGLE_DIALOGUE" xml:space="preserve">
+    <value>Shows/hides the dialogue box. Note that plenty of other commands already do one of these (e.g., DIALOGUE automatically shows the dialogue box).</value>
+  </data>
+  <data name="ScriptCommandVerbHelpTOPIC_GET" xml:space="preserve">
+    <value>Gives the player a particular topic.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpTRANS_OUT" xml:space="preserve">
+    <value>Plays a transition to black.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpTRANS_IN" xml:space="preserve">
+    <value>Plays a transition from black into the scene.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpVCE_PLAY" xml:space="preserve">
+    <value>Plays a voice file.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpVGOTO" xml:space="preserve">
+    <value>Goes to a specified script section if a specified conditional is true.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpWAIT" xml:space="preserve">
+    <value>Waits a particular number of frames.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpWAIT_CANCEL" xml:space="preserve">
+    <value>A command nearly identical to WAIT, but allows for the wait to be canceled with a button press or screen tap.</value>
+  </data>
+  <data name="ScriptCommandVerbHelpBACK" xml:space="preserve">
+    <value>When used in the initial script section, starts execution to the first script block. Otherwise, makes the script return to whatever called it (e.g. the puzzle phase) or returns you to the investigation phase.</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.zh-Hans.resx
+++ b/src/SerialLoops/Assets/Strings.zh-Hans.resx
@@ -2174,7 +2174,7 @@
   <data name="This script is not included in the event table." xml:space="preserve">
     <value>此脚本未包含在事件表中。</value>
   </data>
-  <data name="This system texture uses a common palette, so palette replacement has been disabled" xml:space="preserve">
+  <data name="SystemTexturePaletteReplacementDisabled" xml:space="preserve">
     <value>此系统纹理使用通用调色板，因此已禁用调色板替换</value>
   </data>
   <data name="Time (Frames)" xml:space="preserve">

--- a/src/SerialLoops/Controls/LabelWithIcon.axaml
+++ b/src/SerialLoops/Controls/LabelWithIcon.axaml
@@ -5,7 +5,7 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SerialLoops.Controls.LabelWithIcon">
     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="5">
-        <Svg Name="IconPath" Width="18" />
-        <TextBlock Name="LabelText" />
+        <Svg Name="IconPath" Width="18" VerticalAlignment="Center" />
+        <TextBlock Name="LabelText" VerticalAlignment="Center" />
     </StackPanel>
 </UserControl>

--- a/src/SerialLoops/Controls/LinkButton.axaml
+++ b/src/SerialLoops/Controls/LinkButton.axaml
@@ -5,8 +5,8 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SerialLoops.Controls.LinkButton">
     <Grid ColumnDefinitions="Auto,Auto" VerticalAlignment="Center">
-        <Svg Grid.Column="0" Name="IconPath" Width="18"/>
-        <TextBlock Grid.Column="1" Classes="link" IsEnabled="True" Name="LinkText"/>
+        <Svg Grid.Column="0" Name="IconPath" Width="18" VerticalAlignment="Center" />
+        <TextBlock Grid.Column="1" Classes="link" IsEnabled="True" Name="LinkText" VerticalAlignment="Center" />
         <!-- TODO: (Maybe?) Remove this kludge (routes around https://github.com/AvaloniaUI/Avalonia/issues/15281) -->
         <Button Grid.Column="1" Cursor="Hand" Background="Transparent" Width="{Binding #LinkText.Bounds.Size.Width}"
                 Height="{Binding #LinkText.Bounds.Size.Height}" Name="BackingButton"/>

--- a/src/SerialLoops/Controls/ScenarioCommandPicker.axaml
+++ b/src/SerialLoops/Controls/ScenarioCommandPicker.axaml
@@ -7,7 +7,7 @@
              x:DataType="vm:ScenarioCommandPickerViewModel"
              x:Class="SerialLoops.Controls.ScenarioCommandPicker">
     <StackPanel Orientation="Horizontal" Spacing="5">
-        <TextBlock Text="{Binding ScenarioCommandIndex}" Margin="0,7,0,0"/>
+        <TextBlock Text="{Binding ScenarioCommandIndex}" VerticalAlignment="Center"/>
         <Button Content="{Binding ScenarioCommandText}">
             <Button.Flyout>
                 <Flyout>

--- a/src/SerialLoops/Models/ScriptCommandTreeItem.cs
+++ b/src/SerialLoops/Models/ScriptCommandTreeItem.cs
@@ -1,8 +1,11 @@
 ﻿using System.Collections.ObjectModel;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
+using HaruhiChokuretsuLib.Archive.Event;
 using ReactiveUI;
 using SerialLoops.Lib.Script;
+using SerialLoops.Utility;
 
 namespace SerialLoops.Models;
 
@@ -25,7 +28,9 @@ public class ScriptCommandTreeItem : ITreeItem, IViewFor<ScriptItemCommand>
     {
         ViewModel = command;
         this.OneWayBind(ViewModel, vm => vm.Display, v => v._textBlock.Text);
+        _textBlock.VerticalAlignment = VerticalAlignment.Center;
         _panel.Children.Add(_textBlock);
+        _panel[ToolTip.TipProperty] = Shared.GetScriptVerbHelp(ViewModel?.Verb ?? EventFile.CommandVerb.NOOP1);
     }
 
     public Control GetDisplay()

--- a/src/SerialLoops/Models/ScriptCommandTreeItem.cs
+++ b/src/SerialLoops/Models/ScriptCommandTreeItem.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using HaruhiChokuretsuLib.Archive.Event;

--- a/src/SerialLoops/Utility/SLConverters.cs
+++ b/src/SerialLoops/Utility/SLConverters.cs
@@ -10,6 +10,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Skia;
 using HaruhiChokuretsuLib.Archive.Event;
+using SerialLoops.Assets;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Util;
@@ -29,6 +30,8 @@ public static partial class SLConverters
     public static FuncValueConverter<bool, IImmutableSolidColorBrush> BooleanBrushConverter => new((val) => val ? Brushes.Transparent : Brushes.LightGreen);
     public static FuncValueConverter<string, string> CharacterNameCropConverter => new((name) => name[4..]);
     public static FuncValueConverter<List<Speaker>, string> ListDisplayConverter => new((strs) => string.Join(", ", strs.Select(s => s.ToString())));
+
+    public static FuncValueConverter<ScenarioCommand.ScenarioVerb, string> ScenarioVerbHelpConverter => new(Shared.GetScenarioVerbHelp);
 }
 
 public class DisplayNameConverter : IMultiValueConverter

--- a/src/SerialLoops/Utility/SLConverters.cs
+++ b/src/SerialLoops/Utility/SLConverters.cs
@@ -30,8 +30,9 @@ public static partial class SLConverters
     public static FuncValueConverter<bool, IImmutableSolidColorBrush> BooleanBrushConverter => new((val) => val ? Brushes.Transparent : Brushes.LightGreen);
     public static FuncValueConverter<string, string> CharacterNameCropConverter => new((name) => name[4..]);
     public static FuncValueConverter<List<Speaker>, string> ListDisplayConverter => new((strs) => string.Join(", ", strs.Select(s => s.ToString())));
-
     public static FuncValueConverter<ScenarioCommand.ScenarioVerb, string> ScenarioVerbHelpConverter => new(Shared.GetScenarioVerbHelp);
+    public static FuncValueConverter<EventFile.CommandVerb, string> ScriptVerbHelpConverter => new(Shared.GetScriptVerbHelp);
+    public static FuncValueConverter<string, string> ScriptVerbStringHelpConverter => new(Shared.GetScriptVerbHelp);
 }
 
 public class DisplayNameConverter : IMultiValueConverter

--- a/src/SerialLoops/Utility/SLConverters.cs
+++ b/src/SerialLoops/Utility/SLConverters.cs
@@ -10,7 +10,6 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Skia;
 using HaruhiChokuretsuLib.Archive.Event;
-using SerialLoops.Assets;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Util;

--- a/src/SerialLoops/Utility/Shared.cs
+++ b/src/SerialLoops/Utility/Shared.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Emik;
+using HaruhiChokuretsuLib.Archive.Event;
 using HaruhiChokuretsuLib.Util;
 using MsBox.Avalonia.Enums;
 using SerialLoops.Assets;
@@ -104,5 +105,27 @@ public static class Shared
         }
 
         return false;
+    }
+
+    public static string GetScenarioVerbHelp(ScenarioCommand.ScenarioVerb verb)
+    {
+        return verb switch
+        {
+            ScenarioCommand.ScenarioVerb.NEW_GAME => Strings.ScenarioVerbHelpNEW_GAME,
+            ScenarioCommand.ScenarioVerb.SAVE => Strings.ScenarioVerbHelpSAVE,
+            ScenarioCommand.ScenarioVerb.LOAD_SCENE => Strings.ScenarioVerbHelpLOAD_SCENE,
+            ScenarioCommand.ScenarioVerb.PUZZLE_PHASE => Strings.ScenarioVerbHelpPUZZLE_PHASE,
+            ScenarioCommand.ScenarioVerb.ROUTE_SELECT => Strings.ScenarioVerbHelpROUTE_SELECT,
+            ScenarioCommand.ScenarioVerb.STOP => Strings.ScenarioVerbHelpSTOP,
+            ScenarioCommand.ScenarioVerb.SAVE2 => Strings.ScenarioVerbHelpSAVE2,
+            ScenarioCommand.ScenarioVerb.TOPICS => Strings.ScenarioVerbHelpTOPICS,
+            ScenarioCommand.ScenarioVerb.COMPANION_SELECT => Strings.ScenarioVerbHelpCOMPANION_SELECT,
+            ScenarioCommand.ScenarioVerb.PLAY_VIDEO => Strings.ScenarioVerbHelpPLAY_VIDEO,
+            ScenarioCommand.ScenarioVerb.NOP => Strings.ScenarioVerbHelpNOP,
+            ScenarioCommand.ScenarioVerb.UNLOCK_ENDINGS => Strings.ScenarioVerbHelpUNLOCK_ENDINGS,
+            ScenarioCommand.ScenarioVerb.UNLOCK => Strings.ScenarioVerbHelpUNLOCK,
+            ScenarioCommand.ScenarioVerb.END => Strings.ScenarioVerbHelpEND,
+            _ => string.Empty,
+        };
     }
 }

--- a/src/SerialLoops/Utility/Shared.cs
+++ b/src/SerialLoops/Utility/Shared.cs
@@ -17,6 +17,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.PixelFormats;
 using SkiaSharp;
+using static HaruhiChokuretsuLib.Archive.Event.EventFile;
 
 namespace SerialLoops.Utility;
 
@@ -125,6 +126,82 @@ public static class Shared
             ScenarioCommand.ScenarioVerb.UNLOCK_ENDINGS => Strings.ScenarioVerbHelpUNLOCK_ENDINGS,
             ScenarioCommand.ScenarioVerb.UNLOCK => Strings.ScenarioVerbHelpUNLOCK,
             ScenarioCommand.ScenarioVerb.END => Strings.ScenarioVerbHelpEND,
+            _ => string.Empty,
+        };
+    }
+
+    public static string GetScriptVerbHelp(string verb)
+    {
+        return Enum.TryParse<CommandVerb>(verb, out var parsedVerb) ? GetScriptVerbHelp(parsedVerb) : string.Empty;
+    }
+    public static string GetScriptVerbHelp(CommandVerb verb)
+    {
+        return verb switch
+        {
+            CommandVerb.AVOID_DISP => Strings.ScriptCommandVerbHelpAVOID_DISP,
+            CommandVerb.BACK => Strings.ScriptCommandVerbHelpBACK,
+            CommandVerb.BG_DISP => Strings.ScriptCommandVerbHelpBG_DISP,
+            CommandVerb.BG_DISP2 => Strings.ScriptCommandVerbHelpBG_DISP2,
+            CommandVerb.BG_DISPCG => Strings.ScriptCommandVerbHelpBG_DISPCG,
+            CommandVerb.BG_FADE => Strings.ScriptCommandVerbHelpBG_FADE,
+            CommandVerb.BG_REVERT => Strings.ScriptCommandVerbHelpBG_REVERT,
+            CommandVerb.BG_SCROLL => Strings.ScriptCommandVerbHelpBG_SCROLL,
+            CommandVerb.BGM_PLAY => Strings.ScriptCommandVerbHelpBGM_PLAY,
+            CommandVerb.CHESS_CLEAR_ANNOTATIONS => Strings.ScriptCommandVerbHelpCHESS_CLEAR_ANNOTATIONS,
+            CommandVerb.CHESS_LOAD => Strings.ScriptCommandVerbHelpCHESS_LOAD,
+            CommandVerb.CHESS_MOVE => Strings.ScriptCommandVerbHelpCHESS_MOVE,
+            CommandVerb.CHESS_RESET => Strings.ScriptCommandVerbHelpCHESS_RESET,
+            CommandVerb.CHESS_TOGGLE_CROSS => Strings.ScriptCommandVerbHelpCHESS_TOGGLE_CROSS,
+            CommandVerb.CHESS_TOGGLE_GUIDE => Strings.ScriptCommandVerbHelpCHESS_TOGGLE_GUIDE,
+            CommandVerb.CHESS_TOGGLE_HIGHLIGHT => Strings.ScriptCommandVerbHelpCHESS_TOGGLE_HIGHLIGHT,
+            CommandVerb.CHESS_VGOTO => Strings.ScriptCommandVerbHelpCHESS_VGOTO,
+            CommandVerb.CHIBI_EMOTE => Strings.ScriptCommandVerbHelpCHIBI_EMOTE,
+            CommandVerb.CHIBI_ENTEREXIT => Strings.ScriptCommandVerbHelpCHIBI_ENTEREXIT,
+            CommandVerb.CONFETTI => Strings.ScriptCommandVerbHelpCONFETTI,
+            CommandVerb.DIALOGUE => Strings.ScriptCommandVerbHelpDIALOGUE,
+            CommandVerb.EPHEADER => Strings.ScriptCommandVerbHelpEPHEADER,
+            CommandVerb.FLAG => Strings.ScriptCommandVerbHelpFLAG,
+            CommandVerb.GLOBAL2D => Strings.ScriptCommandVerbHelpGLOBAL2D,
+            CommandVerb.GOTO => Strings.ScriptCommandVerbHelpGOTO,
+            CommandVerb.HARUHI_METER => Strings.ScriptCommandVerbHelpHARUHI_METER,
+            CommandVerb.HARUHI_METER_NOSHOW => Strings.ScriptCommandVerbHelpHARUHI_METER_NOSHOW,
+            CommandVerb.HOLD => Strings.ScriptCommandVerbHelpHOLD,
+            CommandVerb.INIT_READ_FLAG => Strings.ScriptCommandVerbHelpINIT_READ_FLAG,
+            CommandVerb.INVEST_END => Strings.ScriptCommandVerbHelpINVEST_END,
+            CommandVerb.INVEST_START => Strings.ScriptCommandVerbHelpINVEST_START,
+            CommandVerb.ITEM_DISPIMG  => Strings.ScriptCommandVerbHelpITEM_DISPIMG,
+            CommandVerb.KBG_DISP  => Strings.ScriptCommandVerbHelpKBG_DISP,
+            CommandVerb.LOAD_ISOMAP => Strings.ScriptCommandVerbHelpLOAD_ISOMAP,
+            CommandVerb.MODIFY_FRIENDSHIP => Strings.ScriptCommandVerbHelpMODIFY_FRIENDSHIP,
+            CommandVerb.NEXT_SCENE => Strings.ScriptCommandVerbHelpNEXT_SCENE,
+            CommandVerb.NOOP1 => Strings.ScriptCommandVerbHelpNOOP,
+            CommandVerb.NOOP2 => Strings.ScriptCommandVerbHelpNOOP,
+            CommandVerb.NOOP3 => Strings.ScriptCommandVerbHelpNOOP,
+            CommandVerb.OP_MODE => Strings.ScriptCommandVerbHelpOP_MODE,
+            CommandVerb.PALEFFECT => Strings.ScriptCommandVerbHelpPALEFFECT,
+            CommandVerb.PIN_MNL => Strings.ScriptCommandVerbHelpPIN_MNL,
+            CommandVerb.REMOVED => Strings.ScriptCommandVerbHelpREMOVED,
+            CommandVerb.SCENE_GOTO => Strings.ScriptCommandVerbHelpSCENE_GOTO,
+            CommandVerb.SCENE_GOTO_CHESS => Strings.ScriptCommandVerbHelpSCENE_GOTO_CHESS,
+            CommandVerb.SCREEN_FADEIN => Strings.ScriptCommandVerbHelpSCREEN_FADEIN,
+            CommandVerb.SCREEN_FADEOUT => Strings.ScriptCommandVerbHelpSCREEN_FADEOUT,
+            CommandVerb.SCREEN_FLASH => Strings.ScriptCommandVerbHelpSCREEN_FLASH,
+            CommandVerb.SCREEN_SHAKE => Strings.ScriptCommandVerbHelpSCREEN_SHAKE,
+            CommandVerb.SCREEN_SHAKE_STOP => Strings.ScriptCommandVerbHelpSCREEN_SHAKE_STOP,
+            CommandVerb.SELECT => Strings.ScriptCommandVerbHelpSELECT,
+            CommandVerb.SET_PLACE => Strings.ScriptCommandVerbHelpSET_PLACE,
+            CommandVerb.SKIP_SCENE => Strings.ScriptCommandVerbHelpSKIP_SCENE,
+            CommandVerb.SND_PLAY => Strings.ScriptCommandVerbHelpSND_PLAY,
+            CommandVerb.SND_STOP => Strings.ScriptCommandVerbHelpSND_STOP,
+            CommandVerb.STOP => Strings.ScriptCommandVerbHelpSTOP,
+            CommandVerb.TOGGLE_DIALOGUE => Strings.ScriptCommandVerbHelpTOGGLE_DIALOGUE,
+            CommandVerb.TOPIC_GET => Strings.ScriptCommandVerbHelpTOPIC_GET,
+            CommandVerb.TRANS_IN => Strings.ScriptCommandVerbHelpTRANS_IN,
+            CommandVerb.TRANS_OUT => Strings.ScriptCommandVerbHelpTRANS_OUT,
+            CommandVerb.VCE_PLAY => Strings.ScriptCommandVerbHelpVCE_PLAY,
+            CommandVerb.VGOTO => Strings.ScriptCommandVerbHelpVGOTO,
+            CommandVerb.WAIT => Strings.ScriptCommandVerbHelpWAIT,
+            CommandVerb.WAIT_CANCEL => Strings.ScriptCommandVerbHelpWAIT_CANCEL,
             _ => string.Empty,
         };
     }

--- a/src/SerialLoops/ViewModels/Editors/BackgroundEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/BackgroundEditorViewModel.cs
@@ -24,6 +24,17 @@ public class BackgroundEditorViewModel : EditorViewModel
     public BackgroundItem Bg { get; set; }
     public SKBitmap BgBitmap => Bg.GetBackground();
     public string BgDescription => $"{Bg.Id} (0x{Bg.Id:X3}); {Bg.BackgroundType}";
+
+    public string DescriptionToolTip => Bg.BackgroundType switch
+    {
+        BgType.KINETIC_SCREEN => Strings.BackgroundEditorHelpBgTypeKINETIC_SCREEN,
+        BgType.TEX_BG => Strings.BackgroundEditorHelpBgTypeTEX_BG,
+        BgType.TEX_CG => Strings.BackgroundEditorHelpBgTypeTEX_CG,
+        BgType.TEX_CG_DUAL_SCREEN => Strings.BackgroundEditorHelpBgTypeTEX_CG_DUAL_SCREEN,
+        BgType.TEX_CG_WIDE => Strings.BackgroundEditorHelpBgTypeTEX_CG_WIDE,
+        BgType.TEX_CG_SINGLE => Strings.BackgroundEditorHelpBgTypeTEX_CG_SINGLE,
+        _ => string.Empty,
+    };
     public ICommand ExportCommand { get; set; }
     public ICommand ReplaceCommand { get; set; }
     public ICommand CgNameChangeCommand { get; set; }

--- a/src/SerialLoops/ViewModels/Editors/ChibiEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ChibiEditorViewModel.cs
@@ -61,6 +61,7 @@ public partial class ChibiEditorViewModel : EditorViewModel
                 "97" => Strings.ChibiEditorAnim97Help,
                 "98" => Strings.ChibiEditorAnim98Help,
                 "99" => Strings.ChibiEditorAnim99Help,
+                _ => string.Empty,
             };
         }
     }

--- a/src/SerialLoops/ViewModels/Editors/ChibiEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ChibiEditorViewModel.cs
@@ -46,8 +46,26 @@ public partial class ChibiEditorViewModel : EditorViewModel
             DirectionSelector.SelectedDirection = DirectionSelector.Directions[2];
             _selectedDirection = DirectionSelector.SelectedDirection.Direction;
             UpdateChibi();
+            SelectedAnimToolTip = _selectedAnimation[(_selectedAnimation.Length - 2).._selectedAnimation.Length] switch
+            {
+                "00" => Strings.ChibiEditorAnim00Help,
+                "01" => Strings.ChibiEditorAnim01Help,
+                "02" => Strings.ChibiEditorAnim02Help,
+                "03" => Strings.ChibiEditorAnim03Help,
+                "04" => Strings.ChibiEditorAnim04Help,
+                "05" => Strings.ChibiEditorAnim05Help,
+                "06" => Strings.ChibiEditorAnim06Help,
+                "07" => Strings.ChibiEditorAnim07Help,
+                "08" => Strings.ChibiEditorAnim08Help,
+                "10" => Strings.ChibiEditorAnim10Help,
+                "97" => Strings.ChibiEditorAnim97Help,
+                "98" => Strings.ChibiEditorAnim98Help,
+                "99" => Strings.ChibiEditorAnim99Help,
+            };
         }
     }
+    [Reactive]
+    public string SelectedAnimToolTip { get; set; } = Strings.ChibiEditorAnim00Help;
 
     public ObservableCollection<ReactiveFrameWithTiming> ChibiFrames { get; } = [];
 

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/ChibiEmoteScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/ChibiEmoteScriptCommandEditorViewModel.cs
@@ -13,7 +13,8 @@ namespace SerialLoops.ViewModels.Editors.ScriptCommandEditors;
 public class ChibiEmoteScriptCommandEditorViewModel(ScriptItemCommand command, ScriptEditorViewModel scriptEditor, ILogger log) : ScriptCommandEditorViewModel(command, scriptEditor, log)
 {
     public ObservableCollection<ChibiItem> Chibis { get; } = new(scriptEditor.Window.OpenProject.Items
-        .Where(i => i.Type == ItemDescription.ItemType.Chibi).Cast<ChibiItem>());
+        .Where(i => i.Type == ItemDescription.ItemType.Chibi
+                    && ((ChibiItem)i).ChibiEntries.Any(e => e.Name.Contains("01"))).Cast<ChibiItem>());
     public ChibiItem Chibi
     {
         get => ((ChibiScriptParameter)Command.Parameters[0]).Chibi;

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/ChibiEnterExitScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/ChibiEnterExitScriptCommandEditorViewModel.cs
@@ -13,7 +13,8 @@ namespace SerialLoops.ViewModels.Editors.ScriptCommandEditors;
 public class ChibiEnterExitScriptCommandEditorViewModel(ScriptItemCommand command, ScriptEditorViewModel scriptEditor, ILogger log) : ScriptCommandEditorViewModel(command, scriptEditor, log)
 {
     public ObservableCollection<ChibiItem> Chibis { get; } = new(scriptEditor.Window.OpenProject.Items.Where(
-        i => i.Type == ItemDescription.ItemType.Chibi).Cast<ChibiItem>());
+        i => i.Type == ItemDescription.ItemType.Chibi
+             && ((ChibiItem)i).ChibiEntries.Any(e => e.Name.Contains("01"))).Cast<ChibiItem>());
     public ChibiItem Chibi
     {
         get => ((ChibiScriptParameter)Command.Parameters[0]).Chibi;

--- a/src/SerialLoops/ViewModels/Editors/SystemTextureEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/SystemTextureEditorViewModel.cs
@@ -24,6 +24,8 @@ public class SystemTextureEditorViewModel : EditorViewModel
     public ICommand ReplaceWithPaletteCommand { get; set; }
     public SKBitmap SystemTextureBitmap => SystemTexture.GetTexture();
     public bool UsesCommonPalette => SystemTexture.UsesCommonPalette();
+    public bool UsesMainPalette => SystemTexture.UsesMainPalette();
+    public bool UsesChessPalette => SystemTexture.UsesChessPalette();
     public SKBitmap PaletteBitmap => SystemTexture.Grp.GetPalette();
 
     public SystemTextureEditorViewModel(SystemTextureItem item, MainWindowViewModel window, Project project, ILogger log) : base(item, window, log, project)

--- a/src/SerialLoops/Views/Dialogs/AddScenarioCommandDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/AddScenarioCommandDialog.axaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:assets="using:SerialLoops.Assets"
         xmlns:controls="using:SerialLoops.Controls"
+        xmlns:utility="using:SerialLoops.Utility"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:DataType="vm:AddScenarioCommandDialogViewModel"
         x:Class="SerialLoops.Views.Dialogs.AddScenarioCommandDialog"
@@ -15,12 +16,18 @@
         ExtendClientAreaChromeHints="NoChrome"
         Title="{x:Static assets:Strings.Add_Command}"
         Name="AddCommandDialog">
+
     <Panel>
         <controls:AcrylicBorderHandler/>
 
         <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto" VerticalAlignment="Center">
-            <TextBlock Text="{x:Static assets:Strings.Command_Type_}" Margin="10"/>
-            <ComboBox Grid.Column="1" Grid.Row="0" ItemsSource="{Binding Verbs}" SelectedItem="{Binding SelectedVerb}" Margin="5"/>
+            <TextBlock Text="{x:Static assets:Strings.Command_Type_}" VerticalAlignment="Center" Margin="10"/>
+            <StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal" Spacing="3" Margin="5">
+                <ComboBox ItemsSource="{Binding Verbs}"
+                          SelectedItem="{Binding SelectedVerb}"/>
+                <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                     ToolTip.Tip="{Binding SelectedVerb, Converter={x:Static utility:SLConverters.ScenarioVerbHelpConverter}}"/>
+            </StackPanel>
             <StackPanel Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Margin="10" Spacing="5" HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button Content="{x:Static assets:Strings.Cancel}" Command="{Binding CancelCommand}" CommandParameter="{Binding #AddCommandDialog}" IsCancel="True"/>
                 <Button Content="{x:Static assets:Strings.Create}" Command="{Binding CreateCommand}" CommandParameter="{Binding #AddCommandDialog}" IsDefault="True"/>

--- a/src/SerialLoops/Views/Dialogs/AddScriptCommandDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/AddScriptCommandDialog.axaml
@@ -5,8 +5,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:assets="using:SerialLoops.Assets"
         xmlns:controls="using:SerialLoops.Controls"
+        xmlns:utility="using:SerialLoops.Utility"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        Width="200" Height="150"
+        SizeToContent="Width" Height="150"
         TransparencyLevelHint="AcrylicBlur"
         Background="{DynamicResource FallbackBackgroundColor}"
         ExtendClientAreaToDecorationsHint="True"
@@ -21,8 +22,12 @@
         <StackPanel Orientation="Vertical" Spacing="20" Margin="15">
             <StackPanel Orientation="Vertical" Spacing="3">
                 <TextBlock Text="{x:Static assets:Strings.Select_Command_Type}"/>
-                <ComboBox ItemsSource="{Binding CommandVerbs}" SelectedItem="{Binding SelectedCommandVerb}"
-                          IsDropDownOpen="True" Name="CommandBox"/>
+                <StackPanel Orientation="Horizontal" Spacing="3">
+                    <ComboBox ItemsSource="{Binding CommandVerbs}" SelectedItem="{Binding SelectedCommandVerb}"
+                              IsDropDownOpen="True" Name="CommandBox"/>
+                    <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                         ToolTip.Tip="{Binding SelectedCommandVerb, Converter={x:Static utility:SLConverters.ScriptVerbStringHelpConverter}}"/>
+                </StackPanel>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="5">
                 <Button Content="{x:Static assets:Strings.Cancel}" Command="{Binding CancelCommand}"

--- a/src/SerialLoops/Views/Dialogs/BgmLoopPropertiesDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/BgmLoopPropertiesDialog.axaml
@@ -30,7 +30,7 @@
                 <StackPanel Height="{Binding Waveform.Height, Converter={StaticResource SubtractionConverter},
                             ConverterParameter=65}"/>
                 <StackPanel Orientation="Horizontal" Spacing="3">
-                    <TextBlock Text="{x:Static assets:Strings.Start}"/>
+                    <TextBlock Text="{x:Static assets:Strings.Start}" VerticalAlignment="Center"/>
                     <NumericUpDown Name="StartSampleBox" Minimum="0" Maximum="{Binding #EndSampleBox.Value}"
                                    FormatString="0.0000">
                         <NumericUpDown.Value>
@@ -42,7 +42,7 @@
                     </NumericUpDown>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="3">
-                    <TextBlock Text="{x:Static assets:Strings.End}"/>
+                    <TextBlock Text="{x:Static assets:Strings.End}" VerticalAlignment="Center"/>
                     <NumericUpDown Name="EndSampleBox" Minimum="{Binding #StartSampleBox.Value}" FormatString="0.0000">
                         <NumericUpDown.Maximum>
                             <MultiBinding Converter="{StaticResource SampleToTimestampConverter}">
@@ -59,7 +59,7 @@
                     </NumericUpDown>
                 </StackPanel>
             </StackPanel>
-            <StackPanel Orientation="Vertical" Spacing="5">
+            <StackPanel Orientation="Vertical" Spacing="5" VerticalAlignment="Center">
                 <Image Source="{Binding Waveform, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
                        Width="{Binding Waveform.Width}" Height="{Binding Waveform.Height}"/>
                 <Slider Name="StartSampleSlider" Width="{Binding Waveform.Width}" Minimum="0"
@@ -69,7 +69,7 @@
                         Maximum="{Binding #EndSampleBox.Maximum}"
                         ValueChanged="EndSlider_ValueChanged"/>
                 <StackPanel Orientation="Vertical" Spacing="3" HorizontalAlignment="Right" Width="{Binding Waveform.Width}">
-                    <StackPanel Orientation="Horizontal" Spacing="3">
+                    <StackPanel Orientation="Horizontal" Spacing="3" HorizontalAlignment="Right">
                         <Button Content="{x:Static assets:Strings.Cancel}" IsCancel="True" Command="{Binding CancelCommand}"
                                 CommandParameter="{Binding #BgmLoopPropsDialog}"/>
                         <Button Content="{x:Static assets:Strings.Save}" IsDefault="True" Command="{Binding SaveCommand}"

--- a/src/SerialLoops/Views/Dialogs/BgmVolumePropertiesDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/BgmVolumePropertiesDialog.axaml
@@ -27,8 +27,13 @@
                 <controls:SoundPlayerPanel DataContext="{Binding VolumePreviewPlayer}"/>
                 <StackPanel Orientation="Vertical" Spacing="5">
                     <Slider Name="VolumeSlider" Minimum="0" Maximum="200" Height="{Binding Waveform.Height}"
-                            Orientation="Vertical" Value="{Binding Volume}" />
-                    <Button Content="{x:Static assets:Strings.Normalize}" Command="{Binding NormalizeCommand}"/>
+                            Orientation="Vertical" Value="{Binding Volume}" ToolTip.Tip="{Binding Volume}"/>
+                    <Button Command="{Binding NormalizeCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="3">
+                            <TextBlock Text="{x:Static assets:Strings.Normalize}" VerticalAlignment="Center"/>
+                            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" ToolTip.Tip="{x:Static assets:Strings.BgmVolumeNormalizeHelp}"/>
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
                 <Image Source="{Binding Waveform, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
                        Width="{Binding Waveform.Width}" Height="{Binding Waveform.Height}"/>

--- a/src/SerialLoops/Views/Dialogs/SaveSlotEditorDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/SaveSlotEditorDialog.axaml
@@ -43,25 +43,25 @@
                             <HeaderedContentControl Grid.Row="1" Grid.Column="0" Header="{x:Static assets:Strings.Volume_Config}" Margin="10"
                                            HorizontalAlignment="Center" HorizontalContentAlignment="Center">
                                 <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,Auto" VerticalAlignment="Center">
-                                    <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Music_}" />
+                                    <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Music_}" />
                                     <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0"
                                                    Value="{Binding BgmVolume}" Minimum="0"
                                                    Maximum="100" FormatString="N0" Increment="1"
                                                    ParsingNumberStyle="Integer" />
 
-                                    <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Sound_Effects_}" />
+                                    <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Sound_Effects_}" />
                                     <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0"
                                                    Value="{Binding SfxVolume}" Minimum="0"
                                                    Maximum="100" FormatString="N0" Increment="1"
                                                    ParsingNumberStyle="Integer" />
 
-                                    <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Dialogue_}" />
+                                    <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Dialogue_}" />
                                     <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0"
                                                    Value="{Binding WordsVolume}" Minimum="0"
                                                    Maximum="100" FormatString="N0" Increment="1"
                                                    ParsingNumberStyle="Integer" />
 
-                                    <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.Voices_}" />
+                                    <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Voices_}" />
                                     <NumericUpDown Grid.Column="1" Grid.Row="3" Margin="10,0,0,0"
                                                    Value="{Binding VoiceVolume}" Minimum="0"
                                                    Maximum="100" FormatString="N0" Increment="1"
@@ -165,22 +165,22 @@
                                                            HorizontalAlignment="Center" HorizontalContentAlignment="Center">
                                                 <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto">
                                                     <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="5">
-                                                        <TextBlock Margin="0,7,0,0" Text="{x:Static assets:Strings.Level}"/>
+                                                        <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Level}"/>
                                                         <NumericUpDown Value="{Binding Level}" Minimum="1"
                                                                        Maximum="5" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                                     </StackPanel>
                                                     <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Spacing="5">
-                                                        <TextBlock Margin="0,7,0,0" Text="{x:Static assets:Strings.Remaining_Uses}"/>
+                                                        <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Remaining_Uses}"/>
                                                         <NumericUpDown Value="{Binding RemainingUses}" Minimum="0"
                                                                        Maximum="9" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                                     </StackPanel>
                                                     <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="5">
-                                                        <TextBlock Margin="0,7,0,0" Text="{x:Static assets:Strings.Uses_Since_Level_Up}"/>
+                                                        <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Uses_Since_Level_Up}"/>
                                                         <NumericUpDown Value="{Binding UsesSinceLevelUp}" Minimum="0"
                                                                        Maximum="10" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                                     </StackPanel>
                                                     <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Spacing="5">
-                                                        <TextBlock Margin="0,7,0,0" Text="{x:Static assets:Strings.Uses_to_Level_Up}"/>
+                                                        <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Uses_to_Level_Up}"/>
                                                         <NumericUpDown Value="{Binding UsesToLevelUp}" Minimum="1"
                                                                        Maximum="10" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                                     </StackPanel>
@@ -199,16 +199,16 @@
                          GotFocus="CharacterPortraitTab_OnGotFocus">
                     <ScrollViewer>
                         <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,Auto">
-                            <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Save_Time_}"/>
+                            <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Save_Time_}"/>
                             <StackPanel Grid.Row="0" Grid.Column="1" Margin="10,0,0,0" Orientation="Horizontal" Spacing="3">
                                 <CalendarDatePicker SelectedDate="{Binding SaveDate}"/>
                                 <TimePicker SelectedTime="{Binding SaveTime}"/>
                             </StackPanel>
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Scenario_Command_Index_}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Scenario_Command_Index_}"/>
                             <controls:ScenarioCommandPicker Grid.Row="1" Grid.Column="1" DataContext="{Binding ScenarioCommandPickerVm}"/>
 
-                            <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Episode_Number}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Episode_Number}"/>
                             <NumericUpDown Grid.Row="2" Grid.Column="1" Margin="10,0,0,0" Value="{Binding Episode}" Minimum="1"
                                            Maximum="5" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
 
@@ -259,37 +259,37 @@
                                 <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto,Auto">
                                     <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="5">
                                         <Image Source="{Binding HaruhiVoicePortrait, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
-                                        <TextBlock Text="{Binding HaruhiName}" Margin="0,7,0,0"/>
+                                        <TextBlock Text="{Binding HaruhiName}" VerticalAlignment="Center"/>
                                         <NumericUpDown Value="{Binding HaruhiFriendshipLevel}" Minimum="1"
                                                        Maximum="255" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                     </StackPanel>
                                     <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Spacing="5">
                                         <Image Source="{Binding AsahinaVoicePortrait, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
-                                        <TextBlock Text="{Binding AsahinaName}" Margin="0,7,0,0"/>
+                                        <TextBlock Text="{Binding AsahinaName}" VerticalAlignment="Center"/>
                                         <NumericUpDown Value="{Binding AsahinaFriendshipLevel}" Minimum="1"
                                                        Maximum="255" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                     </StackPanel>
                                     <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="5">
                                         <Image Source="{Binding NagatoVoicePortrait, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
-                                        <TextBlock Text="{Binding NagatoName}" Margin="0,7,0,0"/>
+                                        <TextBlock Text="{Binding NagatoName}" VerticalAlignment="Center"/>
                                         <NumericUpDown Value="{Binding NagatoFriendshipLevel}" Minimum="1"
                                                        Maximum="255" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                     </StackPanel>
                                     <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Spacing="5">
                                         <Image Source="{Binding KoizumiVoicePortrait, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
-                                        <TextBlock Text="{Binding KoizumiName}" Margin="0,7,0,0"/>
+                                        <TextBlock Text="{Binding KoizumiName}" VerticalAlignment="Center"/>
                                         <NumericUpDown Value="{Binding KoizumiFriendshipLevel}" Minimum="1"
                                                        Maximum="255" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                     </StackPanel>
                                     <StackPanel Grid.Row="2" Grid.Column="0" Orientation="Horizontal" Spacing="5">
                                         <Image Source="{Binding TsuruyaVoicePortrait, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
-                                        <TextBlock Text="{Binding TsuruyaName}" Margin="0,7,0,0"/>
+                                        <TextBlock Text="{Binding TsuruyaName}" VerticalAlignment="Center"/>
                                         <NumericUpDown Value="{Binding TsuruyaFriendshipLevel}" Minimum="1"
                                                        Maximum="255" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                     </StackPanel>
                                     <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Spacing="5">
                                         <Border Width="16" Height="16" Background="Transparent"/>
-                                        <TextBlock Text="{x:Static assets:Strings.Unknown}" Margin="0,7,0,0"/>
+                                        <TextBlock Text="{x:Static assets:Strings.Unknown}" VerticalAlignment="Center"/>
                                         <NumericUpDown Value="{Binding UnknownFriendshipLevel}" Minimum="1"
                                                        Maximum="255" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" />
                                     </StackPanel>
@@ -303,19 +303,19 @@
                     <ScrollViewer>
                         <Grid RowDefinitions="Auto,Auto,Auto,*" ColumnDefinitions="Auto,*">
                             <StackPanel Margin="10,5" Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="5">
-                                <TextBlock Margin="0,7,0,0" Text="{x:Static assets:Strings.Script_}"/>
+                                <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Script_}"/>
                                 <ComboBox ItemsSource="{Binding ScriptItems}" SelectedItem="{Binding SelectedScriptItem}"/>
                                 <controls:ItemLink Item="{Binding SelectedScriptItem}" Tabs="{Binding Tabs}"
                                                    IsVisible="{Binding Tabs, Converter={x:Static ObjectConverters.IsNotNull}}"/>
                             </StackPanel>
 
                             <StackPanel Margin="10,5" Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="5">
-                                <TextBlock Margin="0,7,0,0" Text="{x:Static assets:Strings.Script_Section}"/>
+                                <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Script_Section}"/>
                                 <ComboBox ItemsSource="{Binding ScriptSections}" SelectedItem="{Binding SelectedScriptSection}"/>
                             </StackPanel>
 
                             <StackPanel Margin="10,5" Grid.Row="2" Grid.Column="0" Orientation="Horizontal" Spacing="5">
-                                <TextBlock Margin="0,7,0,0" Text="{x:Static assets:Strings.Command_Index_}"/>
+                                <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Command_Index_}"/>
                                 <NumericUpDown Value="{Binding ScriptCommandIndex}"
                                                Minimum="0" Maximum="{Binding SelectedScriptSection.Objects.Count, Converter={StaticResource SubtractionConverter}, ConverterParameter=1}"
                                                FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>

--- a/src/SerialLoops/Views/Editors/BackgroundEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/BackgroundEditorView.axaml
@@ -14,22 +14,33 @@
         <StackPanel Orientation="Vertical" Spacing="5" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Image Source="{Binding BgBitmap, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
                    Width="{Binding BgBitmap.Width}" Height="{Binding BgBitmap.Height}"/>
-            <TextBlock Text="{Binding BgDescription}"/>
+            <StackPanel Orientation="Horizontal" Spacing="3">
+                <TextBlock Text="{Binding BgDescription}" VerticalAlignment="Center"/>
+                <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" ToolTip.Tip="{Binding DescriptionToolTip}"
+                     VerticalAlignment="Center"/>
+            </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="3">
                 <Button Content="{x:Static assets:Strings.Export}" Command="{Binding ExportCommand}"/>
                 <Button Content="{x:Static assets:Strings.Replace}" Command="{Binding ReplaceCommand}"/>
             </StackPanel>
-            <StackPanel Name="CgPanel" IsVisible="{Binding ShowExtras}" HorizontalAlignment="Left">
-                <TextBox Name="CgBox" Width="200" Text="{Binding Bg.CgName, Mode=OneTime}">
-                    <i:Interaction.Behaviors>
-                        <ia:EventTriggerBehavior EventName="TextChanged" SourceObject="{Binding #CgBox}">
-                            <ia:InvokeCommandAction Command="{Binding CgNameChangeCommand}" CommandParameter="{Binding #CgBox.Text}" />
-                        </ia:EventTriggerBehavior>
-                    </i:Interaction.Behaviors>
-                </TextBox>
-                <TextBlock Text="{Binding FlagDescription}"/>
-                <TextBlock Text="{Binding UnknownExtrasShortDescription}"/>
-                <TextBlock Text="{Binding UnknownExtrasByteDescription}"/>
+            <StackPanel Name="CgPanel" IsVisible="{Binding ShowExtras}" Orientation="Vertical"
+                        HorizontalAlignment="Left" Spacing="10">
+                <StackPanel Orientation="Horizontal" Spacing="3">
+                    <TextBox Name="CgBox" Width="200" Text="{Binding Bg.CgName, Mode=OneTime}">
+                        <i:Interaction.Behaviors>
+                            <ia:EventTriggerBehavior EventName="TextChanged" SourceObject="{Binding #CgBox}">
+                                <ia:InvokeCommandAction Command="{Binding CgNameChangeCommand}" CommandParameter="{Binding #CgBox.Text}" />
+                            </ia:EventTriggerBehavior>
+                        </i:Interaction.Behaviors>
+                    </TextBox>
+                    <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                         ToolTip.Tip="{x:Static assets:Strings.BackgroundEditorHelpCgName}"/>
+                </StackPanel>
+                <StackPanel Orientation="Vertical" Spacing="3">
+                    <TextBlock Text="{Binding FlagDescription}"/>
+                    <TextBlock Text="{Binding UnknownExtrasShortDescription}"/>
+                    <TextBlock Text="{Binding UnknownExtrasByteDescription}"/>
+                </StackPanel>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/src/SerialLoops/Views/Editors/BackgroundMusicEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/BackgroundMusicEditorView.axaml
@@ -11,8 +11,18 @@
     <Grid RowDefinitions="Auto,Auto,Auto,*">
         <controls:SoundPlayerPanel Name="Player" Grid.Row="0" DataContext="{Binding BgmPlayer}"/>
         <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="3" Margin="2">
-            <Button Content="{x:Static assets:Strings.Manage_Loop}" Command="{Binding ManageLoopCommand}"/>
-            <Button Content="{x:Static assets:Strings.Adjust_Volume}" Command="{Binding AdjustVolumeCommand}"/>
+            <Button Command="{Binding ManageLoopCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="3">
+                    <TextBlock Text="{x:Static assets:Strings.Manage_Loop}" VerticalAlignment="Center"/>
+                    <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" ToolTip.Tip="{x:Static assets:Strings.BgmEditorLoopInfoHelp}"/>
+                </StackPanel>
+            </Button>
+            <Button Command="{Binding AdjustVolumeCommand}">
+                <StackPanel Orientation="Horizontal" Spacing="3">
+                    <TextBlock Text="{x:Static assets:Strings.Adjust_Volume}" VerticalAlignment="Center"/>
+                    <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" ToolTip.Tip="{x:Static assets:Strings.BgmEditorVolumeHelp}"/>
+                </StackPanel>
+            </Button>
         </StackPanel>
         <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="3" Margin="2">
             <Button Content="{x:Static assets:Strings.Replace}" Command="{Binding ReplaceCommand}"/>

--- a/src/SerialLoops/Views/Editors/CharacterEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/CharacterEditorView.axaml
@@ -38,12 +38,18 @@
         <Image Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center" Stretch="None" Margin="15"
                Source="{Binding NameplateBitmap, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"/>
 
-        <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Voice_Font}"/>
+        <StackPanel Grid.Row="5" Grid.Column="0" Orientation="Horizontal" Spacing="3" Margin="0 0 10 0">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Voice_Font}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center" ToolTip.Tip="{x:Static assets:Strings.CharacterEditorVoiceFontHelp}"/>
+        </StackPanel>
         <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding Sfxs}" SelectedItem="{Binding VoiceFont}"/>
         <controls:ItemLink Grid.Row="5" Grid.Column="2" Item="{Binding VoiceFont}"
                            Tabs="{Binding Tabs}"/>
 
-        <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Text_Timer}"/>
+        <StackPanel Grid.Row="6" Grid.Column="0" Orientation="Horizontal" Spacing="3" Margin="0 0 10 0">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Text_Timer}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center" ToolTip.Tip="{x:Static assets:Strings.CharacterEditorTextTimerHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Row="6" Grid.Column="1" Value="{Binding TextTimer}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ChessPuzzleEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ChessPuzzleEditorView.axaml
@@ -62,15 +62,15 @@
             </ItemsControl.Styles>
         </ItemsControl>
         <Grid Grid.Column="1" Grid.Row="0" ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
-            <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Number_of_Moves}"/>
+            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Number_of_Moves}"/>
             <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Value="{Binding NumMoves}"
                            Minimum="0" Maximum="5" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-            <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Time_Limit}"/>
+            <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Time_Limit}"/>
             <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Value="{Binding TimeLimit}"
                            Minimum="0" Maximum="999" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-            <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Unknown}"/>
+            <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Unknown}"/>
             <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Value="{Binding Unknown08}"
                            Minimum="0" Maximum="10000" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
         </Grid>

--- a/src/SerialLoops/Views/Editors/ChibiEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ChibiEditorView.axaml
@@ -15,7 +15,11 @@
 
         <HeaderedContentControl Grid.Row="1" Grid.Column="0" Header="{x:Static assets:Strings.Animation}">
             <StackPanel Orientation="Vertical" Spacing="10">
-                <ComboBox ItemsSource="{Binding ChibiAnimationNames}" SelectedItem="{Binding SelectedAnimation}"/>
+                <StackPanel Orientation="Horizontal" Spacing="3">
+                    <ComboBox ItemsSource="{Binding ChibiAnimationNames}" SelectedItem="{Binding SelectedAnimation}"
+                              VerticalAlignment="Center"/>
+                    <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center" ToolTip.Tip="{Binding SelectedAnimToolTip}"/>
+                </StackPanel>
                 <controls:ChibiDirectionSelector DataContext="{Binding DirectionSelector}"/>
             </StackPanel>
         </HeaderedContentControl>

--- a/src/SerialLoops/Views/Editors/ScenarioCommandEditors/LoadSceneScenarioCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScenarioCommandEditors/LoadSceneScenarioCommandEditorView.axaml
@@ -10,8 +10,12 @@
              x:Class="SerialLoops.Views.Editors.ScenarioCommandEditors.LoadSceneScenarioCommandEditorView">
     <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto"
           VerticalAlignment="Center" Margin="10">
-        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}"/>
-        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedScenarioCommand.Verb}"/>
+        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal" Spacing="3">
+            <TextBlock Text="{Binding SelectedScenarioCommand.Verb}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScenarioVerbHelpLOAD_SCENE}"/>
+        </StackPanel>
         <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Script}"/>
         <StackPanel Orientation="Horizontal" Spacing="3" Grid.Row="1" Grid.Column="1" Margin="5">
             <ComboBox Margin="5" ItemsSource="{Binding Scripts}" SelectedItem="{Binding Scene}"/>

--- a/src/SerialLoops/Views/Editors/ScenarioCommandEditors/PuzzlePhaseScenarioCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScenarioCommandEditors/PuzzlePhaseScenarioCommandEditorView.axaml
@@ -10,8 +10,12 @@
              x:Class="SerialLoops.Views.Editors.ScenarioCommandEditors.PuzzlePhaseScenarioCommandEditorView">
     <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto"
           VerticalAlignment="Center" Margin="10">
-        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}"/>
-        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedScenarioCommand.Verb}"/>
+        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal" Spacing="3">
+            <TextBlock Text="{Binding SelectedScenarioCommand.Verb}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScenarioVerbHelpPUZZLE_PHASE}"/>
+        </StackPanel>
         <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Puzzle}"/>
         <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Spacing="3" Margin="5">
             <ComboBox Margin="5" ItemsSource="{Binding Puzzles}" SelectedItem="{Binding Puzzle}"/>

--- a/src/SerialLoops/Views/Editors/ScenarioCommandEditors/RouteSelectScenarioCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScenarioCommandEditors/RouteSelectScenarioCommandEditorView.axaml
@@ -11,8 +11,12 @@
              x:Class="SerialLoops.Views.Editors.ScenarioCommandEditors.RouteSelectScenarioCommandEditorView">
     <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto"
           VerticalAlignment="Center" Margin="10">
-        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}"/>
-        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedScenarioCommand.Verb}"/>
+        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal" Spacing="3">
+            <TextBlock Text="{Binding SelectedScenarioCommand.Verb}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScenarioVerbHelpROUTE_SELECT}"/>
+        </StackPanel>
         <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Group_Selection}"/>
         <StackPanel Orientation="Horizontal" Spacing="3" Grid.Row="1" Grid.Column="1" Margin="5">
             <ComboBox ItemsSource="{Binding GroupSelections}" SelectedItem="{Binding GroupSelection}"/>

--- a/src/SerialLoops/Views/Editors/ScenarioCommandEditors/ScenarioCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScenarioCommandEditors/ScenarioCommandEditorView.axaml
@@ -4,13 +4,18 @@
              xmlns:vm="using:SerialLoops.ViewModels.Editors.ScenarioCommandEditors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:assets="using:SerialLoops.Assets"
+             xmlns:utility="using:SerialLoops.Utility"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:ScenarioCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScenarioCommandEditors.ScenarioCommandEditorView">
     <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto"
           VerticalAlignment="Center" Margin="10">
-        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}"/>
-        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedScenarioCommand.Verb}"/>
+        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Command}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal" Spacing="3">
+            <TextBlock Text="{Binding SelectedScenarioCommand.Verb}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{Binding SelectedScenarioCommand.Verb, Converter={x:Static utility:SLConverters.ScenarioVerbHelpConverter}}"/>
+        </StackPanel>
         <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" Text="{x:Static assets:Strings.Parameter_Value}"/>
         <NumericUpDown Minimum="0" Maximum="{Binding MaxValue}" ClipValueToMinMax="True" FormatString="0"
                        Value="{Binding Parameter}" Grid.Row="1" Grid.Column="1" Margin="5"/>

--- a/src/SerialLoops/Views/Editors/ScenarioEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScenarioEditorView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vm="using:SerialLoops.ViewModels.Editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:assets="using:SerialLoops.Assets"
              xmlns:models="using:SerialLoops.Models"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:ScenarioEditorViewModel"
@@ -16,21 +17,21 @@
 
         <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right"
                     Width="{Binding #CommandsBox.Width}" Spacing="5" Margin="5">
-            <Button ToolTip.Tip="Add Command" Width="22" Command="{Binding AddCommand}">
+            <Button ToolTip.Tip="{x:Static assets:Strings.Add_Command}" Width="22" Command="{Binding AddCommand}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Add.svg" Width="22"/>
             </Button>
-            <Button ToolTip.Tip="Remove Command" Width="22" Command="{Binding DeleteCommand}"
+            <Button ToolTip.Tip="{x:Static assets:Strings.Remove_Command}" Width="22" Command="{Binding DeleteCommand}"
                     IsEnabled="{Binding SelectedCommand, Converter={x:Static ObjectConverters.IsNotNull}}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Remove.svg" Width="22"/>
             </Button>
-            <Button ToolTip.Tip="Clear Scenario" Width="22" Command="{Binding ClearCommand}">
+            <Button ToolTip.Tip="{x:Static assets:Strings.Clear_Scenario}" Width="22" Command="{Binding ClearCommand}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Clear.svg" Width="22"/>
             </Button>
-            <Button ToolTip.Tip="Move Command Up" Width="22" Command="{Binding UpCommand}"
+            <Button ToolTip.Tip="{x:Static assets:Strings.Move_Command_Up}" Width="22" Command="{Binding UpCommand}"
                     IsEnabled="{Binding SelectedCommand, Converter={x:Static ObjectConverters.IsNotNull}}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Move_Up.svg" Width="22"/>
             </Button>
-            <Button ToolTip.Tip="Move Command Down" Width="22" Command="{Binding DownCommand}"
+            <Button ToolTip.Tip="{x:Static assets:Strings.Move_Command_Down}" Width="22" Command="{Binding DownCommand}"
                     IsEnabled="{Binding SelectedCommand, Converter={x:Static ObjectConverters.IsNotNull}}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Move_Down.svg" Width="22"/>
             </Button>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispCgScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispCgScriptCommandEditorView.axaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:BgDispCgScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.BgDispCgScriptCommandEditorView">
-    <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto">
+    <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto,Auto">
         <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static assets:Strings.Background__CG_}" VerticalAlignment="Center"/>
         <StackPanel Grid.Row="0" Grid.Column="1" Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ReplaceCgCommand}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispCgScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispCgScriptCommandEditorView.axaml
@@ -15,7 +15,7 @@
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Cg}"/>
         </StackPanel>
 
-        <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="">
+        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="">
             <TextBlock Text="{x:Static assets:Strings.Display_from_Bottom}" VerticalAlignment="Center"/>
             <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
                  ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpDisplayFromBottom}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispCgScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispCgScriptCommandEditorView.axaml
@@ -10,12 +10,16 @@
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.BgDispCgScriptCommandEditorView">
     <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto">
         <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static assets:Strings.Background__CG_}" VerticalAlignment="Center"/>
-        <StackPanel Grid.Row="0" Grid.Column="1"  Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
+        <StackPanel Grid.Row="0" Grid.Column="1" Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ReplaceCgCommand}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Cg}"/>
         </StackPanel>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static assets:Strings.Display_from_Bottom}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="">
+            <TextBlock Text="{x:Static assets:Strings.Display_from_Bottom}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpDisplayFromBottom}"/>
+        </StackPanel>
         <CheckBox Grid.Row="1" Grid.Column="1" Margin="10,0,0,0" IsChecked="{Binding DisplayFromBottom}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgDispScriptCommandEditorView.axaml
@@ -9,7 +9,7 @@
              x:DataType="vm:BgDispScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.BgDispScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static assets:Strings.Background}" Margin="0,7,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static assets:Strings.Background}" VerticalAlignment="Center"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ReplaceBgCommand}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Bg}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgFadeScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgFadeScriptCommandEditorView.axaml
@@ -9,19 +9,19 @@
              x:DataType="vm:BgFadeScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.BgFadeScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Background}" />
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Background}" />
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ReplaceBgCommand}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Bg}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Background__CG_}" />
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Background__CG_}" />
         <StackPanel Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ReplaceCgCommand}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Cg}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Minimum="0" Maximum="100" Value="{Binding FadeTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgScrollScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgScrollScriptCommandEditorView.axaml
@@ -8,7 +8,7 @@
              x:DataType="vm:BgScrollScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.BgScrollScriptCommandEditorView">
     <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto">
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static assets:Strings.Scroll_Direction}"/>
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static assets:Strings.Scroll_Direction}" VerticalAlignment="Center"/>
         <ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding ScrollDirections}" SelectedItem="{Binding ScrollDirection}">
             <ComboBox.ItemTemplate>
                 <DataTemplate DataType="vm:LocalizedBgScrollDirection">
@@ -22,7 +22,11 @@
             </ComboBox.ItemContainerTheme>
         </ComboBox>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static assets:Strings.Scroll_Speed}"/>
+        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="3">
+            <TextBlock Text="{x:Static assets:Strings.Scroll_Speed}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip=""/>
+        </StackPanel>
         <NumericUpDown Grid.Row="1" Grid.Column="1" Value="{Binding ScrollSpeed}" Minimum="1" Maximum="6"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgmPlayScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgmPlayScriptCommandEditorView.axaml
@@ -5,29 +5,28 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:assets="using:SerialLoops.Assets"
              xmlns:controls="using:SerialLoops.Controls"
-             xmlns:items="clr-namespace:SerialLoops.Lib.Items;assembly=SerialLoops.Lib"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:BgmPlayScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.BgmPlayScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Music}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Music}"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="5">
             <ComboBox ItemsSource="{Binding Bgms}" SelectedItem="{Binding Music}"/>
             <controls:ItemLink Item="{Binding Music}" Tabs="{Binding Tabs}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Mode}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Mode}"/>
         <ComboBox Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Volume}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Volume}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Value="{Binding Volume}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="0" Maximum="100"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" Value="{Binding FadeInTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="-1" Maximum="{Binding MaxShort}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Value="{Binding FadeOutTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="-1" Maximum="{Binding MaxShort}"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ChessLoadScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ChessLoadScriptCommandEditorView.axaml
@@ -9,7 +9,7 @@
              x:DataType="vm:ChessLoadScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ChessLoadScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Chess_File}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Chess_File}"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="5">
             <ComboBox ItemsSource="{Binding ChessPuzzles}" SelectedItem="{Binding ChessPuzzle}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding ChessPuzzle}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/DialogueScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/DialogueScriptCommandEditorView.axaml
@@ -23,42 +23,50 @@
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding CharacterSprite}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static assets:Strings.Sprite_Entrance_Transition}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static assets:Strings.Sprite_Entrance_Transition}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="2" ItemsSource="{Binding SpriteEntranceTransitions}" Margin="10,5,0,0"
                   SelectedItem="{Binding SpriteEntranceTransition}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" Text="{x:Static assets:Strings.Sprite_Exit_Move_Transition}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="3" Text="{x:Static assets:Strings.Sprite_Exit_Move_Transition}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="3" ItemsSource="{Binding SpriteExitTransitions}" Margin="10,5,0,0"
                   SelectedItem="{Binding SpriteExitTransition}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" Text="{x:Static assets:Strings.Sprite_Shake}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="4" Text="{x:Static assets:Strings.Sprite_Shake}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="4" ItemsSource="{Binding SpriteShakeEffects}" Margin="10,5,0,0"
                   SelectedItem="{Binding SpriteShakeEffect}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="5" Text="{x:Static assets:Strings.Voice_Line}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="5" Text="{x:Static assets:Strings.Voice_Line}" VerticalAlignment="Center"/>
         <StackPanel Grid.Column="1" Grid.Row="5" Margin="10,5,0,0" Orientation="Horizontal" VerticalAlignment="Center"
                     Spacing="10">
             <ComboBox ItemsSource="{Binding VoicedLines}" SelectedItem="{Binding VoicedLine}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding VoicedLine}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="6" Text="{x:Static assets:Strings.Text_Voice_Font}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="6" Text="{x:Static assets:Strings.Text_Voice_Font}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="6" ItemsSource="{Binding Characters}" SelectedItem="{Binding TextVoiceFont}" Margin="10,5,0,0"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="7" Text="{x:Static assets:Strings.Text_Speed}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="7" Text="{x:Static assets:Strings.Text_Speed}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="7" ItemsSource="{Binding Characters}" SelectedItem="{Binding TextSpeed}" Margin="10,5,0,0"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="8" Text="{x:Static assets:Strings.Text_Entrance_Effect}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="8" Text="{x:Static assets:Strings.Text_Entrance_Effect}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="8" ItemsSource="{Binding TextEntranceEffects}" SelectedItem="{Binding TextEntranceEffect}" Margin="10,5,0,0"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="9" Text="{x:Static assets:Strings.Sprite_Layer}" Margin="0,12,0,0"/>
+        <StackPanel Grid.Column="0" Grid.Row="9" Orientation="Horizontal" Spacing="3">
+            <TextBlock Text="{x:Static assets:Strings.Sprite_Layer}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSpriteLayer}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="9" Minimum="{Binding MinShort}" Maximum="{Binding MaxShort}" Value="{Binding SpriteLayer}"
                        Margin="10,5,0,0" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="10" Text="{x:Static assets:Strings.Don_t_Clear_Text}" Margin="0,12,0,0"/>
+        <StackPanel Grid.Column="0" Grid.Row="10">
+            <TextBlock Text="{x:Static assets:Strings.Don_t_Clear_Text}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpDontClearText}"/>
+        </StackPanel>
         <CheckBox Grid.Column="1" Grid.Row="10" Margin="10,5,0,0" IsChecked="{Binding DontClearText}" />
 
-        <TextBlock Grid.Column="0" Grid.Row="11" Text="{x:Static assets:Strings.Disable_Lip_Flap}" Margin="0,12,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="11" Text="{x:Static assets:Strings.Disable_Lip_Flap}" VerticalAlignment="Center"/>
         <CheckBox Grid.Column="1" Grid.Row="11" Margin="10,5,0,0" IsChecked="{Binding DisableLipFlap}" />
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/FlagScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/FlagScriptCommandEditorView.axaml
@@ -8,10 +8,10 @@
              x:DataType="vm:FlagScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.FlagScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Flag}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Flag}"/>
         <TextBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Text="{Binding Flag}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Set_Clear}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Set_Clear}"/>
         <CheckBox Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" IsChecked="{Binding SetClear}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/GotoScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/GotoScriptCommandEditorView.axaml
@@ -8,7 +8,7 @@
              x:DataType="vm:GotoScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.GotoScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Script_Section}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Script_Section}"/>
         <ComboBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" ItemsSource="{Binding ScriptEditor.ScriptSections}"
                   SelectedItem="{Binding SectionToJumpTo}"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/HaruhiMeterScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/HaruhiMeterScriptCommandEditorView.axaml
@@ -8,13 +8,13 @@
              x:DataType="vm:HaruhiMeterScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.HaruhiMeterScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Add}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Add}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0"  Value="{Binding AddAmount}"
                        Minimum="-9" Maximum="9" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" IsVisible="{Binding !NoShow}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Value="{Binding AddNoShowAmount}"
                        Minimum="-9" Maximum="9" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" IsVisible="{Binding NoShow}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Set}" IsVisible="{Binding !NoShow}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Set}" IsVisible="{Binding !NoShow}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Value="{Binding SetAmount}"
                        Minimum="0" Maximum="9" FormatString="N0" Increment="1" ParsingNumberStyle="Integer" IsVisible="{Binding !NoShow}"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ItemDispimgScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ItemDispimgScriptCommandEditorView.axaml
@@ -9,16 +9,16 @@
              x:DataType="vm:ItemDispimgScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ItemDispimgScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Item}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Item}"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ChangeItemCommand}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Item}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Text="{x:Static assets:Strings.Location}" Margin="0,7,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" Text="{x:Static assets:Strings.Location}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" ItemsSource="{Binding Locations}" SelectedItem="{Binding Location}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static assets:Strings.Transition}" Margin="0,7,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static assets:Strings.Transition}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" ItemsSource="{Binding Transitions}" SelectedItem="{Binding Transition}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/KbgDispScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/KbgDispScriptCommandEditorView.axaml
@@ -9,7 +9,7 @@
              x:DataType="vm:KbgDispScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.KbgDispScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static assets:Strings._Kinetic__Background}" Margin="0,7,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static assets:Strings._Kinetic__Background}" VerticalAlignment="Center"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="10">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ReplaceKbgCommand}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Kbg}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/PalEffectScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/PalEffectScriptCommandEditorView.axaml
@@ -8,15 +8,15 @@
              x:DataType="vm:PalEffectScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.PalEffectScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Mode}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Mode}"/>
         <ComboBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" ItemsSource="{Binding PaletteEffects}"
                   SelectedItem="{Binding PaletteEffect}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Value="{Binding TransitionTime}"
                        Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Unknown}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Unknown}"/>
         <CheckBox Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" IsChecked="{Binding Unknown}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SceneGotoScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SceneGotoScriptCommandEditorView.axaml
@@ -9,7 +9,7 @@
              x:DataType="vm:SceneGotoScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.SceneGotoScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Scene}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Scene}"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Spacing="3" Orientation="Horizontal">
             <ComboBox Margin="10,0,0,0" ItemsSource="{Binding Scripts}"
                       SelectedItem="{Binding SelectedScript}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeInScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeInScriptCommandEditorView.axaml
@@ -9,18 +9,18 @@
              x:DataType="vm:ScreenFadeInScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ScreenFadeInScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                        Value="{Binding FadeTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_In_Percentage}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Percentage}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="100"
                        Value="{Binding FadePercentage}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
         <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,15,0,0" Text="{x:Static assets:Strings.Location}"/>
         <controls:ScreenSelector Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" DataContext="{Binding ScreenSelector}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.Color}"/>
+        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
         <ComboBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" ItemsSource="{Binding Colors}" SelectedItem="{Binding Color}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeInScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeInScriptCommandEditorView.axaml
@@ -17,10 +17,18 @@
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="100"
                        Value="{Binding FadePercentage}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,15,0,0" Text="{x:Static assets:Strings.Location}"/>
+        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Location}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandScreenFadeInParamWarning}"/>
+        </StackPanel>
         <controls:ScreenSelector Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" DataContext="{Binding ScreenSelector}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
+        <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandScreenFadeInParamWarning}"/>
+        </StackPanel>
         <ComboBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" ItemsSource="{Binding Colors}" SelectedItem="{Binding Color}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeOutScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeOutScriptCommandEditorView.axaml
@@ -13,21 +13,21 @@
         <utility:SKAvaloniaColorConverter x:Key="ColorConverter"/>
     </UserControl.Resources>
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                        Value="{Binding FadeTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_Out_Percentage}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Percentage}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="100"
                        Value="{Binding FadePercentage}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.CUSTOM_COLOR}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.CUSTOM_COLOR}"/>
         <ColorPicker Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Color="{Binding CustomColor, Converter={StaticResource ColorConverter}, Mode=TwoWay}"/>
 
         <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,15,0,0" Text="{x:Static assets:Strings.Location}"/>
         <controls:ScreenSelector Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" DataContext="{Binding ScreenSelector}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,7,0,0" Text="{x:Static assets:Strings.Color}"/>
+        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
         <ComboBox Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" ItemsSource="{Binding Colors}" SelectedItem="{Binding Color}"/>
     </Grid>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeOutScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeOutScriptCommandEditorView.axaml
@@ -21,13 +21,25 @@
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="100"
                        Value="{Binding FadePercentage}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.CUSTOM_COLOR}"/>
+        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.CUSTOM_COLOR}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpFadeCustomColor}"/>
+        </StackPanel>
         <ColorPicker Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Color="{Binding CustomColor, Converter={StaticResource ColorConverter}, Mode=TwoWay}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,15,0,0" Text="{x:Static assets:Strings.Location}"/>
+        <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Location}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpFadeLocation}"/>
+        </StackPanel>
         <controls:ScreenSelector Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" DataContext="{Binding ScreenSelector}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
+        <StackPanel Grid.Column="0" Grid.Row="4" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpFadeColor}"/>
+        </StackPanel>
         <ComboBox Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" ItemsSource="{Binding Colors}" SelectedItem="{Binding Color}"/>
     </Grid>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFlashScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFlashScriptCommandEditorView.axaml
@@ -12,19 +12,19 @@
         <utility:SKAvaloniaColorConverter x:Key="ColorConverter"/>
     </UserControl.Resources>
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                         Value="{Binding FadeInTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Hold_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Hold_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                         Value="{Binding HoldTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Minimum="0" Maximum="100"
                         Value="{Binding FadeOutTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.CUSTOM_COLOR}"/>
+        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.CUSTOM_COLOR}"/>
         <ColorPicker Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" Color="{Binding Color, Converter={StaticResource ColorConverter}, Mode=TwoWay}"/>
     </Grid>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFlashScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFlashScriptCommandEditorView.axaml
@@ -24,7 +24,7 @@
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Minimum="0" Maximum="100"
                         Value="{Binding FadeOutTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.CUSTOM_COLOR}"/>
+        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
         <ColorPicker Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" Color="{Binding Color, Converter={StaticResource ColorConverter}, Mode=TwoWay}"/>
     </Grid>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenShakeScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenShakeScriptCommandEditorView.axaml
@@ -8,15 +8,15 @@
              x:DataType="vm:ScreenShakeScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ScreenShakeScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Duration__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Duration__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Value="{Binding Duration}" Minimum="0"
                        Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Horizontal_Intensity}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Horizontal_Intensity}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Value="{Binding HorizontalIntensity}" Minimum="0"
                        Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Vertical_Intensity}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Vertical_Intensity}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Value="{Binding VerticalIntensity}" Minimum="0"
                        Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenShakeScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenShakeScriptCommandEditorView.axaml
@@ -8,17 +8,24 @@
              x:DataType="vm:ScreenShakeScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ScreenShakeScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Duration__Frames_}"/>
-        <NumericUpDown Grid.Column="1" Grid.Row="0" Value="{Binding Duration}" Minimum="0"
-                       Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Duration__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpShakeDuration}"/>
+        </StackPanel>
+        <NumericUpDown Grid.Column="1" Grid.Row="0" Value="{Binding Duration}" Minimum="-1"
+                       Maximum="{Binding MaxShort}" FormatString="N0"
+                       Increment="1" ParsingNumberStyle="Integer" Margin="10 0 0 0"/>
 
         <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Horizontal_Intensity}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Value="{Binding HorizontalIntensity}" Minimum="0"
-                       Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+                       Maximum="{Binding MaxShort}" FormatString="N0"
+                       Increment="1" ParsingNumberStyle="Integer" Margin="10 0 0 0"/>
 
         <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Vertical_Intensity}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Value="{Binding VerticalIntensity}" Minimum="0"
-                       Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+                       Maximum="{Binding MaxShort}" FormatString="N0"
+                       Increment="1" ParsingNumberStyle="Integer" Margin="10 0 0 0"/>
     </Grid>
 </UserControl>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SelectScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SelectScriptCommandEditorView.axaml
@@ -14,7 +14,7 @@
         <utility:TextSubstitionConverter x:Key="TextSubstitionConverter"/>
     </UserControl.Resources>
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Option_1}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Option_1}"/>
         <ComboBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" ItemsSource="{Binding AvailableChoices}" SelectedItem="{Binding Option1}">
             <ComboBox.ItemTemplate>
                 <DataTemplate DataType="hlib:ChoicesSectionEntry">
@@ -29,7 +29,7 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Option_2}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Option_2}"/>
         <ComboBox Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" ItemsSource="{Binding AvailableChoices}" SelectedItem="{Binding Option2}">
             <ComboBox.ItemTemplate>
                 <DataTemplate DataType="hlib:ChoicesSectionEntry">
@@ -56,7 +56,7 @@
                 </ControlTheme>
             </ComboBox.ItemContainerTheme>
         </ComboBox>
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Option_3}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Option_3}"/>
         <ComboBox Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" ItemsSource="{Binding AvailableChoices}" SelectedItem="{Binding Option3}">
             <ComboBox.ItemTemplate>
                 <DataTemplate DataType="hlib:ChoicesSectionEntry">
@@ -83,7 +83,7 @@
                 </ControlTheme>
             </ComboBox.ItemContainerTheme>
         </ComboBox>
-        <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.Option_4}"/>
+        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Option_4}"/>
         <ComboBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" ItemsSource="{Binding AvailableChoices}" SelectedItem="{Binding Option4}">
             <ComboBox.ItemTemplate>
                 <DataTemplate DataType="hlib:ChoicesSectionEntry">
@@ -111,16 +111,16 @@
             </ComboBox.ItemContainerTheme>
         </ComboBox>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,7,0,0" Text="{x:Static assets:Strings.Display_Flag_1}"/>
+        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_1}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Value="{Binding DisplayFlag1}"
                        Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-        <TextBlock Grid.Column="0" Grid.Row="5" Margin="0,7,0,0" Text="{x:Static assets:Strings.Display_Flag_2}"/>
+        <TextBlock Grid.Column="0" Grid.Row="5" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_2}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="5" Margin="10,0,0,0" Value="{Binding DisplayFlag2}"
                        Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-        <TextBlock Grid.Column="0" Grid.Row="6" Margin="0,7,0,0" Text="{x:Static assets:Strings.Display_Flag_3}"/>
+        <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_3}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="6" Margin="10,0,0,0" Value="{Binding DisplayFlag3}"
                        Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-        <TextBlock Grid.Column="0" Grid.Row="7" Margin="0,7,0,0" Text="{x:Static assets:Strings.Display_Flag_4}"/>
+        <TextBlock Grid.Column="0" Grid.Row="7" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_4}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="7" Margin="10,0,0,0" Value="{Binding DisplayFlag4}"
                        Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SelectScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SelectScriptCommandEditorView.axaml
@@ -111,18 +111,37 @@
             </ComboBox.ItemContainerTheme>
         </ComboBox>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_1}"/>
+        <StackPanel Grid.Column="0" Grid.Row="4" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_1}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Value="{Binding DisplayFlag1}"
-                       Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-        <TextBlock Grid.Column="0" Grid.Row="5" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_2}"/>
+                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+
+        <StackPanel Grid.Column="0" Grid.Row="5" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_2}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="5" Margin="10,0,0,0" Value="{Binding DisplayFlag2}"
-                       Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-        <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_3}"/>
+                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+
+        <StackPanel Grid.Column="0" Grid.Row="6" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_3}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="6" Margin="10,0,0,0" Value="{Binding DisplayFlag3}"
-                       Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-        <TextBlock Grid.Column="0" Grid.Row="7" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_4}"/>
+                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+
+        <StackPanel Grid.Column="0" Grid.Row="7" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_4}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="7" Margin="10,0,0,0" Value="{Binding DisplayFlag4}"
-                       Minimum="0" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>
 </UserControl>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SetPlaceScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SetPlaceScriptCommandEditorView.axaml
@@ -9,10 +9,10 @@
              x:DataType="vm:SetPlaceScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.SetPlaceScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Display_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_}"/>
         <CheckBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" IsChecked="{Binding Display}" />
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Place}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Place}"/>
         <StackPanel Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Orientation="Horizontal">
             <Button Content="{x:Static assets:Strings.Select___}" Command="{Binding ChangePlaceCommand}"/>
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Place}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SndPlayScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SndPlayScriptCommandEditorView.axaml
@@ -22,7 +22,11 @@
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Minimum="0" Maximum="100" Value="{Binding Volume}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Load_Sound}"/>
+        <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Load_Sound}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSoundLoad}"/>
+        </StackPanel>
         <CheckBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" IsChecked="{Binding LoadSound}"/>
 
         <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Crossfade_Time__Frames_}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SndPlayScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SndPlayScriptCommandEditorView.axaml
@@ -9,23 +9,23 @@
              x:DataType="vm:SndPlayScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.SndPlayScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Sound}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Sound}"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="3">
             <ComboBox ItemsSource="{Binding SfxChoices}" SelectedItem="{Binding SelectedSfx}"/>
             <controls:ItemLink Item="{Binding SelectedSfx}" Tabs="{Binding Tabs}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Mode}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Mode}"/>
         <ComboBox Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" ItemsSource="{Binding SfxPlayModes}" SelectedItem="{Binding SfxMode}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Volume}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Volume}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Minimum="0" Maximum="100" Value="{Binding Volume}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.Load_Sound}"/>
+        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Load_Sound}"/>
         <CheckBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" IsChecked="{Binding LoadSound}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,7,0,0" Text="{x:Static assets:Strings.Crossfade_Time__Frames_}"/>
+        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Crossfade_Time__Frames_}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Value="{Binding CrossfadeTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="{Binding CrossfadeMin}" Maximum="{Binding CrossfadeMax}"
                        IsEnabled="{Binding !LoadSound}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ToggleDialogueScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ToggleDialogueScriptCommandEditorView.axaml
@@ -8,7 +8,7 @@
              x:DataType="vm:ToggleDialogueScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ToggleDialogueScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Show}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Show}"/>
         <CheckBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" IsChecked="{Binding DialogueVisible}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/TopicGetScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/TopicGetScriptCommandEditorView.axaml
@@ -9,9 +9,9 @@
              x:DataType="vm:TopicGetScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.TopicGetScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Topic}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Topic}"/>
         <StackPanel Name="InvalidTopicPanel" Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="5" IsVisible="{Binding SelectedTopic, Converter={x:Static ObjectConverters.IsNull}}">
-            <TextBlock Margin="0,7,0,0" Text="{Binding TopicId}"/>
+            <TextBlock VerticalAlignment="Center" Text="{Binding TopicId}"/>
             <Button Content="{x:Static assets:Strings.Select_a_Topic}" Command="{Binding SelectTopicCommand}"/>
         </StackPanel>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="5" IsVisible="{Binding SelectedTopic, Converter={x:Static ObjectConverters.IsNotNull}}">

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/TransInOutScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/TransInOutScriptCommandEditorView.axaml
@@ -8,7 +8,7 @@
              x:DataType="vm:TransInOutScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.TransInOutScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static assets:Strings.Transition}" Margin="0,7,0,0"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static assets:Strings.Transition}" VerticalAlignment="Center"/>
         <ComboBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" ItemsSource="{Binding Transitions}" SelectedItem="{Binding Transition}"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/VcePlayScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/VcePlayScriptCommandEditorView.axaml
@@ -9,7 +9,7 @@
              x:DataType="vm:VcePlayScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.VcePlayScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Voice_Line}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Voice_Line}"/>
         <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="3">
             <ComboBox ItemsSource="{Binding Vces}" SelectedItem="{Binding Vce}"/>
             <controls:ItemLink Item="{Binding Vce}" Tabs="{Binding Tabs}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/VgotoScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/VgotoScriptCommandEditorView.axaml
@@ -8,10 +8,10 @@
              x:DataType="vm:VgotoScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.VgotoScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Conditional}"/>
+        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Conditional}"/>
         <TextBox Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Text="{Binding Conditional}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Script_Section}"/>
+        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Script_Section}"/>
         <ComboBox Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" ItemsSource="{Binding ScriptEditor.ScriptSections}"
                   SelectedItem="{Binding SectionToJumpTo}"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/WaitScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/WaitScriptCommandEditorView.axaml
@@ -8,7 +8,7 @@
              x:DataType="vm:WaitScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.WaitScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Row="0" Margin="0,7,0,0" Grid.Column="0" Text="{x:Static assets:Strings.Wait_Time__Frames_}"/>
+        <TextBlock Grid.Row="0" VerticalAlignment="Center" Grid.Column="0" Text="{x:Static assets:Strings.Wait_Time__Frames_}"/>
         <NumericUpDown Grid.Row="0" Margin="10,0,0,0" Grid.Column="1" Minimum="0" Maximum="1023" Value="{Binding WaitTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/SystemTextureEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/SystemTextureEditorView.axaml
@@ -15,10 +15,23 @@
                    HorizontalAlignment="Left"/>
             <StackPanel Orientation="Horizontal" Spacing="3">
                 <Button Content="{x:Static assets:Strings.Export}" Command="{Binding ExportCommand}"/>
-                <Button Content="{x:Static assets:Strings.Replace}" Command="{Binding ReplaceCommand}"/>
-                <Button Content="{x:Static assets:Strings.Replace_with_Palette}" IsEnabled="{Binding !UsesCommonPalette}" Command="{Binding ReplaceWithPaletteCommand}"/>
+                <Button Command="{Binding ReplaceCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="3">
+                        <TextBlock Text="{x:Static assets:Strings.Replace}" VerticalAlignment="Center"/>
+                        <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                             ToolTip.Tip="{x:Static assets:Strings.SystemTextureReplaceHelp}"/>
+                    </StackPanel>
+                </Button>
+                <Button IsEnabled="{Binding !UsesCommonPalette}" Command="{Binding ReplaceWithPaletteCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="3">
+                        <TextBlock Text="{x:Static assets:Strings.Replace_with_Palette}" VerticalAlignment="Center"/>
+                        <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                             ToolTip.Tip="{x:Static assets:Strings.SystemTextureReplaceWithPaletteHelp}" ToolTip.ShowOnDisabled="True"/>
+                    </StackPanel>
+                </Button>
             </StackPanel>
-            <TextBlock IsVisible="{Binding UsesCommonPalette}" Text="{x:Static assets:Strings.This_system_texture_uses_a_common_palette__so_palette_replacement_has_been_disabled}"/>
+            <TextBlock IsVisible="{Binding UsesMainPalette}" Text="{x:Static assets:Strings.SystemTexturePaletteReplacementDisabled}"/>
+            <TextBlock IsVisible="{Binding UsesChessPalette}" Text="{x:Static assets:Strings.SystemTexturePaletteReplacementDisabledChess}"/>
             <HeaderedContentControl Header="{x:Static assets:Strings.Palette}" Width="264" HorizontalAlignment="Left">
                 <Image Source="{Binding PaletteBitmap, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
                        HorizontalAlignment="Left"

--- a/src/SerialLoops/Views/Editors/TopicEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/TopicEditorView.axaml
@@ -17,7 +17,11 @@
         <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static assets:Strings.ID}"/>
         <TextBlock Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Text="{Binding Topic.TopicEntry.Id}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" IsVisible="{Binding Topic.HiddenMainTopic, Converter={x:Static ObjectConverters.IsNotNull}}" Text="{x:Static assets:Strings.Hidden_ID}"/>
+        <StackPanel Grid.Column="0" Grid.Row="1" Orientation="Horizontal" Spacing="3"
+                    IsVisible="{Binding Topic.HiddenMainTopic, Converter={x:Static ObjectConverters.IsNotNull}}">
+            <TextBlock Text="{x:Static assets:Strings.Hidden_ID}" VerticalAlignment="Center"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center" ToolTip.Tip="{x:Static assets:Strings.TopicEditorHiddenIdHelp}"/>
+        </StackPanel>
         <TextBlock Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" IsVisible="{Binding Topic.HiddenMainTopic, Converter={x:Static ObjectConverters.IsNotNull}}" Text="{Binding Topic.HiddenMainTopic.Id}"/>
 
         <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Title}"/>
@@ -39,60 +43,66 @@
         <NumericUpDown Grid.Column="1" Grid.Row="6" Margin="10,0,0,0" Value="{Binding PuzzlePhaseGroup}" Minimum="1" Maximum="6"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <HeaderedContentControl Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="7" Header="{x:Static assets:Strings.Times}">
+        <controls:HeaderedContentControlWithSvg Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="7" Header="{x:Static assets:Strings.Times}"
+                                                IconPath="avares://SerialLoops/Assets/Icons/Help.svg"
+                                                IconTip="{x:Static assets:Strings.TopicTimesHelp}">
             <Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
                 <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Base_Time_Gain}"/>
                 <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="3">
                     <NumericUpDown Value="{Binding BaseTimeGain}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-                    <TextBlock Text="{x:Static assets:Strings.sec}"/>
+                    <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
                 <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Kyon_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding KyonTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
-                                   FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-                    <TextBlock Text="{x:Static assets:Strings._}"/>
+                                   FormatString="N0" Increment="1" ParsingNumberStyle="Integer" VerticalAlignment="Center"/>
+                    <TextBlock Text="{x:Static assets:Strings._}" VerticalAlignment="Center"/>
                 </StackPanel>
-                <StackPanel Grid.Column="2" Grid.Row="1" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2">
-                    <TextBlock Text="{Binding KyonTime}"/>
-                    <TextBlock Text="{x:Static assets:Strings.sec}"/>
+                <StackPanel Grid.Column="2" Grid.Row="1" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="{Binding KyonTime}" VerticalAlignment="Center"/>
+                    <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
                 <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Mikuru_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding MikuruTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-                    <TextBlock Text="{x:Static assets:Strings._}"/>
+                    <TextBlock Text="{x:Static assets:Strings._}" VerticalAlignment="Center"/>
                 </StackPanel>
-                <StackPanel Grid.Column="2" Grid.Row="2" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2">
-                    <TextBlock Text="{Binding MikuruTime}"/>
-                    <TextBlock Text="{x:Static assets:Strings.sec}"/>
+                <StackPanel Grid.Column="2" Grid.Row="2" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="{Binding MikuruTime}" VerticalAlignment="Center"/>
+                    <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
                 <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.Nagato_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding NagatoTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-                    <TextBlock Text="{x:Static assets:Strings._}"/>
+                    <TextBlock Text="{x:Static assets:Strings._}" VerticalAlignment="Center"/>
                 </StackPanel>
-                <StackPanel Grid.Column="2" Grid.Row="3" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2">
-                    <TextBlock Text="{Binding NagatoTime}"/>
-                    <TextBlock Text="{x:Static assets:Strings.sec}"/>
+                <StackPanel Grid.Column="2" Grid.Row="3" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="{Binding NagatoTime}" VerticalAlignment="Center"/>
+                    <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
                 <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,7,0,0" Text="{x:Static assets:Strings.Koizumi_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding KoizumiTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-                    <TextBlock Text="{x:Static assets:Strings._}"/>
+                    <TextBlock Text="{x:Static assets:Strings._}" VerticalAlignment="Center"/>
                 </StackPanel>
-                <StackPanel Grid.Column="2" Grid.Row="4" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2">
-                    <TextBlock Text="{Binding KoizumiTime}"/>
-                    <TextBlock Text="{x:Static assets:Strings.sec}"/>
+                <StackPanel Grid.Column="2" Grid.Row="4" Margin="10,0,0,0" Orientation="Horizontal" Spacing="2"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="{Binding KoizumiTime}" VerticalAlignment="Center"/>
+                    <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
             </Grid>
-        </HeaderedContentControl>
+        </controls:HeaderedContentControlWithSvg>
     </Grid>
 </UserControl>
 

--- a/src/SerialLoops/Views/Editors/TopicEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/TopicEditorView.axaml
@@ -24,22 +24,22 @@
         </StackPanel>
         <TextBlock Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" IsVisible="{Binding Topic.HiddenMainTopic, Converter={x:Static ObjectConverters.IsNotNull}}" Text="{Binding Topic.HiddenMainTopic.Id}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Title}"/>
+        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Title}"/>
         <TextBox Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Text="{Binding Title}"/>
 
         <TextBlock Grid.Column="0" Grid.Row="3" Text="{x:Static assets:Strings.Type}" />
         <TextBlock Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" Text="{Binding Topic.TopicEntry.CardType}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,7,0,0" Text="{x:Static assets:Strings.Associated_Script}" IsVisible="{Binding Topic.TopicEntry.Type, Converter={x:Static ObjectConverters.NotEqual}, ConverterParameter=3}"/>
+        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Associated_Script}" IsVisible="{Binding Topic.TopicEntry.Type, Converter={x:Static ObjectConverters.NotEqual}, ConverterParameter=3}"/>
         <StackPanel Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Orientation="Horizontal" Spacing="5" IsVisible="{Binding Topic.TopicEntry.Type, Converter={x:Static ObjectConverters.NotEqual}, ConverterParameter=3}">
             <ComboBox ItemsSource="{Binding Scripts}" SelectedItem="{Binding AssociatedScript}"/>
             <controls:ItemLink Item="{Binding AssociatedScript}" Tabs="{Binding Tabs}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="5" Margin="0,7,0,0" Text="{x:Static assets:Strings.Episode_Group}"/>
+        <TextBlock Grid.Column="0" Grid.Row="5" VerticalAlignment="Center" Text="{x:Static assets:Strings.Episode_Group}"/>
         <ComboBox Grid.Column="1" Grid.Row="5" ItemsSource="{Binding EpisodeGroups}" SelectedIndex="{Binding EpisodeGroup}" Margin="10,0,0,0"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="6" Margin="0,7,0,0" Text="{x:Static assets:Strings.Puzzle_Phase_Group}"/>
+        <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" Text="{x:Static assets:Strings.Puzzle_Phase_Group}"/>
         <NumericUpDown Grid.Column="1" Grid.Row="6" Margin="10,0,0,0" Value="{Binding PuzzlePhaseGroup}" Minimum="1" Maximum="6"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
@@ -47,14 +47,14 @@
                                                 IconPath="avares://SerialLoops/Assets/Icons/Help.svg"
                                                 IconTip="{x:Static assets:Strings.TopicTimesHelp}">
             <Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-                <TextBlock Grid.Column="0" Grid.Row="0" Margin="0,7,0,0" Text="{x:Static assets:Strings.Base_Time_Gain}"/>
+                <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Base_Time_Gain}"/>
                 <StackPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Orientation="Horizontal" Spacing="3">
                     <NumericUpDown Value="{Binding BaseTimeGain}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
                     <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
-                <TextBlock Grid.Column="0" Grid.Row="1" Margin="0,7,0,0" Text="{x:Static assets:Strings.Kyon_Time_Percentage}"/>
+                <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Kyon_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding KyonTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer" VerticalAlignment="Center"/>
@@ -66,7 +66,7 @@
                     <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
-                <TextBlock Grid.Column="0" Grid.Row="2" Margin="0,7,0,0" Text="{x:Static assets:Strings.Mikuru_Time_Percentage}"/>
+                <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Mikuru_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding MikuruTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
@@ -78,7 +78,7 @@
                     <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
-                <TextBlock Grid.Column="0" Grid.Row="3" Margin="0,7,0,0" Text="{x:Static assets:Strings.Nagato_Time_Percentage}"/>
+                <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Nagato_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding NagatoTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
@@ -90,7 +90,7 @@
                     <TextBlock Text="{x:Static assets:Strings.sec}" VerticalAlignment="Center"/>
                 </StackPanel>
 
-                <TextBlock Grid.Column="0" Grid.Row="4" Margin="0,7,0,0" Text="{x:Static assets:Strings.Koizumi_Time_Percentage}"/>
+                <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Koizumi_Time_Percentage}"/>
                 <StackPanel Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Orientation="Horizontal">
                     <NumericUpDown Value="{Binding KoizumiTimePercentage}" Minimum="0" Maximum="{Binding MaxShort}"
                                    FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>

--- a/src/SerialLoops/Views/MainWindow.axaml.cs
+++ b/src/SerialLoops/Views/MainWindow.axaml.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using Avalonia;
 using Avalonia.Controls;
 using SerialLoops.Assets;
 using SerialLoops.Lib.Factories;

--- a/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
+++ b/test/SerialLoops.Tests.Headless/Editors/BackgroundMusicEditorTests.cs
@@ -18,7 +18,6 @@ using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Util;
 using SerialLoops.Lib.Util.WaveformRenderer;
 using SerialLoops.Tests.Shared;
-using SerialLoops.Utility;
 using SerialLoops.ViewModels;
 using SerialLoops.ViewModels.Editors;
 using SerialLoops.Views.Editors;

--- a/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
+++ b/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
@@ -10,7 +10,6 @@ using Avalonia.VisualTree;
 using HaruhiChokuretsuLib.Archive;
 using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Archive.Graphics;
-using Microsoft.VisualBasic.CompilerServices;
 using Moq;
 using NUnit.Framework;
 using SerialLoops.Lib;

--- a/test/SerialLoops.Tests.Shared/UiVals.cs
+++ b/test/SerialLoops.Tests.Shared/UiVals.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Reflection;


### PR DESCRIPTION
This adds self-documentation to the app in the form of neat little tooltips.

![image](https://github.com/user-attachments/assets/97ecf34e-58c4-4bd3-8972-82aaa48dca11)
![image](https://github.com/user-attachments/assets/86c7dbb4-6c5f-469f-9f89-be993d067bb4)
![image](https://github.com/user-attachments/assets/48278dec-9e3c-493a-947a-ac84213f963c)
![image](https://github.com/user-attachments/assets/130ff3e1-b39f-4062-be51-0b6b32991c67)


Additional changes:
* In addition to the main common palette, there is also a chess common palette. We now account for this and don't allow replacing system textures with either of these palettes.
* Editors which manually specified vertical margins have been switched to use `VerticalAlignment="Center"`
* CHIBI_EMOTE and CHIBI_ENTEREXIT have been restricted to chibis with walk cycles to prevent crashes
* An issue with the BG_SCROLL command preview has been fixed so that it now renders properly

Closes #483.