### PR TITLE
Implement more feedback from user studies

### DIFF
--- a/src/SerialLoops.Lib/Config.cs
+++ b/src/SerialLoops.Lib/Config.cs
@@ -52,10 +52,6 @@ public class Config
 
     public void ValidateConfig(Func<string, string> localize, ILogger log)
     {
-        if (string.IsNullOrWhiteSpace(DevkitArmPath))
-        {
-            log.LogError(localize("devkitARM is not detected at the default or specified install location. Please set devkitARM path."));
-        }
         if (CurrentCultureName is null)
         {
             CurrentCultureName = CultureInfo.CurrentCulture.Name;

--- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
@@ -123,7 +123,7 @@ public class ConfigFactory : IConfigFactory
             DevkitArmPath = devkitArmDir,
             EmulatorPath = emulatorPath,
             EmulatorFlatpak = emulatorFlatpak,
-            UseDocker = false,
+            UseDocker = OperatingSystem.IsWindows(),
             DevkitArmDockerTag = "latest",
             AutoReopenLastProject = false,
             RememberProjectWorkspace = true,

--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -1471,7 +1471,7 @@ public partial class Project
                                                    parameters.Count <= c.Parameters.Count &&
                                                    c.Parameters.Zip(parameters)
                                                        .All(z => string.IsNullOrWhiteSpace(z.Second) || z.Second == "*" ||
-                                                                 (z.Second.StartsWith("!") && !(z.First?.GetValueString(this)?.Contains(z.Second, StringComparison.OrdinalIgnoreCase) ?? false)) ||
+                                                                 (z.Second.StartsWith("!") && !(z.First?.GetValueString(this)?.Contains(z.Second[1..], StringComparison.OrdinalIgnoreCase) ?? false)) ||
                                                                  (z.First?.GetValueString(this)?.Contains(z.Second, StringComparison.OrdinalIgnoreCase) ?? false))));
                 }
                 return false;

--- a/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
@@ -327,16 +327,16 @@ public class ScriptItemCommand : ReactiveObject
                             parameters.Add(new OptionScriptParameter(localize("Option 4"), eventFile.ChoicesSection.Objects[parameter]));
                             break;
                         case 4:
-                            parameters.Add(new ShortScriptParameter(localize("Display Flag 1"), parameter));
+                            parameters.Add(new ConditionalScriptParameter(localize("Conditional 1"), eventFile.ConditionalsSection.Objects.ElementAtOrDefault(parameter) ?? string.Empty));
                             break;
                         case 5:
-                            parameters.Add(new ShortScriptParameter(localize("Display Flag 2"), parameter));
+                            parameters.Add(new ConditionalScriptParameter(localize("Conditional 2"), eventFile.ConditionalsSection.Objects.ElementAtOrDefault(parameter) ?? string.Empty));
                             break;
                         case 6:
-                            parameters.Add(new ShortScriptParameter(localize("Display Flag 3"), parameter));
+                            parameters.Add(new ConditionalScriptParameter(localize("Conditional 3"), eventFile.ConditionalsSection.Objects.ElementAtOrDefault(parameter) ?? string.Empty));
                             break;
                         case 7:
-                            parameters.Add(new ShortScriptParameter(localize("Display Flag 4"), parameter));
+                            parameters.Add(new ConditionalScriptParameter(localize("Conditional 4"), eventFile.ConditionalsSection.Objects.ElementAtOrDefault(parameter) ?? string.Empty));
                             break;
                     }
                     break;
@@ -714,11 +714,12 @@ public class ScriptItemCommand : ReactiveObject
                 str += $" {((DialogueScriptParameter)Parameters[0]).Line.Text.GetSubstitutedString(Project)[..Math.Min(((DialogueScriptParameter)Parameters[0]).Line.Text.Length, 10)]}...";
                 break;
             case CommandVerb.GOTO:
-                str += $" {((ScriptSectionScriptParameter)Parameters[0]).Section.Name}";
+                str += $" {(((ScriptSectionScriptParameter)Parameters[0]).Section.Name.StartsWith("NONE") ? ((ScriptSectionScriptParameter)Parameters[0]).Section.Name[4..] : ((ScriptSectionScriptParameter)Parameters[0]).Section.Name)}";
                 break;
             case CommandVerb.VGOTO:
                 string conditional = ((ConditionalScriptParameter)Parameters[0]).Conditional;
-                str += $" '{(conditional.Length > 10 ? $"{conditional[..10]}..." : conditional)}', {((ScriptSectionScriptParameter)Parameters[1]).Section.Name}";
+                str += $" '{(conditional.Length > 10 ? $"{conditional[..10]}..." : conditional)}'," +
+                       $" {(((ScriptSectionScriptParameter)Parameters[1]).Section.Name.StartsWith("NONE") ? ((ScriptSectionScriptParameter)Parameters[1]).Section.Name[4..] : ((ScriptSectionScriptParameter)Parameters[1]).Section.Name)}";
                 break;
             case CommandVerb.WAIT:
                 str += $" {((ShortScriptParameter)Parameters[0]).Value}";

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />
-    <PackageReference Include="ReactiveUI" Version="20.1.63" />
+    <PackageReference Include="ReactiveUI" Version="20.2.45" />
     <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageReference Include="SoftCircuits.OrderedDictionary" Version="3.3.0" />
     <PackageReference Include="Topten.RichTextKit" Version="0.4.167" />

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.0.1" />
     <PackageReference Include="HaroohieClub.NitroPacker" Version="3.1.7" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.52.15" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.53.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />

--- a/src/SerialLoops.Lib/Util/Extensions.cs
+++ b/src/SerialLoops.Lib/Util/Extensions.cs
@@ -15,6 +15,7 @@ using NAudio.Wave;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.Script.Parameters;
 using SkiaSharp;
+using SoftCircuits.Collections;
 using static HaruhiChokuretsuLib.Archive.Event.EventFile;
 using static SerialLoops.Lib.Script.SpritePositioning;
 
