### PR TITLE
Add option to remove move limit on chess puzzles

### DIFF
--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -1418,6 +1418,24 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The game&apos;s move counter only has sprites going up to five; however, if you&apos;re fine with glitched numbers and want to play a longer game of chess, you cancheck this box and have fun..
+        /// </summary>
+        public static string ChessPuzzleEditorRemoveLimitHelp {
+            get {
+                return ResourceManager.GetString("ChessPuzzleEditorRemoveLimitHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove Limit.
+        /// </summary>
+        public static string ChessPuzzleEditorRemoveMoveLimitText {
+            get {
+                return ResourceManager.GetString("ChessPuzzleEditorRemoveMoveLimitText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Chibi.
         /// </summary>
         public static string Chibi {
@@ -9792,7 +9810,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tip: Type to jump to an 
+        ///   Looks up a localized string similar to Tip: Type to jump to an
         ///item in the dropdown!.
         /// </summary>
         public static string TypeToSearchHelp {

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3651,4 +3651,10 @@ item in the dropdown!</value>
   <data name="CharacterSpriteEditorSelectMouthFrames" xml:space="preserve">
     <value>Select mouth animation frames</value>
   </data>
+  <data name="ChessPuzzleEditorRemoveMoveLimitText" xml:space="preserve">
+    <value>Remove Limit</value>
+  </data>
+  <data name="ChessPuzzleEditorRemoveLimitHelp" xml:space="preserve">
+    <value>The game's move counter only has sprites going up to five; however, if you're fine with glitched numbers and want to play a longer game of chess, you cancheck this box and have fun.</value>
+  </data>
 </root>

--- a/src/SerialLoops/ViewModels/Editors/ChessPuzzleEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ChessPuzzleEditorViewModel.cs
@@ -23,6 +23,19 @@ public class ChessPuzzleEditorViewModel : EditorViewModel
     [Reactive]
     public ObservableCollection<ChessPieceOnBoard> Pieces { get; private set; }
 
+    private bool _removeMovesLimit = false;
+
+    public bool RemoveMovesLimit
+    {
+        get => _removeMovesLimit;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _removeMovesLimit, value);
+            NumMovesLimit = value ? 10000 : 5;
+        }
+    }
+    [Reactive]
+    public int NumMovesLimit { get; set; } = 5;
     private int _numMoves;
     public int NumMoves
     {

--- a/src/SerialLoops/Views/Editors/ChessPuzzleEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/ChessPuzzleEditorView.axaml
@@ -61,10 +61,16 @@
                 </Style>
             </ItemsControl.Styles>
         </ItemsControl>
-        <Grid Grid.Column="1" Grid.Row="0" ColumnDefinitions="Auto,Auto" RowDefinitions="Auto,Auto,Auto">
+        <Grid Grid.Column="1" Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto,Auto,Auto">
             <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="{x:Static assets:Strings.Number_of_Moves}"/>
             <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="10,0,0,0" Value="{Binding NumMoves}"
-                           Minimum="0" Maximum="5" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+                           Minimum="0" Maximum="{Binding NumMovesLimit}" FormatString="N0" Increment="1" ParsingNumberStyle="Integer"/>
+            <StackPanel Grid.Column="2" Grid.Row="0" Orientation="Horizontal" Spacing="3" Margin="5 0 0 0">
+                <CheckBox VerticalAlignment="Center" Content="{x:Static assets:Strings.ChessPuzzleEditorRemoveMoveLimitText}"
+                          IsChecked="{Binding RemoveMovesLimit}"/>
+                <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
+                     ToolTip.Tip="{x:Static assets:Strings.ChessPuzzleEditorRemoveLimitHelp}"/>
+            </StackPanel>
 
             <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Text="{x:Static assets:Strings.Time_Limit}"/>
             <NumericUpDown Grid.Column="1" Grid.Row="1" Margin="10,0,0,0" Value="{Binding TimeLimit}"


### PR DESCRIPTION
Fulfilling a quick feature request from one of our Discord friends. Super simple and comes with a help option that warns people not to do it unless they're just messing around.

Going to merge without review so that KahnerC can get started with this (assuming tests pass).