@@ -512,6 +513,29 @@ public static partial class Extensions
     public static string ToUnixPath(this string str)
     {
         return str.Replace('\\', '/');
+    }
+
+    public static bool Swap<T, TS>(this OrderedDictionary<T, TS> orderedDict, int firstIndex, int secondIndex)
+    {
+        if (firstIndex < 0 || secondIndex < 0 || firstIndex >= orderedDict.Count || secondIndex >= orderedDict.Count || firstIndex == secondIndex)
+        {
+            return false;
+        }
+
+        T item1Key = orderedDict.Keys[firstIndex];
+        TS item1Value = orderedDict.ByIndex[firstIndex];
+        T item2Key = orderedDict.Keys[secondIndex];
+        TS item2Value = orderedDict.ByIndex[secondIndex];
+
+        orderedDict.RemoveAt(firstIndex);
+        orderedDict.RemoveAt(firstIndex < secondIndex ? secondIndex - 1 : secondIndex);
+        if (secondIndex < firstIndex)
+        {
+            firstIndex--;
+        }
+        orderedDict.Insert(firstIndex, item2Key, item2Value);
+        orderedDict.Insert(secondIndex, item1Key, item1Value);
+        return true;
     }
 
     [GeneratedRegex(@"#x(?<offset>\d{2})")]

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -590,15 +590,6 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Arrow Keys - Move Image.
-        /// </summary>
-        public static string Arrow_Keys___Move_Image {
-            get {
-                return ResourceManager.GetString("Arrow Keys - Move Image", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Asahina companion selected description.
         /// </summary>
         public static string Asahina_companion_selected_description {
@@ -4424,6 +4415,18 @@ namespace SerialLoops.Assets {
         public static string Image_Files {
             get {
                 return ResourceManager.GetString("Image Files", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Arrow Keys - Move Image
+        ///+/- - Zoom In/Out
+        ///
+        ///Hold Shift to increase step.
+        /// </summary>
+        public static string ImageCropResizeInstructions {
+            get {
+                return ResourceManager.GetString("ImageCropResizeInstructions", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7433,6 +7433,42 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Conditional 1.
+        /// </summary>
+        public static string ScriptCommandEditorSelectParam4 {
+            get {
+                return ResourceManager.GetString("ScriptCommandEditorSelectParam4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Conditional 2.
+        /// </summary>
+        public static string ScriptCommandEditorSelectParam5 {
+            get {
+                return ResourceManager.GetString("ScriptCommandEditorSelectParam5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Conditional 3.
+        /// </summary>
+        public static string ScriptCommandEditorSelectParam6 {
+            get {
+                return ResourceManager.GetString("ScriptCommandEditorSelectParam6", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Conditional 4.
+        /// </summary>
+        public static string ScriptCommandEditorSelectParam7 {
+            get {
+                return ResourceManager.GetString("ScriptCommandEditorSelectParam7", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to By default, tall CGs will display from the top. If this is checked, it will instead display from the bottom..
         /// </summary>
         public static string ScriptCommandParameterHelpDisplayFromBottom {
@@ -7487,11 +7523,11 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If this is -1, this option is always shown. If it is a value 0 or above, this option is shown until the flag of that value is set..
+        ///   Looks up a localized string similar to If this is left blank, the option is always shown. Otherwise, this is a conditional value that if evaluated to true will display the option and will hide it if false.
         /// </summary>
-        public static string ScriptCommandParameterHelpSelectDisplayFlag {
+        public static string ScriptCommandParameterHelpSelectConditional {
             get {
-                return ResourceManager.GetString("ScriptCommandParameterHelpSelectDisplayFlag", resourceCulture);
+                return ResourceManager.GetString("ScriptCommandParameterHelpSelectConditional", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7588,7 +7588,7 @@ namespace SerialLoops.Assets {
         /// <summary>
         ///   Looks up a localized string similar to Reverts the background to the last call of BG_DISP (i.e. undoes any BG_FADE or BG_DISPCG calls). This is required before returning to displaying standard TEX_BG BGs. Note that if reverting a TEX_CG_DUAL_SCREEN BG, SET_PLACE must have been used to set the place location and have it displayed.
         ///
-        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, consider  [rest of string was truncated]&quot;;.
+        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, conside [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ScriptCommandVerbHelpBG_REVERT {
             get {
@@ -9614,6 +9614,16 @@ namespace SerialLoops.Assets {
         public static string Type {
             get {
                 return ResourceManager.GetString("Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tip: Type to jump to an 
+        ///item in the dropdown!.
+        /// </summary>
+        public static string TypeToSearchHelp {
+            get {
+                return ResourceManager.GetString("TypeToSearchHelp", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -923,11 +923,29 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Once this position is reached, the BGM will loop back to the start loop position if looping is enabled..
+        /// </summary>
+        public static string BgmLoopEndHelp {
+            get {
+                return ResourceManager.GetString("BgmLoopEndHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to adjust loop data for background music. Please check the logs and file an issue if this reoccurs..
         /// </summary>
         public static string BgmLoopErrorMessage {
             get {
                 return ResourceManager.GetString("BgmLoopErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to BGMs always start from the very beginning. This is the position it will loop back to after it reaches the end loop marker if looping is enabled..
+        /// </summary>
+        public static string BgmLoopStartHelp {
+            get {
+                return ResourceManager.GetString("BgmLoopStartHelp", resourceCulture);
             }
         }
         
@@ -9108,6 +9126,51 @@ namespace SerialLoops.Assets {
         public static string SystemTextureReplaceWithPaletteHelp {
             get {
                 return ResourceManager.GetString("SystemTextureReplaceWithPaletteHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close All.
+        /// </summary>
+        public static string TabaloniaCloseAll {
+            get {
+                return ResourceManager.GetString("TabaloniaCloseAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close All Other Tabs.
+        /// </summary>
+        public static string TabaloniaCloseAllOtherTabs {
+            get {
+                return ResourceManager.GetString("TabaloniaCloseAllOtherTabs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close All to Left.
+        /// </summary>
+        public static string TabaloniaCloseAllToLeft {
+            get {
+                return ResourceManager.GetString("TabaloniaCloseAllToLeft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close All to Right.
+        /// </summary>
+        public static string TabaloniaCloseAllToRight {
+            get {
+                return ResourceManager.GetString("TabaloniaCloseAllToRight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close Item.
+        /// </summary>
+        public static string TabaloniaCloseItem {
+            get {
+                return ResourceManager.GetString("TabaloniaCloseItem", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -8094,6 +8094,24 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove Command or Section.
+        /// </summary>
+        public static string ScriptEditorRemoveCommandOrSectionTip {
+            get {
+                return ResourceManager.GetString("ScriptEditorRemoveCommandOrSectionTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SCRIPT00 must always be the first script section, so you can&apos;t move it..
+        /// </summary>
+        public static string ScriptEditorScript00NoMoveTip {
+            get {
+                return ResourceManager.GetString("ScriptEditorScript00NoMoveTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Scripts.
         /// </summary>
         public static string Scripts {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -4059,6 +4059,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The game runs at 60 frames per second, so 60 frames is equivalent to 1 second..
+        /// </summary>
+        public static string FramesToSecondsHelp {
+            get {
+                return ResourceManager.GetString("FramesToSecondsHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to French.
         /// </summary>
         public static string French {
@@ -7490,6 +7499,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If this is not set to the default value, the screen will not fully fade in/out. This should not be changed unless you are experimenting with a very specific effect..
+        /// </summary>
+        public static string ScriptCommandParameterFadePercHelp {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterFadePercHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to By default, tall CGs will display from the top. If this is checked, it will instead display from the bottom..
         /// </summary>
         public static string ScriptCommandParameterHelpDisplayFromBottom {
@@ -7504,15 +7522,6 @@ namespace SerialLoops.Assets {
         public static string ScriptCommandParameterHelpDontClearText {
             get {
                 return ResourceManager.GetString("ScriptCommandParameterHelpDontClearText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The the color type to use. Except for special transitions, it is generally recommended to use Custom Color as it provides the most flexibility..
-        /// </summary>
-        public static string ScriptCommandParameterHelpFadeColor {
-            get {
-                return ResourceManager.GetString("ScriptCommandParameterHelpFadeColor", resourceCulture);
             }
         }
         
@@ -7535,6 +7544,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The the color type to use. Except for special transitions, it is generally recommended to use Custom Color as it provides the most flexibility..
+        /// </summary>
+        public static string ScriptCommandParameterHelpFadeOutColor {
+            get {
+                return ResourceManager.GetString("ScriptCommandParameterHelpFadeOutColor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The speed at which the background scrolls; higher is faster. Default is 1..
         /// </summary>
         public static string ScriptCommandParameterHelpScrollSpeed {
@@ -7553,7 +7571,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set to -1 to shake the screen until the SCREEN_SHAKE_STOP command is executed.
+        ///   Looks up a localized string similar to Set to -1 to shake the screen until the SCREEN_SHAKE_STOP command is executed. The game runs at 60 frames per second, so 60 frames is equivalent to 1 second..
         /// </summary>
         public static string ScriptCommandParameterHelpShakeDuration {
             get {
@@ -7580,11 +7598,20 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Should be the same as the previous SCREEN_FADEOUT command.
+        ///   Looks up a localized string similar to Should be the same as the previous SCREEN_FADEOUT command. In SCRIPT00 (the first fade of the scene), this must be Black for the fade to work properly..
         /// </summary>
-        public static string ScriptCommandScreenFadeInParamWarning {
+        public static string ScriptCommandScreenParamFadeInColorHelp {
             get {
-                return ResourceManager.GetString("ScriptCommandScreenFadeInParamWarning", resourceCulture);
+                return ResourceManager.GetString("ScriptCommandScreenParamFadeInColorHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Should be the same as the previous SCREEN_FADEOUT command. In SCRIPT00 (the first fade of the scene), this must be Both screens for the fade to work properly..
+        /// </summary>
+        public static string ScriptCommandScreenParamFadeInLocationHelp {
+            get {
+                return ResourceManager.GetString("ScriptCommandScreenParamFadeInLocationHelp", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.en-GB.resx
+++ b/src/SerialLoops/Assets/Strings.en-GB.resx
@@ -199,7 +199,7 @@
   <data name="Apply Template" xml:space="preserve">
     <value>Apply Template</value>
   </data>
-  <data name="Arrow Keys - Move Image" xml:space="preserve">
+  <data name="ImageCropResizeInstructions" xml:space="preserve">
     <value>Arrow Keys - Move Image</value>
   </data>
   <data name="Asahina companion selected description" xml:space="preserve">

--- a/src/SerialLoops/Assets/Strings.it.resx
+++ b/src/SerialLoops/Assets/Strings.it.resx
@@ -199,7 +199,7 @@
   <data name="Add Starting Chibis" xml:space="preserve">
     <value>Aggiungi Chibi</value>
   </data>
-  <data name="Arrow Keys - Move Image" xml:space="preserve">
+  <data name="ImageCropResizeInstructions" xml:space="preserve">
     <value>Freccette - Sposta immagine</value>
   </data>
   <data name="Apply Assembly Hack" xml:space="preserve">

--- a/src/SerialLoops/Assets/Strings.pt-BR.resx
+++ b/src/SerialLoops/Assets/Strings.pt-BR.resx
@@ -234,7 +234,7 @@
   <data name="Batch Dialogue Display option" xml:space="preserve">
     <value>Opção de Visualizar Diálogo</value>
   </data>
-  <data name="Arrow Keys - Move Image" xml:space="preserve">
+  <data name="ImageCropResizeInstructions" xml:space="preserve">
     <value>Teclas de Seta - Mover imagem</value>
   </data>
   <data name="Building Iteratively" xml:space="preserve">

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3587,4 +3587,8 @@ SELECT cannot be used in the initial, unnamed script block.</value>
   <data name="ScriptCommandParameterHelpSoundLoad" xml:space="preserve">
     <value>This must be checked when a sound is played initially. If a sound plays for a long time and you want to change its volume, uncheck this and set the crossfade time instead.</value>
   </data>
+  <data name="TypeToSearchHelp" xml:space="preserve">
+    <value>Tip: Type to jump to an 
+item in the dropdown!</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3581,8 +3581,8 @@ SELECT cannot be used in the initial, unnamed script block.</value>
   <data name="ScriptCommandParameterHelpShakeDuration" xml:space="preserve">
     <value>Set to -1 to shake the screen until the SCREEN_SHAKE_STOP command is executed</value>
   </data>
-  <data name="ScriptCommandParameterHelpSelectDisplayFlag" xml:space="preserve">
-    <value>If this is -1, this option is always shown. If it is a value 0 or above, this option is shown until the flag of that value is set.</value>
+  <data name="ScriptCommandParameterHelpSelectConditional" xml:space="preserve">
+    <value>If this is left blank, the option is always shown. Otherwise, this is a conditional value that if evaluated to true will display the option and will hide it if false</value>
   </data>
   <data name="ScriptCommandParameterHelpSoundLoad" xml:space="preserve">
     <value>This must be checked when a sound is played initially. If a sound plays for a long time and you want to change its volume, uncheck this and set the crossfade time instead.</value>
@@ -3596,5 +3596,17 @@ item in the dropdown!</value>
   </data>
   <data name="ScriptEditorScript00NoMoveTip" xml:space="preserve">
     <value>SCRIPT00 must always be the first script section, so you can't move it.</value>
+  </data>
+  <data name="ScriptCommandEditorSelectParam4" xml:space="preserve">
+    <value>Conditional 1</value>
+  </data>
+  <data name="ScriptCommandEditorSelectParam5" xml:space="preserve">
+    <value>Conditional 2</value>
+  </data>
+  <data name="ScriptCommandEditorSelectParam6" xml:space="preserve">
+    <value>Conditional 3</value>
+  </data>
+  <data name="ScriptCommandEditorSelectParam7" xml:space="preserve">
+    <value>Conditional 4</value>
   </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3569,10 +3569,10 @@ SELECT cannot be used in the initial, unnamed script block.</value>
   <data name="ScriptCommandParameterHelpDontClearText" xml:space="preserve">
     <value>If set, the text box will not be cleared and the next text will be displayed immediately. This allows for cool effects where you can change things like the text entrance effect, voice font, etc. in the same box.</value><comment>Help tooltip for the "Don't Clear Text" parameter of the DIALOGUE command</comment>
   </data>
-  <data name="ScriptCommandScreenFadeInParamWarning" xml:space="preserve">
-    <value>Should be the same as the previous SCREEN_FADEOUT command</value>
+  <data name="ScriptCommandScreenParamFadeInLocationHelp" xml:space="preserve">
+    <value>Should be the same as the previous SCREEN_FADEOUT command. In SCRIPT00 (the first fade of the scene), this must be Both screens for the fade to work properly.</value>
   </data>
-  <data name="ScriptCommandParameterHelpFadeColor" xml:space="preserve">
+  <data name="ScriptCommandParameterHelpFadeOutColor" xml:space="preserve">
     <value>The the color type to use. Except for special transitions, it is generally recommended to use Custom Color as it provides the most flexibility.</value>
   </data>
   <data name="ScriptCommandParameterHelpFadeCustomColor" xml:space="preserve">
@@ -3582,7 +3582,7 @@ SELECT cannot be used in the initial, unnamed script block.</value>
     <value>The screen to apply the fade to. Except for the initial fade in SCRIPT00, you must use Custom Color to fade both screens.</value>
   </data>
   <data name="ScriptCommandParameterHelpShakeDuration" xml:space="preserve">
-    <value>Set to -1 to shake the screen until the SCREEN_SHAKE_STOP command is executed</value>
+    <value>Set to -1 to shake the screen until the SCREEN_SHAKE_STOP command is executed. The game runs at 60 frames per second, so 60 frames is equivalent to 1 second.</value>
   </data>
   <data name="ScriptCommandParameterHelpSelectConditional" xml:space="preserve">
     <value>If this is left blank, the option is always shown. Otherwise, this is a conditional value that if evaluated to true will display the option and will hide it if false</value>
@@ -3632,5 +3632,14 @@ item in the dropdown!</value>
   </data>
   <data name="TabaloniaCloseAllToLeft" xml:space="preserve">
     <value>Close All to Left</value>
+  </data>
+  <data name="ScriptCommandParameterFadePercHelp" xml:space="preserve">
+    <value>If this is not set to the default value, the screen will not fully fade in/out. This should not be changed unless you are experimenting with a very specific effect.</value>
+  </data>
+  <data name="ScriptCommandScreenParamFadeInColorHelp" xml:space="preserve">
+    <value>Should be the same as the previous SCREEN_FADEOUT command. In SCRIPT00 (the first fade of the scene), this must be Black for the fade to work properly.</value>
+  </data>
+  <data name="FramesToSecondsHelp" xml:space="preserve">
+    <value>The game runs at 60 frames per second, so 60 frames is equivalent to 1 second.</value>
   </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3591,4 +3591,10 @@ SELECT cannot be used in the initial, unnamed script block.</value>
     <value>Tip: Type to jump to an 
 item in the dropdown!</value>
   </data>
+  <data name="ScriptEditorRemoveCommandOrSectionTip" xml:space="preserve">
+    <value>Remove Command or Section</value>
+  </data>
+  <data name="ScriptEditorScript00NoMoveTip" xml:space="preserve">
+    <value>SCRIPT00 must always be the first script section, so you can't move it.</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -228,8 +228,11 @@
     <value>Apply Template</value>
     <comment>The template in question is a script template</comment>
   </data>
-  <data name="Arrow Keys - Move Image" xml:space="preserve">
-    <value>Arrow Keys - Move Image</value>
+  <data name="ImageCropResizeInstructions" xml:space="preserve">
+    <value>Arrow Keys - Move Image
++/- - Zoom In/Out
+
+Hold Shift to increase step</value>
   </data>
   <data name="Asahina companion selected description" xml:space="preserve">
     <value>Asahina companion selected description</value>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3609,4 +3609,25 @@ item in the dropdown!</value>
   <data name="ScriptCommandEditorSelectParam7" xml:space="preserve">
     <value>Conditional 4</value>
   </data>
+  <data name="BgmLoopStartHelp" xml:space="preserve">
+    <value>BGMs always start from the very beginning. This is the position it will loop back to after it reaches the end loop marker if looping is enabled.</value>
+  </data>
+  <data name="BgmLoopEndHelp" xml:space="preserve">
+    <value>Once this position is reached, the BGM will loop back to the start loop position if looping is enabled.</value>
+  </data>
+  <data name="TabaloniaCloseItem" xml:space="preserve">
+    <value>Close Item</value>
+  </data>
+  <data name="TabaloniaCloseAll" xml:space="preserve">
+    <value>Close All</value>
+  </data>
+  <data name="TabaloniaCloseAllOtherTabs" xml:space="preserve">
+    <value>Close All Other Tabs</value>
+  </data>
+  <data name="TabaloniaCloseAllToRight" xml:space="preserve">
+    <value>Close All to Right</value>
+  </data>
+  <data name="TabaloniaCloseAllToLeft" xml:space="preserve">
+    <value>Close All to Left</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.zh-Hans.resx
+++ b/src/SerialLoops/Assets/Strings.zh-Hans.resx
@@ -206,7 +206,7 @@
   <data name="Apply Template" xml:space="preserve">
     <value>应用模板</value>
   </data>
-  <data name="Arrow Keys - Move Image" xml:space="preserve">
+  <data name="ImageCropResizeInstructions" xml:space="preserve">
     <value>方向键 - 移动图像</value>
   </data>
   <data name="Asahina companion selected description" xml:space="preserve">

--- a/src/SerialLoops/Models/ScriptSectionTreeItem.cs
+++ b/src/SerialLoops/Models/ScriptSectionTreeItem.cs
@@ -31,7 +31,7 @@ public class ScriptSectionTreeItem : ITreeItem, IViewFor<ReactiveScriptSection>
     {
         ViewModel = section;
         this.OneWayBind(ViewModel, vm => vm.Commands, v => v.Children);
-        this.OneWayBind(ViewModel, vm => vm.Name, v => v._textBlock.Text);
+        this.OneWayBind(ViewModel, vm => vm.DisplayName, v => v._textBlock.Text);
         this.Bind(ViewModel, vm => vm.Name, v => v.Text);
         _panel.Children.Add(_textBlock);
     }

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -96,7 +96,7 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.999-cibuild0055319-alpha" />
     <!--The behaviors packages past 11.1.0.4 break our middle click to close functionality, so we're staying on that package for now.-->
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.4" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.2.0.14" />
     <PackageReference Include="DialogHost.Avalonia" Version="0.9.2" />
     <PackageReference Include="Emik.Rubbish" Version="1.1.0" />
     <PackageReference Include="HaroohieClub.DotNet.Bundle" Version="1.0.3" />
@@ -104,11 +104,11 @@
     <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
     <PackageReference Include="MiniToolbar.Avalonia" Version="1.0.81" />
     <PackageReference Include="ReactiveHistory" Version="0.10.7" />
-    <PackageReference Include="ReactiveUI" Version="20.1.63" />
+    <PackageReference Include="ReactiveUI" Version="20.2.45" />
     <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageReference Include="SixLabors.Fonts" Version="2.1.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
-    <PackageReference Include="Tabalonia" Version="0.10.4.2" />
+    <PackageReference Include="Tabalonia" Version="0.10.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">

--- a/src/SerialLoops/Utility/SLConverters.cs
+++ b/src/SerialLoops/Utility/SLConverters.cs
@@ -149,27 +149,6 @@ public class IntAdditionConverter : IValueConverter
     }
 }
 
-public class HeightConverter : IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (double.IsNaN((double)value))
-        {
-            return double.PositiveInfinity;
-        }
-        return (double)value / 2 - 125;
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (double.IsNaN((double)value))
-        {
-            return double.PositiveInfinity;
-        }
-        return ((double)value + 125) * 2;
-    }
-}
-
 public class BgmLoopSampleToTimestampConverter : IMultiValueConverter
 {
     public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)

--- a/src/SerialLoops/Utility/SLConverters.cs
+++ b/src/SerialLoops/Utility/SLConverters.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Avalonia;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
@@ -27,10 +26,8 @@ public static partial class SLConverters
     public static FuncValueConverter<DsScreen, bool> BottomScreenSelectableConverter => new((screen) => screen != DsScreen.BOTTOM);
     public static FuncValueConverter<DsScreen, bool> BothScreensSelectedConverter => new((screen) => screen == DsScreen.BOTH);
     public static FuncValueConverter<bool, IImmutableSolidColorBrush> BooleanBrushConverter => new((val) => val ? Brushes.Transparent : Brushes.LightGreen);
-    public static FuncValueConverter<string, string> CharacterNameCropConverter => new((name) => name[4..]);
-    public static FuncValueConverter<List<Speaker>, string> ListDisplayConverter => new((strs) => string.Join(", ", strs.Select(s => s.ToString())));
+    public static FuncValueConverter<string, string> CharacterNameCropConverter => new(name => name[4..]);
     public static FuncValueConverter<ScenarioCommand.ScenarioVerb, string> ScenarioVerbHelpConverter => new(Shared.GetScenarioVerbHelp);
-    public static FuncValueConverter<EventFile.CommandVerb, string> ScriptVerbHelpConverter => new(Shared.GetScriptVerbHelp);
     public static FuncValueConverter<string, string> ScriptVerbStringHelpConverter => new(Shared.GetScriptVerbHelp);
 }
 

--- a/src/SerialLoops/ViewModels/Controls/MapCharactersSubEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Controls/MapCharactersSubEditorViewModel.cs
@@ -235,7 +235,7 @@ public class MapCharactersSubEditorViewModel : ViewModelBase
         LoadMapCharacters();
     }
 
-    private void LoadMapCharacters(bool refresh = false, bool clean = false)
+    private void LoadMapCharacters(bool refresh = false, bool clean = false, ReactiveMapCharacter selected = null)
     {
         if (clean)
         {
@@ -271,6 +271,11 @@ public class MapCharactersSubEditorViewModel : ViewModelBase
                 ObjectLayer.Insert(layoutIndex, character);
             }
         }
+
+        if (selected is not null)
+        {
+            SelectedMapCharacter = MapCharacters.FirstOrDefault(c => c.MapCharacter == selected.MapCharacter);
+        }
     }
 
     public void UpdateMapCharacter(ReactiveMapCharacter mapCharacter, short x, short y)
@@ -278,7 +283,7 @@ public class MapCharactersSubEditorViewModel : ViewModelBase
         bool noChange = mapCharacter.MapCharacter.X == x && mapCharacter.MapCharacter.Y == y;
         mapCharacter.MapCharacter.X = x;
         mapCharacter.MapCharacter.Y = y;
-        LoadMapCharacters(refresh: true, clean: true);
+        LoadMapCharacters(refresh: true, clean: true, selected: mapCharacter);
 
         if (noChange)
         {

--- a/src/SerialLoops/ViewModels/Dialogs/ExportPatchDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/ExportPatchDialogViewModel.cs
@@ -16,7 +16,7 @@ using SerialLoops.Views.Dialogs;
 
 namespace SerialLoops.ViewModels.Dialogs;
 
-public class ExportPatchDialogViewModel
+public class ExportPatchDialogViewModel : ViewModelBase
 {
     private Project _project;
     private ILogger _log;

--- a/src/SerialLoops/ViewModels/Dialogs/GenerateTemplateDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/GenerateTemplateDialogViewModel.cs
@@ -16,7 +16,7 @@ using SoftCircuits.Collections;
 
 namespace SerialLoops.ViewModels.Dialogs;
 
-public class GenerateTemplateDialogViewModel
+public class GenerateTemplateDialogViewModel : ViewModelBase
 {
     public string TemplateName { get; set; }
     public string TemplateDescription { get; set; }

--- a/src/SerialLoops/ViewModels/Dialogs/ImageCropResizeDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/ImageCropResizeDialogViewModel.cs
@@ -61,21 +61,41 @@ public class ImageCropResizeDialogViewModel : ViewModelBase
         SaveCommand = ReactiveCommand.CreateFromTask<ImageCropResizeDialog>(Save);
         CancelCommand = ReactiveCommand.Create<ImageCropResizeDialog>((dialog) => dialog.Close());
         PreserveAspectRatio = true;
+
+        // Does this seem silly to you? I don't care, it's necessary
+        // Pan & Zoom border is scaled to the size of the source image, so we have to start the image scaled up so that
+        // You can zoom in and out
+        if (SourceWidth < FinalImage.Width && SourceHeight < FinalImage.Height)
+        {
+            double scale;
+            if (FinalImage.Width / SourceWidth > FinalImage.Height / SourceHeight)
+            {
+                scale = FinalImage.Width / SourceWidth;
+            }
+            else
+            {
+                scale = FinalImage.Height / SourceHeight;
+            }
+            StartImage = StartImage.CreateScaledBitmap(new((int)(scale * SourceWidth), (int)(scale * SourceHeight)));
+            SourceWidth *= scale;
+            SourceHeight *= scale;
+        }
     }
 
     private void ScaleToFit(ImageCropResizeDialog dialog)
     {
         double zoom;
-        if (FinalImage.Width / (double)SourceWidth > FinalImage.Height / (double)SourceHeight)
+        if (FinalImage.Width / SourceWidth > FinalImage.Height / SourceHeight)
         {
-            zoom = FinalImage.Width / (double)SourceWidth;
+            zoom = FinalImage.Width / SourceWidth;
         }
         else
         {
-            zoom = FinalImage.Height / (double)SourceHeight;
+            zoom = FinalImage.Height / SourceHeight;
         }
         dialog.Paz.Zoom(zoom, SourceWidth / 2, SourceHeight / 2);
         dialog.Paz.Pan(0, 0);
+        dialog.Paz.Focus();
     }
 
     private async Task Save(ImageCropResizeDialog dialog)

--- a/src/SerialLoops/ViewModels/Editors/ChibiEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ChibiEditorViewModel.cs
@@ -123,7 +123,7 @@ public partial class ChibiEditorViewModel : EditorViewModel
             try
             {
                 await using FileStream fs = File.Create(Path.Combine(exportFolder,
-                    $"{_chibi.DisplayName}_{_selectedAnimation}{ChibiItem.DirectionToCode(_selectedDirection)}_{i++:D3}_{ChibiFrames[i].Timing}f.png"));
+                    $"{_chibi.DisplayName}_{_selectedAnimation}{ChibiItem.DirectionToCode(_selectedDirection)}_{i:D3}_{ChibiFrames[i].Timing}f.png"));
                 ChibiFrames[i].Frame.Encode(fs, SKEncodedImageFormat.Png, 1);
             }
             catch (Exception ex)

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/SceneGotoScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/SceneGotoScriptCommandEditorViewModel.cs
@@ -23,19 +23,9 @@ public class SceneGotoScriptCommandEditorViewModel : ScriptCommandEditorViewMode
         {
             this.RaiseAndSetIfChanged(ref _selectedScript, value);
             ((ConditionalScriptParameter)Command.Parameters[0]).Conditional = _selectedScript.Name;
-            if (Script.Event.ConditionalsSection.Objects.Contains(_selectedScript.Name))
-            {
-                Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
-                        .Objects[Command.Index].Parameters[0] =
-                    (short)Script.Event.ConditionalsSection.Objects.IndexOf(_selectedScript.Name);
-            }
-            else
-            {
-                Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
-                        .Objects[Command.Index].Parameters[0] =
-                    (short)(Script.Event.ConditionalsSection.Objects.Count - 1);
-                Script.Event.ConditionalsSection.Objects.Insert(Script.Event.ConditionalsSection.Objects.Count - 1, _selectedScript.Name);
-            }
+            Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
+                    .Objects[Command.Index].Parameters[0] = (short)Script.Event.ConditionalsSection.Objects.Count;
+            Script.Event.ConditionalsSection.Objects.Add(_selectedScript.Name);
             Script.UnsavedChanges = true;
         }
     }

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/SelectScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/SelectScriptCommandEditorViewModel.cs
@@ -56,44 +56,44 @@ public class SelectScriptCommandEditorViewModel : ScriptCommandEditorViewModel
         }
     }
 
-    private short _displayFlag1;
-    public short DisplayFlag1
+    private string _condtional1;
+    public string Conditional1
     {
-        get => _displayFlag1;
+        get => _condtional1;
         set
         {
-            this.RaiseAndSetIfChanged(ref _displayFlag1, value);
-            EditDisplayFlag(0, _displayFlag1);
+            this.RaiseAndSetIfChanged(ref _condtional1, value);
+            EditConditional(0, _condtional1);
         }
     }
-    private short _displayFlag2;
-    public short DisplayFlag2
+    private string _condtional2;
+    public string Conditional2
     {
-        get => _displayFlag2;
+        get => _condtional2;
         set
         {
-            this.RaiseAndSetIfChanged(ref _displayFlag2, value);
-            EditDisplayFlag(1, _displayFlag2);
+            this.RaiseAndSetIfChanged(ref _condtional2, value);
+            EditConditional(1, _condtional2);
         }
     }
-    private short _displayFlag3;
-    public short DisplayFlag3
+    private string _condtional3;
+    public string Conditional3
     {
-        get => _displayFlag3;
+        get => _condtional3;
         set
         {
-            this.RaiseAndSetIfChanged(ref _displayFlag3, value);
-            EditDisplayFlag(2, _displayFlag3);
+            this.RaiseAndSetIfChanged(ref _condtional3, value);
+            EditConditional(2, _condtional3);
         }
     }
-    private short _displayFlag4;
-    public short DisplayFlag4
+    private string _condtional4;
+    public string Conditional4
     {
-        get => _displayFlag4;
+        get => _condtional4;
         set
         {
-            this.RaiseAndSetIfChanged(ref _displayFlag4, value);
-            EditDisplayFlag(3, _displayFlag4);
+            this.RaiseAndSetIfChanged(ref _condtional4, value);
+            EditConditional(3, _condtional4);
         }
     }
 
@@ -108,27 +108,37 @@ public class SelectScriptCommandEditorViewModel : ScriptCommandEditorViewModel
         _option2 = ((OptionScriptParameter)Command.Parameters[1]).Option.Id == 0 ? AvailableChoices[0] : ((OptionScriptParameter)Command.Parameters[1]).Option;
         _option3 = ((OptionScriptParameter)Command.Parameters[2]).Option.Id == 0 ? AvailableChoices[0] : ((OptionScriptParameter)Command.Parameters[2]).Option;
         _option4 = ((OptionScriptParameter)Command.Parameters[3]).Option.Id == 0 ? AvailableChoices[0] : ((OptionScriptParameter)Command.Parameters[3]).Option;
-        _displayFlag1 = ((ShortScriptParameter)Command.Parameters[4]).Value;
-        _displayFlag2 = ((ShortScriptParameter)Command.Parameters[5]).Value;
-        _displayFlag3 = ((ShortScriptParameter)Command.Parameters[6]).Value;
-        _displayFlag4 = ((ShortScriptParameter)Command.Parameters[7]).Value;
+        _condtional1 = ((ConditionalScriptParameter)Command.Parameters[4]).Conditional;
+        _condtional2 = ((ConditionalScriptParameter)Command.Parameters[5]).Conditional;
+        _condtional3 = ((ConditionalScriptParameter)Command.Parameters[6]).Conditional;
+        _condtional4 = ((ConditionalScriptParameter)Command.Parameters[7]).Conditional;
     }
 
     private void EditOptionParameter(int index, ChoicesSectionEntry option)
     {
         ((OptionScriptParameter)Command.Parameters[index]).Option = option;
         Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
-            .Objects[Command.Index].Parameters[index] = Script.Event.ChoicesSection.Objects.IndexOf(option) == -1 ? (short)0 : (short)Script.Event.ChoicesSection.Objects.IndexOf(option) ;
+            .Objects[Command.Index].Parameters[index] = Script.Event.ChoicesSection.Objects.IndexOf(option) == -1
+            ? (short)0
+            : (short)Script.Event.ChoicesSection.Objects.IndexOf(option);
         Script.UnsavedChanges = true;
         ScriptEditor.UpdatePreview();
         Script.Refresh(OpenProject, Log);
     }
 
-    private void EditDisplayFlag(int index, short displayFlag)
+    private void EditConditional(int index, string conditional)
     {
-        ((ShortScriptParameter)Command.Parameters[index + 4]).Value = displayFlag;
+        ((ConditionalScriptParameter)Command.Parameters[index + 4]).Conditional = conditional;
+        if (string.IsNullOrEmpty(conditional))
+        {
+            Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
+                .Objects[Command.Index].Parameters[index + 4] = -1;
+            Script.UnsavedChanges = true;
+            return;
+        }
         Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
-            .Objects[Command.Index].Parameters[index + 4] = displayFlag;
+                .Objects[Command.Index].Parameters[index + 4] = (short)Script.Event.ConditionalsSection.Objects.Count;
+        Script.Event.ConditionalsSection.Objects.Add(conditional);
         Script.UnsavedChanges = true;
     }
 }

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/VgotoScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/VgotoScriptCommandEditorViewModel.cs
@@ -17,19 +17,9 @@ public class VgotoScriptCommandEditorViewModel(ScriptItemCommand command, Script
         {
             this.RaiseAndSetIfChanged(ref _conditional, value);
             ((ConditionalScriptParameter)Command.Parameters[0]).Conditional = value;
-            if (Script.Event.ConditionalsSection.Objects.Contains(_conditional))
-            {
-                Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
-                        .Objects[Command.Index].Parameters[0] =
-                    (short)Script.Event.ConditionalsSection.Objects.IndexOf(_conditional);
-            }
-            else
-            {
-                Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
-                        .Objects[Command.Index].Parameters[0] =
-                    (short)(Script.Event.ConditionalsSection.Objects.Count - 1);
-                Script.Event.ConditionalsSection.Objects.Insert(Script.Event.ConditionalsSection.Objects.Count - 1, _conditional);
-            }
+            Script.Event.ScriptSections[Script.Event.ScriptSections.IndexOf(Command.Section)]
+                .Objects[Command.Index].Parameters[0] = (short)Script.Event.ConditionalsSection.Objects.Count;
+            Script.Event.ConditionalsSection.Objects.Add(_conditional);
             Script.UnsavedChanges = true;
             Command.UpdateDisplay();
         }

--- a/src/SerialLoops/Views/Dialogs/AddScenarioCommandDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/AddScenarioCommandDialog.axaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:DataType="vm:AddScenarioCommandDialogViewModel"
         x:Class="SerialLoops.Views.Dialogs.AddScenarioCommandDialog"
-        SizeToContent="WidthAndHeight"
+        SizeToContent="WidthAndHeight" CanResize="False"
         TransparencyLevelHint="AcrylicBlur"
         Background="{DynamicResource FallbackBackgroundColor}"
         ExtendClientAreaToDecorationsHint="True"
@@ -20,7 +20,7 @@
     <Panel>
         <controls:AcrylicBorderHandler/>
 
-        <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto" VerticalAlignment="Center">
+        <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto" VerticalAlignment="Center">
             <TextBlock Text="{x:Static assets:Strings.Command_Type_}" VerticalAlignment="Center" Margin="10"/>
             <StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal" Spacing="3" Margin="5">
                 <ComboBox ItemsSource="{Binding Verbs}"
@@ -32,6 +32,8 @@
                 <Button Content="{x:Static assets:Strings.Cancel}" Command="{Binding CancelCommand}" CommandParameter="{Binding #AddCommandDialog}" IsCancel="True"/>
                 <Button Content="{x:Static assets:Strings.Create}" Command="{Binding CreateCommand}" CommandParameter="{Binding #AddCommandDialog}" IsDefault="True"/>
             </StackPanel>
+            <TextBlock Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" Text="{x:Static assets:Strings.TypeToSearchHelp}" VerticalAlignment="Center" TextAlignment="Center"
+                       TextWrapping="Wrap" Margin="0 0 0 10"/>
         </Grid>
     </Panel>
 </Window>

--- a/src/SerialLoops/Views/Dialogs/AddScriptCommandDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/AddScriptCommandDialog.axaml
@@ -7,7 +7,7 @@
         xmlns:controls="using:SerialLoops.Controls"
         xmlns:utility="using:SerialLoops.Utility"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        SizeToContent="Width" Height="150"
+        SizeToContent="Width" Height="200" CanResize="False"
         TransparencyLevelHint="AcrylicBlur"
         Background="{DynamicResource FallbackBackgroundColor}"
         ExtendClientAreaToDecorationsHint="True"
@@ -35,6 +35,8 @@
                 <Button Content="{x:Static assets:Strings.Create}" Command="{Binding CreateCommand}"
                         CommandParameter="{Binding #AddCommandDialog}" IsDefault="True"/>
             </StackPanel>
+            <TextBlock Text="{x:Static assets:Strings.TypeToSearchHelp}" VerticalAlignment="Center" TextAlignment="Center"
+                       TextWrapping="Wrap"/>
         </StackPanel>
     </Panel>
 </Window>

--- a/src/SerialLoops/Views/Dialogs/AddScriptSectionDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/AddScriptSectionDialog.axaml
@@ -22,7 +22,6 @@
             <StackPanel Orientation="Vertical" Spacing="3">
                 <TextBlock Text="{x:Static assets:Strings.Section_Name_}"/>
                 <StackPanel Orientation="Horizontal" Spacing="2">
-                    <TextBlock Text="NONE"/>
                     <TextBox Text="{Binding SectionName}"/>
                 </StackPanel>
             </StackPanel>

--- a/src/SerialLoops/Views/Dialogs/BgmLoopPropertiesDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/BgmLoopPropertiesDialog.axaml
@@ -10,7 +10,7 @@
         TransparencyLevelHint="AcrylicBlur"
         Background="{DynamicResource FallbackBackgroundColor}"
         ExtendClientAreaToDecorationsHint="True"
-        SizeToContent="WidthAndHeight"
+        SizeToContent="WidthAndHeight" CanResize="False"
         x:DataType="vm:BgmLoopPropertiesDialogViewModel"
         x:Class="SerialLoops.Views.Dialogs.BgmLoopPropertiesDialog"
         Icon="/Assets/serial-loops.ico"

--- a/src/SerialLoops/Views/Dialogs/BgmVolumePropertiesDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/BgmVolumePropertiesDialog.axaml
@@ -9,7 +9,7 @@
         TransparencyLevelHint="AcrylicBlur"
         Background="{DynamicResource FallbackBackgroundColor}"
         ExtendClientAreaToDecorationsHint="True"
-        SizeToContent="WidthAndHeight"
+        SizeToContent="WidthAndHeight" CanResize="False"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:DataType="vm:BgmVolumePropertiesDialogViewModel"
         x:Class="SerialLoops.Views.Dialogs.BgmVolumePropertiesDialog"

--- a/src/SerialLoops/Views/Dialogs/ExportPatchDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/ExportPatchDialog.axaml
@@ -22,21 +22,21 @@
             <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" Text="{x:Static assets:Strings.Note__When_exporting_an_xdelta_patch__the_base_ROM_you_should_use_is_likely_different_than_the_one_you_used_when_creating_the_project__Please_choose_the_base_Japanese_ROM__SHA_1_can_be_confirmed_below__to_ensure_that_people_who_want_to_play_your_hack_only_need_to_patch_the_game_once_}"/>
 
             <StackPanel Orientation="Vertical" Spacing="10" HorizontalAlignment="Center">
-                <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                <StackPanel Orientation="Vertical" Spacing="10" HorizontalAlignment="Center">
                     <Button Content="{x:Static assets:Strings.Select_base_ROM}" Command="{Binding OpenRomCommand}"
-                            CommandParameter="{Binding #Dialog}"/>
-                    <TextBlock Text="{Binding BaseRomHash}"/>
+                            CommandParameter="{Binding #Dialog}" HorizontalAlignment="Center"/>
+                    <TextBlock Text="{Binding BaseRomHash}" HorizontalAlignment="Center"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
-                    <TextBlock Text="{Binding ExpectedRomHashString}" TextWrapping="Wrap"/>
-                    <Svg Path="{Binding MatchSvgPath}" Width="16" Height="16"/>
+                    <TextBlock Text="{Binding ExpectedRomHashString}" TextWrapping="Wrap" HorizontalAlignment="Center"/>
+                    <Svg Path="{Binding MatchSvgPath}" Width="16" Height="16" HorizontalAlignment="Center"/>
                 </StackPanel>
             </StackPanel>
 
-            <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+            <StackPanel Orientation="Vertical" Spacing="10" HorizontalAlignment="Center">
                 <Button Content="{x:Static assets:Strings.XDelta_patch}" Command="{Binding SelectXdeltaPathCommand}"
-                        CommandParameter="{Binding #Dialog}"/>
-                <TextBlock TextWrapping="Wrap" Text="{Binding XDeltaPath}"/>
+                        CommandParameter="{Binding #Dialog}" HorizontalAlignment="Center"/>
+                <TextBlock TextWrapping="Wrap" Text="{Binding XDeltaPath}" HorizontalAlignment="Center"/>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">

--- a/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml
@@ -22,7 +22,7 @@
 
         <StackPanel Orientation="Vertical" Spacing="5" HorizontalAlignment="Center" Margin="10 30">
             <StackPanel Orientation="Horizontal" Margin="5">
-                <Canvas Width="450" Height="400" ClipToBounds="True" Name="MainCanvas">
+                <Canvas Width="600" Height="550" ClipToBounds="True" Name="MainCanvas">
                     <paz:ZoomBorder Stretch="None" ZoomSpeed="1.2" ClipToBounds="True" Focusable="True"
                                     VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                                     EnablePan="True" PanButton="Left" Name="Paz"

--- a/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml
@@ -22,7 +22,7 @@
 
         <StackPanel Orientation="Vertical" Spacing="5" HorizontalAlignment="Center" Margin="10 30">
             <StackPanel Orientation="Horizontal" Margin="5">
-                <Canvas Width="650" Height="600" ClipToBounds="True" Name="MainCanvas">
+                <Canvas Width="450" Height="400" ClipToBounds="True" Name="MainCanvas">
                     <paz:ZoomBorder Stretch="None" ZoomSpeed="1.2" ClipToBounds="True" Focusable="True"
                                     VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                                     EnablePan="True" PanButton="Left" Name="Paz"
@@ -52,17 +52,6 @@
                     <HeaderedContentControl Header="{x:Static assets:Strings.Scale_Image}"
                                    Width="200" Padding="5">
                         <StackPanel Orientation="Vertical" Spacing="5" Margin="5">
-                            <!-- <StackPanel Orientation="Horizontal" Spacing="3" VerticalAlignment="Center" HorizontalAlignment="Right"> -->
-                            <!--     <TextBlock Text="{x:Static assets:Strings.Size_}"/> -->
-                            <!--     <StackPanel Orientation="Vertical"> -->
-                            <!--         <NumericUpDown Name="WidthStepper" Value="{Binding #PreviewCanvas.PreviewWidth}" /> -->
-                            <!--         <NumericUpDown Name="HeightStepper" Value="{Binding #PreviewCanvas.PreviewHeight}" /> -->
-                            <!--     </StackPanel> -->
-                            <!-- </StackPanel> -->
-                            <!-- <StackPanel Orientation="Horizontal" Spacing="3" VerticalAlignment="Center"> -->
-                            <!--     <TextBlock Text="{x:Static assets:Strings.Preserve_Aspect_Ratio_}"/> -->
-                            <!--     <CheckBox IsChecked="{Binding PreserveAspectRatio}"/> -->
-                            <!-- </StackPanel> -->
                             <StackPanel Orientation="Horizontal" Spacing="3" VerticalAlignment="Center">
                                 <TextBlock Text="{x:Static assets:Strings.Scale_to_Fit_}"/>
                                 <Button Content="{x:Static assets:Strings.Apply}" Command="{Binding ScaleToFitCommand}"
@@ -71,7 +60,7 @@
                         </StackPanel>
                     </HeaderedContentControl>
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Width="200" Margin="5">
-                        <TextBlock Text="{x:Static assets:Strings.Arrow_Keys___Move_Image}"/>
+                        <TextBlock Text="{x:Static assets:Strings.ImageCropResizeInstructions}" TextAlignment="Center" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </StackPanel>
             </StackPanel>

--- a/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/ImageCropResizeDialog.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace SerialLoops.Views.Dialogs;
 
@@ -10,21 +11,35 @@ public partial class ImageCropResizeDialog : Window
         InitializeComponent();
     }
 
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        Paz.Focus();
+    }
+
     private void Paz_OnKeyDown(object sender, KeyEventArgs e)
     {
+        double panDelta = e.KeyModifiers == KeyModifiers.Shift ? 10 : 1;
+        double zoomDelta = e.KeyModifiers == KeyModifiers.Shift ? 0.1 : 0.01;
         switch (e.Key)
         {
             case Key.Up:
-                Paz.PanDelta(0, -1);
+                Paz.PanDelta(0, -panDelta);
                 break;
             case Key.Down:
-                Paz.PanDelta(0, 1);
+                Paz.PanDelta(0, panDelta);
                 break;
             case Key.Left:
-                Paz.PanDelta(-1, 0);
+                Paz.PanDelta(-panDelta, 0);
                 break;
             case Key.Right:
-                Paz.PanDelta(1, 0);
+                Paz.PanDelta(panDelta, 0);
+                break;
+            case Key.OemPlus:
+                Paz.ZoomDeltaTo(zoomDelta, 0, 0);
+                break;
+            case Key.OemMinus:
+                Paz.ZoomDeltaTo(-zoomDelta, 0, 0);
                 break;
         }
     }

--- a/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml
@@ -23,7 +23,7 @@
 
             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding NewName}"
                      Watermark="{x:Static assets:Strings.Haroohie}" Margin="10 0 0 0"
-                     Width="200" Name="NameBox"/>
+                     Width="200" Name="NameBox" KeyDown="NameBox_KeyDown"/>
 
             <StackPanel Grid.Row="1" Grid.Column="1" HorizontalAlignment="Right" Orientation="Horizontal" Spacing="5"
                         Margin="0 30 0 0">

--- a/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml.cs
@@ -1,4 +1,6 @@
+using System.Text.RegularExpressions;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 
 namespace SerialLoops.Views.Dialogs;
@@ -8,6 +10,15 @@ public partial class ProjectRenameDuplicateDialog : Window
     public ProjectRenameDuplicateDialog()
     {
         InitializeComponent();
+    }
+
+    private void NameBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(e.KeySymbol) && !Regex.IsMatch(e.KeySymbol, @"[A-Za-z\d-_\.]") && e.Key != Key.Back)
+        {
+            e.Handled = true;
+            return;
+        }
     }
 
     protected override void OnLoaded(RoutedEventArgs e)

--- a/src/SerialLoops/Views/Editors/ChibiEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ChibiEditorView.axaml
@@ -23,7 +23,9 @@
                 <controls:ChibiDirectionSelector DataContext="{Binding DirectionSelector}"/>
             </StackPanel>
         </HeaderedContentControl>
-        <HeaderedContentControl Grid.Row="1" Grid.Column="1" Header="{x:Static assets:Strings.Frames}">
+        <controls:HeaderedContentControlWithSvg Grid.Row="1" Grid.Column="1" Header="{x:Static assets:Strings.Frames}"
+                                                IconPath="avares://SerialLoops/Assets/Icons/Help.svg"
+                                                IconTip="{x:Static assets:Strings.FramesToSecondsHelp}">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <ItemsRepeater ItemsSource="{Binding ChibiFrames}">
                     <ItemsRepeater.Layout>
@@ -39,7 +41,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </ScrollViewer>
-        </HeaderedContentControl>
+        </controls:HeaderedContentControlWithSvg>
 
         <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="5">
             <Button Content="{x:Static assets:Strings.Export_Frames}" Command="{Binding ExportFramesCommand}"/>

--- a/src/SerialLoops/Views/Editors/ScenarioCommandEditors/RouteSelectScenarioCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScenarioCommandEditors/RouteSelectScenarioCommandEditorView.axaml
@@ -5,7 +5,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:assets="using:SerialLoops.Assets"
              xmlns:controls="using:SerialLoops.Controls"
-             xmlns:items="using:SerialLoops.Lib.Items"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:RouteSelectScenarioCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScenarioCommandEditors.RouteSelectScenarioCommandEditorView">

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgFadeScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgFadeScriptCommandEditorView.axaml
@@ -21,7 +21,11 @@
             <controls:ItemLink Tabs="{Binding Tabs}" Item="{Binding Cg}"/>
         </StackPanel>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Minimum="0" Maximum="100" Value="{Binding FadeTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgmPlayScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/BgmPlayScriptCommandEditorView.axaml
@@ -22,11 +22,19 @@
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Value="{Binding Volume}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="0" Maximum="100"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" Value="{Binding FadeInTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="-1" Maximum="{Binding MaxShort}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="4" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Value="{Binding FadeOutTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="-1" Maximum="{Binding MaxShort}"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ChibiEnterExitScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ChibiEnterExitScriptCommandEditorView.axaml
@@ -4,7 +4,6 @@
              xmlns:vm="using:SerialLoops.ViewModels.Editors.ScriptCommandEditors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:assets="using:SerialLoops.Assets"
-             xmlns:items="using:SerialLoops.Lib.Items"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:ChibiEnterExitScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ChibiEnterExitScriptCommandEditorView">

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/LoadIsomapScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/LoadIsomapScriptCommandEditorView.axaml
@@ -4,12 +4,16 @@
              xmlns:vm="using:SerialLoops.ViewModels.Editors.ScriptCommandEditors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:assets="using:SerialLoops.Assets"
+             xmlns:controls="using:SerialLoops.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:LoadIsomapScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.LoadIsomapScriptCommandEditorView">
     <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,Auto">
         <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Map}"/>
-        <ComboBox Grid.Column="1" Margin="10,0,0,0" ItemsSource="{Binding Maps}" SelectedItem="{Binding SelectedMap}"/>
+        <StackPanel Grid.Column="1" Margin="10,0,0,0" Orientation="Horizontal" Spacing="5">
+            <ComboBox ItemsSource="{Binding Maps}" SelectedItem="{Binding SelectedMap}"/>
+            <controls:ItemLink Tabs="{Binding ScriptEditor.Window.EditorTabs}" Item="{Binding SelectedMap}"/>
+        </StackPanel>
     </Grid>
 </UserControl>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeInScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeInScriptCommandEditorView.axaml
@@ -9,25 +9,33 @@
              x:DataType="vm:ScreenFadeInScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.ScreenFadeInScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                        Value="{Binding FadeTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Percentage}"/>
+        <StackPanel Grid.Column="0" Grid.Row="1" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Percentage}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterFadePercHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="100"
                        Value="{Binding FadePercentage}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
         <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Spacing="3">
             <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Location}"/>
             <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
-                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandScreenFadeInParamWarning}"/>
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandScreenParamFadeInLocationHelp}"/>
         </StackPanel>
         <controls:ScreenSelector Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" DataContext="{Binding ScreenSelector}"/>
 
         <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal" Spacing="3">
             <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
             <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
-                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandScreenFadeInParamWarning}"/>
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandScreenParamFadeInColorHelp}"/>
         </StackPanel>
         <ComboBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" ItemsSource="{Binding Colors}" SelectedItem="{Binding Color}"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeOutScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFadeOutScriptCommandEditorView.axaml
@@ -13,11 +13,19 @@
         <utility:SKAvaloniaColorConverter x:Key="ColorConverter"/>
     </UserControl.Resources>
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                        Value="{Binding FadeTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Percentage}"/>
+        <StackPanel Grid.Column="0" Grid.Row="1" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Percentage}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterFadePercHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="100"
                        Value="{Binding FadePercentage}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
@@ -38,7 +46,7 @@
         <StackPanel Grid.Column="0" Grid.Row="4" Orientation="Horizontal" Spacing="3">
             <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Color}"/>
             <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
-                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpFadeColor}"/>
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpFadeOutColor}"/>
         </StackPanel>
         <ComboBox Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" ItemsSource="{Binding Colors}" SelectedItem="{Binding Color}"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFlashScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/ScreenFlashScriptCommandEditorView.axaml
@@ -12,15 +12,27 @@
         <utility:SKAvaloniaColorConverter x:Key="ColorConverter"/>
     </UserControl.Resources>
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto">
-        <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_In_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                         Value="{Binding FadeInTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Hold_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="1" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Hold_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Minimum="0" Maximum="{Binding MaxShort}"
                         Value="{Binding HoldTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Fade_Out_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="2" Margin="10,0,0,0" Minimum="0" Maximum="100"
                         Value="{Binding FadeOutTime}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SelectScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SelectScriptCommandEditorView.axaml
@@ -84,64 +84,27 @@
             </ComboBox.ItemContainerTheme>
         </ComboBox>
         <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Text="{x:Static assets:Strings.Option_4}"/>
-        <ComboBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" ItemsSource="{Binding AvailableChoices}" SelectedItem="{Binding Option4}">
-            <ComboBox.ItemTemplate>
-                <DataTemplate DataType="hlib:ChoicesSectionEntry">
-                    <TextBlock>
-                        <TextBlock.Text>
-                            <MultiBinding Converter="{StaticResource TextSubstitionConverter}">
-                                <Binding Path="Text"/>
-                                <Binding Path="$parent[editors:SelectScriptCommandEditorView].((vm:SelectScriptCommandEditorViewModel)DataContext).OpenProject"/>
-                            </MultiBinding>
-                        </TextBlock.Text>
-                    </TextBlock>
-                </DataTemplate>
-            </ComboBox.ItemTemplate>
-            <ComboBox.ItemContainerTheme>
-                <ControlTheme TargetType="ComboBoxItem" x:DataType="hlib:ChoicesSectionEntry" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
-                    <Setter Property="TextSearch.Text">
-                        <Setter.Value>
-                            <MultiBinding Converter="{StaticResource TextSubstitionConverter}">
-                                <Binding Path="Text"/>
-                                <Binding Path="$parent[editors:SelectScriptCommandEditorView].((vm:SelectScriptCommandEditorViewModel)DataContext).OpenProject"/>
-                            </MultiBinding>
-                        </Setter.Value>
-                    </Setter>
-                </ControlTheme>
-            </ComboBox.ItemContainerTheme>
-        </ComboBox>
 
         <StackPanel Grid.Column="0" Grid.Row="4" Orientation="Horizontal" Spacing="3">
-            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_1}"/>
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.ScriptCommandEditorSelectParam4}"/>
             <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
-                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectConditional}"/>
         </StackPanel>
-        <NumericUpDown Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Value="{Binding DisplayFlag1}"
-                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+        <TextBox Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Text="{Binding Conditional1}"/>
 
         <StackPanel Grid.Column="0" Grid.Row="5" Orientation="Horizontal" Spacing="3">
-            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_2}"/>
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.ScriptCommandEditorSelectParam5}"/>
             <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
-                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectConditional}"/>
         </StackPanel>
-        <NumericUpDown Grid.Column="1" Grid.Row="5" Margin="10,0,0,0" Value="{Binding DisplayFlag2}"
-                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+        <TextBox Grid.Column="1" Grid.Row="5" Margin="10,0,0,0" Text="{Binding Conditional2}"/>
 
         <StackPanel Grid.Column="0" Grid.Row="6" Orientation="Horizontal" Spacing="3">
-            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_3}"/>
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.ScriptCommandEditorSelectParam6}"/>
             <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
-                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
+                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectConditional}"/>
         </StackPanel>
-        <NumericUpDown Grid.Column="1" Grid.Row="6" Margin="10,0,0,0" Value="{Binding DisplayFlag3}"
-                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
-
-        <StackPanel Grid.Column="0" Grid.Row="7" Orientation="Horizontal" Spacing="3">
-            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Display_Flag_4}"/>
-            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
-                 ToolTip.Tip="{x:Static assets:Strings.ScriptCommandParameterHelpSelectDisplayFlag}"/>
-        </StackPanel>
-        <NumericUpDown Grid.Column="1" Grid.Row="7" Margin="10,0,0,0" Value="{Binding DisplayFlag4}"
-                       Minimum="-1" Maximum="{Binding MaxShort}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+        <TextBox Grid.Column="1" Grid.Row="6" Margin="10,0,0,0" Text="{Binding Conditional3}"/>
     </Grid>
 </UserControl>
 

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/SndPlayScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/SndPlayScriptCommandEditorView.axaml
@@ -29,7 +29,11 @@
         </StackPanel>
         <CheckBox Grid.Column="1" Grid.Row="3" Margin="10,0,0,0" IsChecked="{Binding LoadSound}"/>
 
-        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Text="{x:Static assets:Strings.Crossfade_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="4" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Crossfade_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Column="1" Grid.Row="4" Margin="10,0,0,0" Value="{Binding CrossfadeTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer" Minimum="{Binding CrossfadeMin}" Maximum="{Binding CrossfadeMax}"
                        IsEnabled="{Binding !LoadSound}"/>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/WaitCancelScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/WaitCancelScriptCommandEditorView.axaml
@@ -8,8 +8,12 @@
              x:DataType="vm:WaitCancelScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.WaitCancelScriptCommandEditorView">
     <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,Auto">
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static assets:Strings.Wait_Time__Frames_}"/>
-        <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding WaitTime}"
+        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Wait_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
+        <NumericUpDown Grid.Row="0" Grid.Column="1" Margin="10 0 0 0" Value="{Binding WaitTime}"
                        Minimum="0" Maximum="1023" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>
 </UserControl>

--- a/src/SerialLoops/Views/Editors/ScriptCommandEditors/WaitScriptCommandEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptCommandEditors/WaitScriptCommandEditorView.axaml
@@ -8,7 +8,11 @@
              x:DataType="vm:WaitScriptCommandEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptCommandEditors.WaitScriptCommandEditorView">
     <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto">
-        <TextBlock Grid.Row="0" VerticalAlignment="Center" Grid.Column="0" Text="{x:Static assets:Strings.Wait_Time__Frames_}"/>
+        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" Spacing="3">
+            <TextBlock VerticalAlignment="Center" Text="{x:Static assets:Strings.Wait_Time__Frames_}"/>
+            <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                 ToolTip.Tip="{x:Static assets:Strings.FramesToSecondsHelp}"/>
+        </StackPanel>
         <NumericUpDown Grid.Row="0" Margin="10,0,0,0" Grid.Column="1" Minimum="0" Maximum="1023" Value="{Binding WaitTime}"
                        FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptEditorView.axaml
@@ -8,24 +8,21 @@
              xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:ia="using:Avalonia.Xaml.Interactions.Core"
              xmlns:utility="using:SerialLoops.Utility"
-             xmlns:v="using:SerialLoops.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:ScriptEditorViewModel"
              x:Class="SerialLoops.Views.Editors.ScriptEditorView"
              Name="Editor">
-    <UserControl.Resources>
-        <utility:HeightConverter x:Key="HeightConverter"/>
-    </UserControl.Resources>
 
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" MinHeight="384"/>
+            <RowDefinition Height="4"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" MinWidth="250"/>
-            <ColumnDefinition Width="4"/>
+            <ColumnDefinition Width="2"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
@@ -43,19 +40,18 @@
                 <Svg Path="avares://SerialLoops/Assets/Icons/Clear.svg" Width="22"/>
             </Button>
         </StackPanel>
-        <TreeDataGrid Grid.Column="0" Grid.Row="1" Grid.RowSpan="2" Source="{Binding Source}"
+        <TreeDataGrid Grid.Column="0" Grid.Row="1" Grid.RowSpan="3" Source="{Binding Source}"
                       ShowColumnHeaders="False" CanUserResizeColumns="False" Name="CommandTree"
                       AutoDragDropRows="True" RowDragStarted="TreeDataGrid_OnRowDragStarted" RowDrop="TreeDataGrid_OnRowDrop"
                       KeyDown="CommandTree_OnKeyDown">
         </TreeDataGrid>
 
-        <GridSplitter Grid.Column="1" Grid.Row="0" Grid.RowSpan="3" Background="{StaticResource GroupLineColor}" ResizeDirection="Columns"/>
+        <GridSplitter Grid.Column="1" Grid.Row="0" Grid.RowSpan="4" Background="{StaticResource GroupLineColor}" ResizeDirection="Columns"/>
 
-        <Grid Grid.Column="2" Grid.Row="1" ColumnDefinitions="Auto,*" RowDefinitions="*,Auto">
+        <Grid Grid.Column="2" Grid.Row="1" ColumnDefinitions="Auto,*" RowDefinitions="*">
             <Image Source="{Binding PreviewBitmap, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
-                   Grid.Column="0" Grid.Row="0" Grid.RowSpan="2" Width="256" VerticalAlignment="Top"/>
-            <TabControl Grid.Column="1" Grid.Row="0" MinHeight="384"
-                        MaxHeight="{Binding $parent[v:MainWindow].Bounds.Size.Height, Converter={StaticResource HeightConverter}}">
+                   Grid.Column="0" Grid.Row="0" Width="256" VerticalAlignment="Top"/>
+            <TabControl Grid.Column="1" Grid.Row="0">
                 <TabControl.Items>
 
                     <TabItem Header="{x:Static assets:Strings.Starting_Chibis}">
@@ -190,7 +186,10 @@
             </TabControl>
             <StackPanel Grid.Column="1" Grid.Row="1" />
         </Grid>
-        <ScrollViewer Grid.Column="2" Grid.Row="2">
+
+        <GridSplitter Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="2" Background="{StaticResource GroupLineColor}" ResizeDirection="Rows"/>
+
+        <ScrollViewer Grid.Column="2" Grid.Row="3">
             <ContentPresenter Margin="10" DataContext="{Binding CurrentCommandViewModel}" Content="{Binding}"/>
         </ScrollViewer>
     </Grid>

--- a/src/SerialLoops/Views/Editors/ScriptEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptEditorView.axaml
@@ -130,18 +130,7 @@
                                         <DataTemplate DataType="vm:ReactiveChoice">
                                             <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*,Auto">
                                                 <ComboBox Grid.Row="0" Grid.Column="0" ItemsSource="{Binding #Editor.((vm:ScriptEditorViewModel)DataContext).ScriptSections}"
-                                                          SelectedItem="{Binding AssociatedSection}">
-                                                    <ComboBox.ItemTemplate>
-                                                        <DataTemplate DataType="vm:ReactiveScriptSection">
-                                                            <TextBlock Text="{Binding  Name}"/>
-                                                        </DataTemplate>
-                                                    </ComboBox.ItemTemplate>
-                                                    <ComboBox.ItemContainerTheme>
-                                                        <ControlTheme TargetType="ComboBoxItem" x:DataType="vm:ReactiveScriptSection">
-                                                            <Setter Property="TextSearch.Text" Value="{Binding Name}" />
-                                                        </ControlTheme>
-                                                    </ComboBox.ItemContainerTheme>
-                                                </ComboBox>
+                                                          SelectedItem="{Binding AssociatedSection}"/>
 
                                                 <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ChoiceText}"/>
 

--- a/src/SerialLoops/Views/Editors/ScriptEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ScriptEditorView.axaml
@@ -13,6 +13,10 @@
              x:Class="SerialLoops.Views.Editors.ScriptEditorView"
              Name="Editor">
 
+    <UserControl.Resources>
+        <utility:IntGreaterThanConverter x:Key="GreaterThanConverter"/>
+    </UserControl.Resources>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -26,17 +30,21 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
+        <ToolTip Tip="{x:Static assets:Strings.ScriptEditorScript00NoMoveTip}"
+                 IsOpen="{Binding Script00TipVisible}"/>
+
         <StackPanel Grid.Column="0" Grid.Row="0" Margin="5" Spacing="5" HorizontalAlignment="Left" Orientation="Horizontal">
-            <Button Command="{Binding AddScriptCommandCommand}" HotKey="{Binding AddCommandHotKey}">
+            <Button Command="{Binding AddScriptCommandCommand}" HotKey="{Binding AddCommandHotKey}"
+                    ToolTip.Tip="{x:Static assets:Strings.Add_Command}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Add.svg" Width="22"/>
             </Button>
-            <Button Command="{Binding AddScriptSectionCommand}">
+            <Button Command="{Binding AddScriptSectionCommand}" ToolTip.Tip="{x:Static assets:Strings.Add_Section}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Add_Section.svg" Width="22"/>
             </Button>
-            <Button Command="{Binding DeleteScriptCommandOrSectionCommand}">
+            <Button Command="{Binding DeleteScriptCommandOrSectionCommand}" ToolTip.Tip="{x:Static assets:Strings.ScriptEditorRemoveCommandOrSectionTip}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Remove.svg" Width="22"/>
             </Button>
-            <Button Command="{Binding ClearScriptCommand}">
+            <Button Command="{Binding ClearScriptCommand}" ToolTip.Tip="{x:Static assets:Strings.Clear_Script}">
                 <Svg Path="avares://SerialLoops/Assets/Icons/Clear.svg" Width="22"/>
             </Button>
         </StackPanel>

--- a/src/SerialLoops/Views/MainWindow.axaml
+++ b/src/SerialLoops/Views/MainWindow.axaml
@@ -20,7 +20,8 @@
         Title="{Binding Title}"
         TransparencyLevelHint="AcrylicBlur"
         Background="{DynamicResource FallbackBackgroundColor}"
-        ExtendClientAreaToDecorationsHint="True">
+        ExtendClientAreaToDecorationsHint="True"
+        WindowState="Maximized">
 
     <Design.DataContext>
         <!-- This only sets the DataContext for the previewer in an IDE,
@@ -34,14 +35,14 @@
 
     <Panel>
         <controls:AcrylicBorderHandler/>
-        <Grid RowDefinitions="Auto,*" Margin="{OnPlatform macOS='0 15 0 0', Default='0'}">
+        <Grid RowDefinitions="Auto,*" Margin="{OnPlatform macOS='0 15 0 0', Default='5'}">
             <StackPanel IsVisible="False" Margin="5">
                 <Button Command="{Binding SaveProjectCommand}" HotKey="{Binding SaveHotKey}"/>
                 <Button Command="{Binding SearchProjectCommand}" HotKey="{Binding SearchHotKey}"/>
                 <Button Command="{Binding CloseProjectCommand}" HotKey="{Binding CloseProjectKey}"/>
             </StackPanel>
             <StackPanel Grid.Row="0" HorizontalAlignment="Stretch" Margin="0 5">
-                <NativeMenuBar Name="MenuBar" Margin="0 0 0 5"/>
+                <NativeMenuBar Name="MenuBar" Margin="5 0 0 5"/>
                 <Grid ColumnDefinitions="Auto,*" Classes.project="{Binding OpenProject, Converter={x:Static ObjectConverters.IsNotNull}}" Margin="0" VerticalAlignment="Center">
                     <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Margin="{OnPlatform Default='10 0 0 0', macOS='10 0 10 0'}">
                         <Image Source="{Binding OpenProjectIcon, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"

--- a/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml
+++ b/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml
@@ -20,7 +20,12 @@
         <tab:TabsControl Name="Tabs" ShowDefaultAddButton="False" ItemsSource="{Binding Tabs}"
                          ContainerClearing="Tabs_ContainerClearing" IsVisible="{Binding ShowTabsPanel}"
                          SelectedItem="{Binding SelectedTab}" LastTabClosedAction="{x:Null}"
-                         LeftThumbWidth="4" RightThumbWidth="4" Grid.Row="0" Grid.Column="0" Margin="0 8 0 0">
+                         LeftThumbWidth="4" RightThumbWidth="4" Grid.Row="0" Grid.Column="0" Margin="0 8 0 0"
+                         CloseItemHeaderText="{x:Static assets:Strings.TabaloniaCloseItem}"
+                         CloseAllButThisHeaderText="{x:Static assets:Strings.TabaloniaCloseAllOtherTabs}"
+                         CloseAllToRightHeaderText="{x:Static assets:Strings.TabaloniaCloseAllToRight}"
+                         CloseAllToLeftHeaderText="{x:Static assets:Strings.TabaloniaCloseAllToLeft}"
+                         CloseAllHeaderText="{x:Static assets:Strings.TabaloniaCloseAll}">
             <i:Interaction.Behaviors>
                 <ia:EventTriggerBehavior EventName="SelectionChanged" SourceObject="{Binding #Tabs}">
                     <ia:InvokeCommandAction Command="{Binding TabSwitchedCommand}"/>

--- a/src/SerialLoops/Views/Panels/OpenProjectPanel.axaml
+++ b/src/SerialLoops/Views/Panels/OpenProjectPanel.axaml
@@ -9,9 +9,15 @@
              x:Class="SerialLoops.Views.Panels.OpenProjectPanel">
 
     <Grid RowDefinitions="Auto,*">
-        <Grid Grid.Row="1" ColumnDefinitions="Auto,*">
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" MinWidth="300"/>
+                <ColumnDefinition Width="2"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
             <panels:ItemExplorerPanel Grid.Column="0" Name="ItemExplorer" DataContext="{Binding Explorer}" Width="300"/>
-            <panels:EditorTabsPanel Grid.Column="1" Name="EditorTabs" DataContext="{Binding EditorTabs}"/>
+            <GridSplitter Grid.Column="1" Background="{StaticResource GroupLineColor}" ResizeDirection="Columns"/>
+            <panels:EditorTabsPanel Grid.Column="2" Name="EditorTabs" DataContext="{Binding EditorTabs}"/>
         </Grid>
     </Grid>
 

--- a/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
+++ b/test/SerialLoops.Tests.Headless/Panels/EditorTabsPanelTests.cs
@@ -115,7 +115,7 @@ public class EditorTabsPanelTests
         ItemExplorerPanel itemExplorerPanel = window.FindDescendantOfType<ItemExplorerPanel>();
         DragTabItem tab = editorTabsPanel.FindDescendantOfType<DragTabItem>();
         StackPanel header = tab.FindDescendantOfType<StackPanel>();
-        int addedMargin = OperatingSystem.IsMacOS() ? 15 : 0; // We have an extra 15px top margin on macOS
+        int addedMargin = OperatingSystem.IsMacOS() ? 15 : 5; // We have an extra 15px top margin on macOS
         window.MouseDown(new(itemExplorerPanel.Width + header.Bounds.Center.X, 105 + addedMargin), MouseButton.Middle);
         window.MouseUp(new(itemExplorerPanel.Width + header.Bounds.Center.X, 105 + addedMargin), MouseButton.Middle);
         window.CaptureAndSaveFrame(Path.Combine(_uiVals.AssetsDirectory, "artifacts"), TestContext.CurrentContext.Test.Name, ref currentFrame);


### PR DESCRIPTION
This implements a couple of things:

Features:
* (Not from study, just wanted): Script section re-ordering, including a little tooltip if you try to swap with/drag SCRIPT00 saying it can't be moved
* No pop-up for devkitARM not installed -- we don't do the pop-up for anything else and it's very annoying and confusing if you get in the situation where you don't have devkitARM in the standard location.
* Docker turned on by default on Windows -- thought we had this but apparently we didn't? lmao
* Grid splitters for the item explorer panel and in the script editor -- Item explorer panel can now be adjusted with a grid splitter, as can the split between the preview/tabs and command editors in the script editor. Neat.
* No resizing on some dialogs -- the BGM properties dialogs and the command add dialogs have had the ability to resize them removed so they keep their normal appearance
* Tip for type to search -- on the add command dialogs (scenario & script), there's now a little tip at the bottom advising the user they can start typing to jump to an item in the dropdown
* Tooltips on the script command editor buttons -- thought we already had these but alas
* Start maximized -- it's intended to be used maximized, so why not start them that way? ~Will check that this looks good on mac before merging lol~ per comment below, looks great
* Realized that the SELECT command's second set of parameters were not "display flags" as previously assumed but conditionals! They now parse and are handled correctly
* Tabalonia now has "Close All to Left" and "Close All but This" (now "Close All Other Tabs") has had its performance significantly improved; these context menu options are also now localizable
* Image crop/resize dialog now supports +/- for fine-grained zoom in/out and holding shift to increase the steps between zooms/pans
* Added a bunch more help tooltips throughout the editors
* Added a link to the selected map in the LOAD_ISOMAP command

Bugfixes:
* After dragging/dropping a map character, it would no longer respond to changes in the editor (appearing to be selected but not actually changing facing direction, etc.). It now reselects the map character immediately after drop. Fixes #532 
* Save editor crashed when trying to edit a blank quick save -- you're now able to create one from scratch (important for #533)
* Fixed the margin issue again for the menubar on win/linux dual monitor -- was reintroduced at some point lol
* Significant bugfix for the conditionals garbage collection process to make it actually work 😎 
* Despite having four parameters for choices, the SELECT command seems to have a hardcoded max of three, so I've removed access to changing two of the parameters.
* Fixed an issue with the export patch dialog not being reactive
* Bumped us to the new Avalonia Behaviors version because middle click to close still works as long as you bump the Tabalonia version of that package as well
* Fixed a bug with images smaller than the final image in the crop/resize dialog so that they can now be appropriately cropped/resized lol. Also shrank it so that it's easier to use on smaller resolutions
* Fixed up a very silly bug in chibi frames export