### PR TITLE
User study fixes (pt 4)

### DIFF
--- a/.github/workflows/official-build.yml
+++ b/.github/workflows/official-build.yml
@@ -380,7 +380,7 @@ jobs:
             Simply download the Windows installer application and run it. It will walk you through installation, including installing the necessary dependencies. Specifically, it will run the **devkitPro** installer, the **Docker Desktop** installer, and the **Windows Subsystem for Linux (WSL)** installer.
             * For the devkitPro installer, you can select "Remove Downloaded Files" and uncheck all components except the "NDS Development". It will pop several terminal windows as it installs the necessary components; this is normal, so don't worry!
             * The WSL installer will run automatically. It may pop a window afterwards with more information about WSL; you can close this without reading it as it is not relevant for the project.
-            * The Docker Desktop installer will take a little while to run and afterwards ask you to log out to finish the installation process. You can close the Serial Loops installer once it is finished and then log out and log back in.
+            * The Docker Desktop installer will take a little while to run and afterwards ask you to restart to finish the installation process. You can close the Serial Loops installer once it is finished and then restart your system.
 
             Alternatively, you can download the zip file for a portable application; however, dependencies are not included with this option.
 

--- a/src/SerialLoops.Lib/Items/CharacterItem.cs
+++ b/src/SerialLoops.Lib/Items/CharacterItem.cs
@@ -56,11 +56,7 @@ public class CharacterItem : Item
         newCanvas.DrawBitmap(blankNameplate, new SKPoint(0, 0));
 
         double widthFactor = 1.0;
-        int totalWidth = NameplateProperties.Name.Sum(c =>
-        {
-            project.FontReplacement.TryGetValue(c, out FontReplacement fr);
-            return fr?.Offset ?? 15;
-        });
+        int totalWidth = NameplateProperties.Name.CalculateHaroohieTextWidth(project);
         if (totalWidth > 53)
         {
             widthFactor = 53.0 / totalWidth;
@@ -91,7 +87,22 @@ public class CharacterItem : Item
             project.FontReplacement.TryGetValue(NameplateProperties.Name[i], out FontReplacement replacement);
             if (replacement is not null && project.LangCode != "ja")
             {
-                currentX += (int)(replacement.Offset * widthFactor);
+                if (replacement.CauseOffsetAdjust && i < NameplateProperties.Name.Length - 1)
+                {
+                    project.FontReplacement.TryGetValue(NameplateProperties.Name[i + 1], out FontReplacement nextReplacement);
+                    if (nextReplacement?.TakeOffsetAdjust ?? false)
+                    {
+                        currentX += (int)((replacement.Offset - 1) * widthFactor);
+                    }
+                    else
+                    {
+                        currentX += (int)(replacement.Offset * widthFactor);
+                    }
+                }
+                else
+                {
+                    currentX += (int)(replacement.Offset * widthFactor);
+                }
             }
             else
             {

--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HaruhiChokuretsuLib.Archive.Data;
 using HaruhiChokuretsuLib.Archive.Event;
+using HaruhiChokuretsuLib.Font;
 using HaruhiChokuretsuLib.Util;
 using QuikGraph;
 using SerialLoops.Lib.Script;
@@ -1179,7 +1180,7 @@ public class ScriptItem : Item
                 SKCanvas choiceCanvas = new(choiceGraphic);
                 choiceCanvas.DrawRect(1, 1, 216, 16, new() { Color = new(146, 146, 146) });
                 choiceCanvas.DrawRect(2, 2, 214, 14, new() { Color = new(69, 69, 69) });
-                int choiceWidth = project.LangCode.Equals("ja") ? choice.Length * 14 : choice.Sum(c => project.FontReplacement.ReverseLookup(c).Offset);
+                int choiceWidth = choice.CalculateHaroohieTextWidth(project);
                 choiceCanvas.DrawHaroohieText(choice, project.DialogueColorFilters[0], project, (218 - choiceWidth) / 2, 2);
                 choiceCanvas.Flush();
                 choiceGraphics.Add(choiceGraphic);

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.0.1" />
     <PackageReference Include="HaroohieClub.NitroPacker" Version="3.1.7" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.54.0" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.54.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.0.1" />
     <PackageReference Include="HaroohieClub.NitroPacker" Version="3.1.7" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.53.1" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.54.0" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />

--- a/src/SerialLoops.Lib/Sources/charset.json
+++ b/src/SerialLoops.Lib/Sources/charset.json
@@ -1,1424 +1,1914 @@
 [
   {
-    "OriginalCharacter": "　",
+    "OriginalCharacter": "\u3000",
     "ReplacedCharacter": " ",
-    "Code": 33088,
-    "Offset": 3
+    "CodePoint": 33088,
+    "Offset": 3,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "＠",
     "ReplacedCharacter": "@",
-    "Code": 33175,
-    "Offset": 10
+    "CodePoint": 33175,
+    "Offset": 10,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "、",
     "ReplacedCharacter": ",",
-    "Code": 33089,
-    "Offset": 3
+    "CodePoint": 33089,
+    "Offset": 3,
+    "CauseOffsetAdjust": true,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "。",
     "ReplacedCharacter": "#",
-    "Code": 33090,
-    "Offset": 8
+    "CodePoint": 33090,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "．",
     "ReplacedCharacter": ".",
-    "Code": 33092,
-    "Offset": 2
+    "CodePoint": 33092,
+    "Offset": 2,
+    "CauseOffsetAdjust": true,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "・",
     "ReplacedCharacter": ";",
-    "Code": 33093,
-    "Offset": 3
+    "CodePoint": 33093,
+    "Offset": 3,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "：",
     "ReplacedCharacter": ":",
-    "Code": 33094,
-    "Offset": 2
+    "CodePoint": 33094,
+    "Offset": 2,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "？",
     "ReplacedCharacter": "?",
-    "Code": 33096,
-    "Offset": 6
+    "CodePoint": 33096,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "！",
     "ReplacedCharacter": "!",
-    "Code": 33097,
-    "Offset": 4
+    "CodePoint": 33097,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "＿",
     "ReplacedCharacter": "_",
-    "Code": 33105,
-    "Offset": 8
+    "CodePoint": 33105,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "々",
     "ReplacedCharacter": "*",
-    "Code": 33112,
-    "Offset": 6
+    "CodePoint": 33112,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ー",
     "ReplacedCharacter": "—",
-    "Code": 33115,
-    "Offset": 13
+    "CodePoint": 33115,
+    "Offset": 13,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "―",
     "ReplacedCharacter": "-",
-    "Code": 33116,
-    "Offset": 6
+    "CodePoint": 33116,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "～",
     "ReplacedCharacter": "~",
-    "Code": 33120,
-    "Offset": 7
+    "CodePoint": 33120,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "…",
     "ReplacedCharacter": "…",
-    "Code": 33123,
-    "Offset": 7
+    "CodePoint": 33123,
+    "Offset": 7,
+    "CauseOffsetAdjust": true,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "‘",
     "ReplacedCharacter": "‘",
-    "Code": 33125,
-    "Offset": 2
+    "CodePoint": 33125,
+    "Offset": 2,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "’",
-    "ReplacedCharacter": "'",
-    "Code": 33126,
-    "Offset": 2
+    "ReplacedCharacter": "\u0027",
+    "CodePoint": 33126,
+    "Offset": 2,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "“",
-    "ReplacedCharacter": "\"",
-    "Code": 33127,
-    "Offset": 6
+    "ReplacedCharacter": "\u0022",
+    "CodePoint": 33127,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "”",
     "ReplacedCharacter": "”",
-    "Code": 33128,
-    "Offset": 6
+    "CodePoint": 33128,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "（",
     "ReplacedCharacter": "(",
-    "Code": 33129,
-    "Offset": 4
+    "CodePoint": 33129,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "）",
     "ReplacedCharacter": ")",
-    "Code": 33130,
-    "Offset": 4
+    "CodePoint": 33130,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "《",
-    "ReplacedCharacter": "《",
-    "Code": 33139,
-    "Offset": 14
+    "ReplacedCharacter": "\u003C",
+    "CodePoint": 33139,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "》",
-    "ReplacedCharacter": "》",
-    "Code": 33140,
-    "Offset": 14
+    "ReplacedCharacter": "\u003E",
+    "CodePoint": 33140,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "「",
     "ReplacedCharacter": "「",
-    "Code": 33141,
-    "Offset": 14
+    "CodePoint": 33141,
+    "Offset": 14,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "」",
     "ReplacedCharacter": "」",
-    "Code": 33142,
-    "Offset": 14
+    "CodePoint": 33142,
+    "Offset": 14,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "『",
     "ReplacedCharacter": "『",
-    "Code": 33143,
-    "Offset": 14
+    "CodePoint": 33143,
+    "Offset": 14,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "』",
     "ReplacedCharacter": "』",
-    "Code": 33144,
-    "Offset": 14
+    "CodePoint": 33144,
+    "Offset": 14,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "【",
     "ReplacedCharacter": "[",
-    "Code": 33145,
-    "Offset": 4
+    "CodePoint": 33145,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "】",
     "ReplacedCharacter": "]",
-    "Code": 33146,
-    "Offset": 4
+    "CodePoint": 33146,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "＋",
-    "ReplacedCharacter": "+",
-    "Code": 33147,
-    "Offset": 6
+    "ReplacedCharacter": "\u002B",
+    "CodePoint": 33147,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "－",
     "ReplacedCharacter": "-",
-    "Code": 33148,
-    "Offset": 6
+    "CodePoint": 33148,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "×",
     "ReplacedCharacter": "×",
-    "Code": 33150,
-    "Offset": 10
+    "CodePoint": 33150,
+    "Offset": 10,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "＝",
     "ReplacedCharacter": "=",
-    "Code": 33153,
-    "Offset": 6
+    "CodePoint": 33153,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "°",
     "ReplacedCharacter": "°",
-    "Code": 33163,
-    "Offset": 5
+    "CodePoint": 33163,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "％",
     "ReplacedCharacter": "%",
-    "Code": 33171,
-    "Offset": 7
+    "CodePoint": 33171,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "＆",
-    "ReplacedCharacter": "&",
-    "Code": 33173,
-    "Offset": 7
+    "ReplacedCharacter": "\u0026",
+    "CodePoint": 33173,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "☆",
     "ReplacedCharacter": "☆",
-    "Code": 33177,
-    "Offset": 14
+    "CodePoint": 33177,
+    "Offset": 14,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "■",
     "ReplacedCharacter": "■",
-    "Code": 33185,
-    "Offset": 14
+    "CodePoint": 33185,
+    "Offset": 14,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "♪",
     "ReplacedCharacter": "♪",
-    "Code": 33268,
-    "Offset": 9
+    "CodePoint": 33268,
+    "Offset": 9,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "０",
     "ReplacedCharacter": "0",
-    "Code": 33359,
-    "Offset": 6
+    "CodePoint": 33359,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "１",
     "ReplacedCharacter": "1",
-    "Code": 33360,
-    "Offset": 3
+    "CodePoint": 33360,
+    "Offset": 3,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "２",
     "ReplacedCharacter": "2",
-    "Code": 33361,
-    "Offset": 6
+    "CodePoint": 33361,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "３",
     "ReplacedCharacter": "3",
-    "Code": 33362,
-    "Offset": 6
+    "CodePoint": 33362,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "４",
     "ReplacedCharacter": "4",
-    "Code": 33363,
-    "Offset": 7
+    "CodePoint": 33363,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "５",
     "ReplacedCharacter": "5",
-    "Code": 33364,
-    "Offset": 6
+    "CodePoint": 33364,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "６",
     "ReplacedCharacter": "6",
-    "Code": 33365,
-    "Offset": 6
+    "CodePoint": 33365,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "７",
     "ReplacedCharacter": "7",
-    "Code": 33366,
-    "Offset": 6
+    "CodePoint": 33366,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "８",
     "ReplacedCharacter": "8",
-    "Code": 33367,
-    "Offset": 6
+    "CodePoint": 33367,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "９",
     "ReplacedCharacter": "9",
-    "Code": 33368,
-    "Offset": 6
+    "CodePoint": 33368,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ａ",
     "ReplacedCharacter": "A",
-    "Code": 33376,
-    "Offset": 6
+    "CodePoint": 33376,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｂ",
     "ReplacedCharacter": "B",
-    "Code": 33377,
-    "Offset": 6
+    "CodePoint": 33377,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｃ",
     "ReplacedCharacter": "C",
-    "Code": 33378,
-    "Offset": 7
+    "CodePoint": 33378,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｄ",
     "ReplacedCharacter": "D",
-    "Code": 33379,
-    "Offset": 6
+    "CodePoint": 33379,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｅ",
     "ReplacedCharacter": "E",
-    "Code": 33380,
-    "Offset": 6
+    "CodePoint": 33380,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｆ",
     "ReplacedCharacter": "F",
-    "Code": 33381,
-    "Offset": 6
+    "CodePoint": 33381,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｇ",
     "ReplacedCharacter": "G",
-    "Code": 33382,
-    "Offset": 7
+    "CodePoint": 33382,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｈ",
     "ReplacedCharacter": "H",
-    "Code": 33383,
-    "Offset": 6
+    "CodePoint": 33383,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｉ",
     "ReplacedCharacter": "I",
-    "Code": 33384,
-    "Offset": 4
+    "CodePoint": 33384,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｊ",
     "ReplacedCharacter": "J",
-    "Code": 33385,
-    "Offset": 6
+    "CodePoint": 33385,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｋ",
     "ReplacedCharacter": "K",
-    "Code": 33386,
-    "Offset": 7
+    "CodePoint": 33386,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｌ",
     "ReplacedCharacter": "L",
-    "Code": 33387,
-    "Offset": 7
+    "CodePoint": 33387,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｍ",
     "ReplacedCharacter": "M",
-    "Code": 33388,
-    "Offset": 6
+    "CodePoint": 33388,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｎ",
     "ReplacedCharacter": "N",
-    "Code": 33389,
-    "Offset": 6
+    "CodePoint": 33389,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｏ",
     "ReplacedCharacter": "O",
-    "Code": 33390,
-    "Offset": 7
+    "CodePoint": 33390,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｐ",
     "ReplacedCharacter": "P",
-    "Code": 33391,
-    "Offset": 6
+    "CodePoint": 33391,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｑ",
     "ReplacedCharacter": "Q",
-    "Code": 33392,
-    "Offset": 7
+    "CodePoint": 33392,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｒ",
     "ReplacedCharacter": "R",
-    "Code": 33393,
-    "Offset": 6
+    "CodePoint": 33393,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｓ",
     "ReplacedCharacter": "S",
-    "Code": 33394,
-    "Offset": 6
+    "CodePoint": 33394,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｔ",
     "ReplacedCharacter": "T",
-    "Code": 33395,
-    "Offset": 6
+    "CodePoint": 33395,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｕ",
     "ReplacedCharacter": "U",
-    "Code": 33396,
-    "Offset": 6
+    "CodePoint": 33396,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｖ",
     "ReplacedCharacter": "V",
-    "Code": 33397,
-    "Offset": 6
+    "CodePoint": 33397,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｗ",
     "ReplacedCharacter": "W",
-    "Code": 33398,
-    "Offset": 6
+    "CodePoint": 33398,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｘ",
     "ReplacedCharacter": "X",
-    "Code": 33399,
-    "Offset": 6
+    "CodePoint": 33399,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｙ",
     "ReplacedCharacter": "Y",
-    "Code": 33400,
-    "Offset": 6
+    "CodePoint": 33400,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "Ｚ",
     "ReplacedCharacter": "Z",
-    "Code": 33401,
-    "Offset": 6
+    "CodePoint": 33401,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ａ",
     "ReplacedCharacter": "a",
-    "Code": 33409,
-    "Offset": 7
+    "CodePoint": 33409,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｂ",
     "ReplacedCharacter": "b",
-    "Code": 33410,
-    "Offset": 6
+    "CodePoint": 33410,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｃ",
     "ReplacedCharacter": "c",
-    "Code": 33411,
-    "Offset": 6
+    "CodePoint": 33411,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｄ",
     "ReplacedCharacter": "d",
-    "Code": 33412,
-    "Offset": 6
+    "CodePoint": 33412,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｅ",
     "ReplacedCharacter": "e",
-    "Code": 33413,
-    "Offset": 6
+    "CodePoint": 33413,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｆ",
     "ReplacedCharacter": "f",
-    "Code": 33414,
-    "Offset": 5
+    "CodePoint": 33414,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": true
   },
   {
     "OriginalCharacter": "ｇ",
     "ReplacedCharacter": "g",
-    "Code": 33415,
-    "Offset": 7
+    "CodePoint": 33415,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｈ",
     "ReplacedCharacter": "h",
-    "Code": 33416,
-    "Offset": 6
+    "CodePoint": 33416,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｉ",
     "ReplacedCharacter": "i",
-    "Code": 33417,
-    "Offset": 2
+    "CodePoint": 33417,
+    "Offset": 2,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｊ",
     "ReplacedCharacter": "j",
-    "Code": 33418,
-    "Offset": 4
+    "CodePoint": 33418,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｋ",
     "ReplacedCharacter": "k",
-    "Code": 33419,
-    "Offset": 6
+    "CodePoint": 33419,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｌ",
     "ReplacedCharacter": "l",
-    "Code": 33420,
-    "Offset": 2
+    "CodePoint": 33420,
+    "Offset": 2,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｍ",
     "ReplacedCharacter": "m",
-    "Code": 33421,
-    "Offset": 6
+    "CodePoint": 33421,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｎ",
     "ReplacedCharacter": "n",
-    "Code": 33422,
-    "Offset": 6
+    "CodePoint": 33422,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｏ",
     "ReplacedCharacter": "o",
-    "Code": 33423,
-    "Offset": 6
+    "CodePoint": 33423,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｐ",
     "ReplacedCharacter": "p",
-    "Code": 33424,
-    "Offset": 6
+    "CodePoint": 33424,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｑ",
     "ReplacedCharacter": "q",
-    "Code": 33425,
-    "Offset": 6
+    "CodePoint": 33425,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｒ",
     "ReplacedCharacter": "r",
-    "Code": 33426,
-    "Offset": 5
+    "CodePoint": 33426,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": true
   },
   {
     "OriginalCharacter": "ｓ",
     "ReplacedCharacter": "s",
-    "Code": 33427,
-    "Offset": 6
+    "CodePoint": 33427,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｔ",
     "ReplacedCharacter": "t",
-    "Code": 33428,
-    "Offset": 5
+    "CodePoint": 33428,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｕ",
     "ReplacedCharacter": "u",
-    "Code": 33429,
-    "Offset": 6
+    "CodePoint": 33429,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｖ",
     "ReplacedCharacter": "v",
-    "Code": 33430,
-    "Offset": 6
+    "CodePoint": 33430,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｗ",
     "ReplacedCharacter": "w",
-    "Code": 33431,
-    "Offset": 6
+    "CodePoint": 33431,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｘ",
     "ReplacedCharacter": "x",
-    "Code": 33432,
-    "Offset": 6
+    "CodePoint": 33432,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ｙ",
     "ReplacedCharacter": "y",
-    "Code": 33433,
-    "Offset": 6
+    "CodePoint": 33433,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": true
   },
   {
     "OriginalCharacter": "ｚ",
     "ReplacedCharacter": "z",
-    "Code": 33434,
-    "Offset": 6
+    "CodePoint": 33434,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぁ",
     "ReplacedCharacter": "À",
-    "Code": 33439,
-    "Offset": 6
+    "CodePoint": 33439,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "あ",
     "ReplacedCharacter": "Á",
-    "Code": 33440,
-    "Offset": 6
+    "CodePoint": 33440,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぃ",
     "ReplacedCharacter": "Â",
-    "Code": 33441,
-    "Offset": 6
+    "CodePoint": 33441,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "い",
     "ReplacedCharacter": "Ã",
-    "Code": 33442,
-    "Offset": 6
+    "CodePoint": 33442,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぅ",
     "ReplacedCharacter": "Ä",
-    "Code": 33443,
-    "Offset": 6
+    "CodePoint": 33443,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "う",
     "ReplacedCharacter": "Å",
-    "Code": 33444,
-    "Offset": 6
+    "CodePoint": 33444,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぇ",
     "ReplacedCharacter": "Æ",
-    "Code": 33445,
-    "Offset": 7
+    "CodePoint": 33445,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "え",
     "ReplacedCharacter": "Ç",
-    "Code": 33446,
-    "Offset": 7
+    "CodePoint": 33446,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぉ",
     "ReplacedCharacter": "È",
-    "Code": 33447,
-    "Offset": 6
+    "CodePoint": 33447,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "お",
     "ReplacedCharacter": "É",
-    "Code": 33448,
-    "Offset": 6
+    "CodePoint": 33448,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "か",
     "ReplacedCharacter": "Ê",
-    "Code": 33449,
-    "Offset": 6
+    "CodePoint": 33449,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "が",
     "ReplacedCharacter": "Ë",
-    "Code": 33450,
-    "Offset": 6
+    "CodePoint": 33450,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "き",
     "ReplacedCharacter": "Ì",
-    "Code": 33451,
-    "Offset": 4
+    "CodePoint": 33451,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぎ",
     "ReplacedCharacter": "Í",
-    "Code": 33452,
-    "Offset": 4
+    "CodePoint": 33452,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "く",
     "ReplacedCharacter": "Î",
-    "Code": 33453,
-    "Offset": 4
+    "CodePoint": 33453,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぐ",
     "ReplacedCharacter": "Ï",
-    "Code": 33454,
-    "Offset": 4
+    "CodePoint": 33454,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "け",
     "ReplacedCharacter": "Ð",
-    "Code": 33455,
-    "Offset": 7
+    "CodePoint": 33455,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "げ",
     "ReplacedCharacter": "Ñ",
-    "Code": 33456,
-    "Offset": 6
+    "CodePoint": 33456,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "こ",
     "ReplacedCharacter": "Ò",
-    "Code": 33457,
-    "Offset": 7
+    "CodePoint": 33457,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ご",
     "ReplacedCharacter": "Ó",
-    "Code": 33458,
-    "Offset": 7
+    "CodePoint": 33458,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "さ",
     "ReplacedCharacter": "Ô",
-    "Code": 33459,
-    "Offset": 7
+    "CodePoint": 33459,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ざ",
     "ReplacedCharacter": "Õ",
-    "Code": 33460,
-    "Offset": 7
+    "CodePoint": 33460,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "し",
     "ReplacedCharacter": "Ö",
-    "Code": 33461,
-    "Offset": 7
+    "CodePoint": 33461,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "じ",
     "ReplacedCharacter": "Ø",
-    "Code": 33462,
-    "Offset": 7
+    "CodePoint": 33462,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "す",
     "ReplacedCharacter": "Ù",
-    "Code": 33463,
-    "Offset": 6
+    "CodePoint": 33463,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ず",
     "ReplacedCharacter": "Ú",
-    "Code": 33464,
-    "Offset": 6
+    "CodePoint": 33464,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "せ",
     "ReplacedCharacter": "Û",
-    "Code": 33465,
-    "Offset": 6
+    "CodePoint": 33465,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぜ",
     "ReplacedCharacter": "Ü",
-    "Code": 33466,
-    "Offset": 6
+    "CodePoint": 33466,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "そ",
     "ReplacedCharacter": "Ý",
-    "Code": 33467,
-    "Offset": 6
+    "CodePoint": 33467,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぞ",
     "ReplacedCharacter": "Þ",
-    "Code": 33468,
-    "Offset": 6
+    "CodePoint": 33468,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "た",
     "ReplacedCharacter": "ß",
-    "Code": 33469,
-    "Offset": 6
+    "CodePoint": 33469,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "だ",
     "ReplacedCharacter": "à",
-    "Code": 33470,
-    "Offset": 7
+    "CodePoint": 33470,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ち",
     "ReplacedCharacter": "á",
-    "Code": 33471,
-    "Offset": 7
+    "CodePoint": 33471,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぢ",
     "ReplacedCharacter": "â",
-    "Code": 33472,
-    "Offset": 7
+    "CodePoint": 33472,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "っ",
     "ReplacedCharacter": "ã",
-    "Code": 33473,
-    "Offset": 7
+    "CodePoint": 33473,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "つ",
     "ReplacedCharacter": "ä",
-    "Code": 33474,
-    "Offset": 7
+    "CodePoint": 33474,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "づ",
     "ReplacedCharacter": "å",
-    "Code": 33475,
-    "Offset": 7
+    "CodePoint": 33475,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "て",
     "ReplacedCharacter": "æ",
-    "Code": 33476,
-    "Offset": 7
+    "CodePoint": 33476,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "で",
     "ReplacedCharacter": "ç",
-    "Code": 33477,
-    "Offset": 7
+    "CodePoint": 33477,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "と",
     "ReplacedCharacter": "è",
-    "Code": 33478,
-    "Offset": 6
+    "CodePoint": 33478,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ど",
     "ReplacedCharacter": "é",
-    "Code": 33479,
-    "Offset": 6
+    "CodePoint": 33479,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "な",
     "ReplacedCharacter": "ê",
-    "Code": 33480,
-    "Offset": 6
+    "CodePoint": 33480,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "に",
     "ReplacedCharacter": "ë",
-    "Code": 33481,
-    "Offset": 6
+    "CodePoint": 33481,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぬ",
     "ReplacedCharacter": "ì",
-    "Code": 33482,
-    "Offset": 3
+    "CodePoint": 33482,
+    "Offset": 3,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ね",
     "ReplacedCharacter": "í",
-    "Code": 33483,
-    "Offset": 3
+    "CodePoint": 33483,
+    "Offset": 3,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "の",
     "ReplacedCharacter": "î",
-    "Code": 33484,
-    "Offset": 4
+    "CodePoint": 33484,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "は",
     "ReplacedCharacter": "ï",
-    "Code": 33485,
-    "Offset": 4
+    "CodePoint": 33485,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ば",
     "ReplacedCharacter": "ð",
-    "Code": 33486,
-    "Offset": 7
+    "CodePoint": 33486,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぱ",
     "ReplacedCharacter": "ñ",
-    "Code": 33487,
-    "Offset": 6
+    "CodePoint": 33487,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ひ",
     "ReplacedCharacter": "ò",
-    "Code": 33488,
-    "Offset": 6
+    "CodePoint": 33488,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "び",
     "ReplacedCharacter": "ó",
-    "Code": 33489,
-    "Offset": 6
+    "CodePoint": 33489,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぴ",
     "ReplacedCharacter": "ô",
-    "Code": 33490,
-    "Offset": 6
+    "CodePoint": 33490,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ふ",
     "ReplacedCharacter": "õ",
-    "Code": 33491,
-    "Offset": 6
+    "CodePoint": 33491,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぶ",
     "ReplacedCharacter": "ö",
-    "Code": 33492,
-    "Offset": 6
+    "CodePoint": 33492,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぷ",
     "ReplacedCharacter": "ø",
-    "Code": 33493,
-    "Offset": 6
+    "CodePoint": 33493,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "へ",
     "ReplacedCharacter": "ù",
-    "Code": 33494,
-    "Offset": 6
+    "CodePoint": 33494,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "べ",
     "ReplacedCharacter": "ú",
-    "Code": 33495,
-    "Offset": 6
+    "CodePoint": 33495,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぺ",
     "ReplacedCharacter": "û",
-    "Code": 33496,
-    "Offset": 6
+    "CodePoint": 33496,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ほ",
     "ReplacedCharacter": "ü",
-    "Code": 33497,
-    "Offset": 6
+    "CodePoint": 33497,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぼ",
     "ReplacedCharacter": "ý",
-    "Code": 33498,
-    "Offset": 6
+    "CodePoint": 33498,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ぽ",
     "ReplacedCharacter": "þ",
-    "Code": 33499,
-    "Offset": 5
+    "CodePoint": 33499,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ま",
     "ReplacedCharacter": "ÿ",
-    "Code": 33500,
-    "Offset": 6
+    "CodePoint": 33500,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "み",
     "ReplacedCharacter": "ı",
-    "Code": 33501,
-    "Offset": 2
+    "CodePoint": 33501,
+    "Offset": 2,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "む",
     "ReplacedCharacter": "Œ",
-    "Code": 33502,
-    "Offset": 7
+    "CodePoint": 33502,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "め",
     "ReplacedCharacter": "œ",
-    "Code": 33503,
-    "Offset": 7
+    "CodePoint": 33503,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "も",
     "ReplacedCharacter": "Š",
-    "Code": 33504,
-    "Offset": 6
+    "CodePoint": 33504,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゃ",
     "ReplacedCharacter": "š",
-    "Code": 33505,
-    "Offset": 6
+    "CodePoint": 33505,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "や",
     "ReplacedCharacter": "Ÿ",
-    "Code": 33506,
-    "Offset": 6
+    "CodePoint": 33506,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゅ",
     "ReplacedCharacter": "Ž",
-    "Code": 33507,
-    "Offset": 6
+    "CodePoint": 33507,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゆ",
     "ReplacedCharacter": "ž",
-    "Code": 33508,
-    "Offset": 6
+    "CodePoint": 33508,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ょ",
     "ReplacedCharacter": "ю",
-    "Code": 33509,
-    "Offset": 9
+    "CodePoint": 33509,
+    "Offset": 9,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "よ",
     "ReplacedCharacter": "а",
-    "Code": 33510,
-    "Offset": 6
+    "CodePoint": 33510,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ら",
     "ReplacedCharacter": "б",
-    "Code": 33511,
-    "Offset": 6
+    "CodePoint": 33511,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "り",
     "ReplacedCharacter": "ц",
-    "Code": 33512,
-    "Offset": 7
+    "CodePoint": 33512,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "る",
     "ReplacedCharacter": "д",
-    "Code": 33513,
-    "Offset": 6
+    "CodePoint": 33513,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "れ",
     "ReplacedCharacter": "е",
-    "Code": 33514,
-    "Offset": 6
+    "CodePoint": 33514,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ろ",
     "ReplacedCharacter": "ф",
-    "Code": 33515,
-    "Offset": 8
+    "CodePoint": 33515,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "わ",
     "ReplacedCharacter": "г",
-    "Code": 33517,
-    "Offset": 5
+    "CodePoint": 33517,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "を",
     "ReplacedCharacter": "х",
-    "Code": 33520,
-    "Offset": 6
+    "CodePoint": 33520,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ん",
     "ReplacedCharacter": "и",
-    "Code": 33521,
-    "Offset": 6
+    "CodePoint": 33521,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ァ",
     "ReplacedCharacter": "й",
-    "Code": 33600,
-    "Offset": 6
+    "CodePoint": 33600,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ア",
     "ReplacedCharacter": "к",
-    "Code": 33601,
-    "Offset": 7
+    "CodePoint": 33601,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ィ",
     "ReplacedCharacter": "л",
-    "Code": 33602,
-    "Offset": 6
+    "CodePoint": 33602,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "イ",
     "ReplacedCharacter": "м",
-    "Code": 33603,
-    "Offset": 9
+    "CodePoint": 33603,
+    "Offset": 9,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゥ",
     "ReplacedCharacter": "н",
-    "Code": 33604,
-    "Offset": 6
+    "CodePoint": 33604,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ウ",
     "ReplacedCharacter": "о",
-    "Code": 33605,
-    "Offset": 6
+    "CodePoint": 33605,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ェ",
     "ReplacedCharacter": "п",
-    "Code": 33606,
-    "Offset": 6
+    "CodePoint": 33606,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "エ",
     "ReplacedCharacter": "я",
-    "Code": 33607,
-    "Offset": 6
+    "CodePoint": 33607,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ォ",
     "ReplacedCharacter": "р",
-    "Code": 33608,
-    "Offset": 6
+    "CodePoint": 33608,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "オ",
     "ReplacedCharacter": "с",
-    "Code": 33609,
-    "Offset": 5
+    "CodePoint": 33609,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "カ",
     "ReplacedCharacter": "т",
-    "Code": 33610,
-    "Offset": 6
+    "CodePoint": 33610,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ガ",
     "ReplacedCharacter": "у",
-    "Code": 33611,
-    "Offset": 6
+    "CodePoint": 33611,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "キ",
     "ReplacedCharacter": "ж",
-    "Code": 33612,
-    "Offset": 9
+    "CodePoint": 33612,
+    "Offset": 9,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ギ",
     "ReplacedCharacter": "в",
-    "Code": 33613,
-    "Offset": 6
+    "CodePoint": 33613,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ク",
     "ReplacedCharacter": "ь",
-    "Code": 33614,
-    "Offset": 5
+    "CodePoint": 33614,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "グ",
     "ReplacedCharacter": "ы",
-    "Code": 33615,
-    "Offset": 8
+    "CodePoint": 33615,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ケ",
     "ReplacedCharacter": "з",
-    "Code": 33616,
-    "Offset": 5
+    "CodePoint": 33616,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゲ",
     "ReplacedCharacter": "ш",
-    "Code": 33617,
-    "Offset": 9
+    "CodePoint": 33617,
+    "Offset": 9,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "コ",
     "ReplacedCharacter": "э",
-    "Code": 33618,
-    "Offset": 5
+    "CodePoint": 33618,
+    "Offset": 5,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゴ",
     "ReplacedCharacter": "щ",
-    "Code": 33619,
-    "Offset": 10
+    "CodePoint": 33619,
+    "Offset": 10,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "サ",
     "ReplacedCharacter": "ч",
-    "Code": 33620,
-    "Offset": 6
+    "CodePoint": 33620,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ザ",
     "ReplacedCharacter": "ъ",
-    "Code": 33621,
-    "Offset": 7
+    "CodePoint": 33621,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "シ",
     "ReplacedCharacter": "Ю",
-    "Code": 33622,
-    "Offset": 11
+    "CodePoint": 33622,
+    "Offset": 11,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ジ",
     "ReplacedCharacter": "А",
-    "Code": 33623,
-    "Offset": 9
+    "CodePoint": 33623,
+    "Offset": 9,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ス",
     "ReplacedCharacter": "Б",
-    "Code": 33624,
-    "Offset": 7
+    "CodePoint": 33624,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ズ",
     "ReplacedCharacter": "Ц",
-    "Code": 33625,
-    "Offset": 8
+    "CodePoint": 33625,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "セ",
     "ReplacedCharacter": "Д",
-    "Code": 33626,
-    "Offset": 9
+    "CodePoint": 33626,
+    "Offset": 9,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゼ",
     "ReplacedCharacter": "Е",
-    "Code": 33627,
-    "Offset": 6
+    "CodePoint": 33627,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ソ",
     "ReplacedCharacter": "Ф",
-    "Code": 33628,
-    "Offset": 8
+    "CodePoint": 33628,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ゾ",
     "ReplacedCharacter": "Г",
-    "Code": 33629,
-    "Offset": 6
+    "CodePoint": 33629,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "タ",
     "ReplacedCharacter": "Х",
-    "Code": 33630,
-    "Offset": 8
+    "CodePoint": 33630,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ダ",
     "ReplacedCharacter": "И",
-    "Code": 33631,
-    "Offset": 8
+    "CodePoint": 33631,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "チ",
     "ReplacedCharacter": "Й",
-    "Code": 33632,
-    "Offset": 8
+    "CodePoint": 33632,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ヂ",
     "ReplacedCharacter": "К",
-    "Code": 33633,
-    "Offset": 7
+    "CodePoint": 33633,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ッ",
     "ReplacedCharacter": "Л",
-    "Code": 33634,
-    "Offset": 8
+    "CodePoint": 33634,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ツ",
     "ReplacedCharacter": "М",
-    "Code": 33635,
-    "Offset": 8
+    "CodePoint": 33635,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ヅ",
     "ReplacedCharacter": "Н",
-    "Code": 33636,
-    "Offset": 7
+    "CodePoint": 33636,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "テ",
     "ReplacedCharacter": "О",
-    "Code": 33637,
-    "Offset": 7
+    "CodePoint": 33637,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "デ",
     "ReplacedCharacter": "П",
-    "Code": 33638,
-    "Offset": 7
+    "CodePoint": 33638,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ト",
     "ReplacedCharacter": "Я",
-    "Code": 33639,
-    "Offset": 7
+    "CodePoint": 33639,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ド",
     "ReplacedCharacter": "Р",
-    "Code": 33640,
-    "Offset": 7
+    "CodePoint": 33640,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ナ",
     "ReplacedCharacter": "С",
-    "Code": 33641,
-    "Offset": 7
+    "CodePoint": 33641,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ニ",
     "ReplacedCharacter": "Т",
-    "Code": 33642,
-    "Offset": 6
+    "CodePoint": 33642,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ヌ",
     "ReplacedCharacter": "У",
-    "Code": 33643,
-    "Offset": 8
+    "CodePoint": 33643,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ネ",
     "ReplacedCharacter": "Ж",
-    "Code": 33644,
-    "Offset": 11
+    "CodePoint": 33644,
+    "Offset": 11,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ノ",
     "ReplacedCharacter": "В",
-    "Code": 33645,
-    "Offset": 7
+    "CodePoint": 33645,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ハ",
     "ReplacedCharacter": "Ь",
-    "Code": 33646,
-    "Offset": 7
+    "CodePoint": 33646,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "バ",
     "ReplacedCharacter": "Ы",
-    "Code": 33647,
-    "Offset": 10
+    "CodePoint": 33647,
+    "Offset": 10,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "パ",
     "ReplacedCharacter": "З",
-    "Code": 33648,
-    "Offset": 6
+    "CodePoint": 33648,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ヒ",
     "ReplacedCharacter": "Ш",
-    "Code": 33649,
-    "Offset": 11
+    "CodePoint": 33649,
+    "Offset": 11,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ビ",
     "ReplacedCharacter": "Э",
-    "Code": 33650,
-    "Offset": 7
+    "CodePoint": 33650,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ピ",
     "ReplacedCharacter": "Щ",
-    "Code": 33651,
-    "Offset": 12
+    "CodePoint": 33651,
+    "Offset": 12,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "フ",
     "ReplacedCharacter": "Ч",
-    "Code": 33652,
-    "Offset": 7
+    "CodePoint": 33652,
+    "Offset": 7,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ブ",
     "ReplacedCharacter": "Ъ",
-    "Code": 33653,
-    "Offset": 8
+    "CodePoint": 33653,
+    "Offset": 8,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "プ",
     "ReplacedCharacter": "ё",
-    "Code": 33654,
-    "Offset": 6
+    "CodePoint": 33654,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   },
   {
     "OriginalCharacter": "ヘ",
     "ReplacedCharacter": "Ё",
-    "Code": 33655,
-    "Offset": 6
+    "CodePoint": 33655,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
+  },
+  {
+    "OriginalCharacter": "ベ",
+    "ReplacedCharacter": "₂",
+    "CodePoint": 33656,
+    "Offset": 4,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
+  },
+  {
+    "OriginalCharacter": "ペ",
+    "ReplacedCharacter": "/",
+    "CodePoint": 33657,
+    "Offset": 6,
+    "CauseOffsetAdjust": false,
+    "TakeOffsetAdjust": false
   }
 ]

--- a/src/SerialLoops.Lib/Util/DropOutStack.cs
+++ b/src/SerialLoops.Lib/Util/DropOutStack.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SerialLoops.Lib.Util;
+
+public class DropOutStack<T>(int capacity) where T : class
+{
+    public int Capacity { get; set; } = capacity;
+    private readonly List<T> _stack = [];
+
+    public void Push(T item)
+    {
+        _stack.Add(item);
+    }
+
+    public T Pop()
+    {
+        T last = Peek();
+        if (last is not null)
+        {
+            _stack.RemoveAt(_stack.Count - 1);
+        }
+        return last;
+    }
+
+    public T Peek()
+    {
+        return _stack.Count == 0 ? null : _stack[^1];
+    }
+}

--- a/src/SerialLoops.Lib/Util/Extensions.cs
+++ b/src/SerialLoops.Lib/Util/Extensions.cs
@@ -13,6 +13,7 @@ using HaruhiChokuretsuLib.Font;
 using HaruhiChokuretsuLib.Util;
 using NAudio.Wave;
 using SerialLoops.Lib.Items;
+using SerialLoops.Lib.Script;
 using SerialLoops.Lib.Script.Parameters;
 using SkiaSharp;
 using SoftCircuits.Collections;
@@ -217,6 +218,12 @@ public static partial class Extensions
 
             case CommandVerb.SCREEN_FADEOUT:
                 invocation.Parameters[1] = 100;
+                break;
+
+            case CommandVerb.SCREEN_FLASH:
+                invocation.Parameters[0] = 5;
+                invocation.Parameters[1] = 30;
+                invocation.Parameters[2] = 5;
                 break;
 
             case CommandVerb.SND_PLAY:

--- a/src/SerialLoops.Lib/Util/Extensions.cs
+++ b/src/SerialLoops.Lib/Util/Extensions.cs
@@ -354,6 +354,36 @@ public static partial class Extensions
         };
     }
 
+    public static int CalculateHaroohieTextWidth(this string str, Project project)
+    {
+        if (project.LangCode.Equals("ja"))
+        {
+            return str.Length * 14;
+        }
+        int strWidth = 0;
+        for (int i = 0; i < str.Length; i++)
+        {
+            project.FontReplacement.TryGetValue(str[i], out FontReplacement fr);
+            if ((fr?.CauseOffsetAdjust ?? false) && i < str.Length - 1)
+            {
+                project.FontReplacement.TryGetValue(str[i + 1], out FontReplacement nextFr);
+                if (nextFr?.TakeOffsetAdjust ?? false)
+                {
+                    strWidth += fr.Offset - 1;
+                }
+                else
+                {
+                    strWidth += fr.Offset;
+                }
+            }
+            else
+            {
+                strWidth += fr?.Offset ?? 15;
+            }
+        }
+        return strWidth;
+    }
+
     public static void DrawHaroohieText(this SKCanvas canvas, string text, SKPaint color, Project project, int x = 10,
         int y = 352, bool formatting = true)
     {
@@ -461,7 +491,22 @@ public static partial class Extensions
                 FontReplacement replacement = project.FontReplacement.ReverseLookup(text[i]);
                 if (replacement is not null && project.LangCode != "ja")
                 {
-                    currentX += replacement.Offset;
+                    if (replacement.CauseOffsetAdjust && i < text.Length - 1)
+                    {
+                        project.FontReplacement.TryGetValue(text[i + 1], out FontReplacement nextFr);
+                        if (nextFr?.TakeOffsetAdjust ?? false)
+                        {
+                            currentX += replacement.Offset - 1;
+                        }
+                        else
+                        {
+                            currentX += replacement.Offset;
+                        }
+                    }
+                    else
+                    {
+                        currentX += replacement.Offset;
+                    }
                 }
                 else
                 {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -4696,6 +4696,42 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Center.
+        /// </summary>
+        public static string ItemLocationCenter {
+            get {
+                return ResourceManager.GetString("ItemLocationCenter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exit.
+        /// </summary>
+        public static string ItemLocationExit {
+            get {
+                return ResourceManager.GetString("ItemLocationExit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left.
+        /// </summary>
+        public static string ItemLocationLeft {
+            get {
+                return ResourceManager.GetString("ItemLocationLeft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right.
+        /// </summary>
+        public static string ItemLocationRight {
+            get {
+                return ResourceManager.GetString("ItemLocationRight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Items.
         /// </summary>
         public static string Items {
@@ -9792,7 +9828,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tip: Type to jump to an 
+        ///   Looks up a localized string similar to Tip: Type to jump to an
         ///item in the dropdown!.
         /// </summary>
         public static string TypeToSearchHelp {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -1337,6 +1337,33 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Select sprite base.
+        /// </summary>
+        public static string CharacterSpriteEditorSelectBase {
+            get {
+                return ResourceManager.GetString("CharacterSpriteEditorSelectBase", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select eye animation frames.
+        /// </summary>
+        public static string CharacterSpriteEditorSelectEyeFrames {
+            get {
+                return ResourceManager.GetString("CharacterSpriteEditorSelectEyeFrames", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select mouth animation frames.
+        /// </summary>
+        public static string CharacterSpriteEditorSelectMouthFrames {
+            get {
+                return ResourceManager.GetString("CharacterSpriteEditorSelectMouthFrames", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Check for Updates.
         /// </summary>
         public static string Check_for_Updates {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7753,7 +7753,7 @@ namespace SerialLoops.Assets {
         /// <summary>
         ///   Looks up a localized string similar to Reverts the background to the last call of BG_DISP (i.e. undoes any BG_FADE or BG_DISPCG calls). This is required before returning to displaying standard TEX_BG BGs. Note that if reverting a TEX_CG_DUAL_SCREEN BG, SET_PLACE must have been used to set the place location and have it displayed.
         ///
-        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, consider  [rest of string was truncated]&quot;;.
+        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, conside [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ScriptCommandVerbHelpBG_REVERT {
             get {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7735,7 +7735,7 @@ namespace SerialLoops.Assets {
         /// <summary>
         ///   Looks up a localized string similar to Reverts the background to the last call of BG_DISP (i.e. undoes any BG_FADE or BG_DISPCG calls). This is required before returning to displaying standard TEX_BG BGs. Note that if reverting a TEX_CG_DUAL_SCREEN BG, SET_PLACE must have been used to set the place location and have it displayed.
         ///
-        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, conside [rest of string was truncated]&quot;;.
+        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, consider  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ScriptCommandVerbHelpBG_REVERT {
             get {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7753,7 +7753,7 @@ namespace SerialLoops.Assets {
         /// <summary>
         ///   Looks up a localized string similar to Reverts the background to the last call of BG_DISP (i.e. undoes any BG_FADE or BG_DISPCG calls). This is required before returning to displaying standard TEX_BG BGs. Note that if reverting a TEX_CG_DUAL_SCREEN BG, SET_PLACE must have been used to set the place location and have it displayed.
         ///
-        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, conside [rest of string was truncated]&quot;;.
+        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, consider  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ScriptCommandVerbHelpBG_REVERT {
             get {

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3651,4 +3651,16 @@ item in the dropdown!</value>
   <data name="CharacterSpriteEditorSelectMouthFrames" xml:space="preserve">
     <value>Select mouth animation frames</value>
   </data>
+  <data name="ItemLocationLeft" xml:space="preserve">
+    <value>Left</value>
+  </data>
+  <data name="ItemLocationRight" xml:space="preserve">
+    <value>Right</value>
+  </data>
+  <data name="ItemLocationCenter" xml:space="preserve">
+    <value>Center</value>
+  </data>
+  <data name="ItemLocationExit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3591,7 +3591,7 @@ SELECT cannot be used in the initial, unnamed script block.</value>
     <value>This must be checked when a sound is played initially. If a sound plays for a long time and you want to change its volume, uncheck this and set the crossfade time instead.</value>
   </data>
   <data name="TypeToSearchHelp" xml:space="preserve">
-    <value>Tip: Type to jump to an 
+    <value>Tip: Type to jump to an
 item in the dropdown!</value>
   </data>
   <data name="ScriptEditorRemoveCommandOrSectionTip" xml:space="preserve">
@@ -3641,5 +3641,14 @@ item in the dropdown!</value>
   </data>
   <data name="FramesToSecondsHelp" xml:space="preserve">
     <value>The game runs at 60 frames per second, so 60 frames is equivalent to 1 second.</value>
+  </data>
+  <data name="CharacterSpriteEditorSelectBase" xml:space="preserve">
+    <value>Select sprite base</value>
+  </data>
+  <data name="CharacterSpriteEditorSelectEyeFrames" xml:space="preserve">
+    <value>Select eye animation frames</value>
+  </data>
+  <data name="CharacterSpriteEditorSelectMouthFrames" xml:space="preserve">
+    <value>Select mouth animation frames</value>
   </data>
 </root>

--- a/src/SerialLoops/ViewModels/Editors/CharacterSpriteEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/CharacterSpriteEditorViewModel.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Avalonia.Input;
 using Avalonia.Platform.Storage;
+using HaroohieClub.NitroPacker.Nitro.Gx;
 using HaruhiChokuretsuLib.Util;
 using ReactiveHistory;
 using ReactiveUI;
@@ -20,7 +22,7 @@ using SkiaSharp;
 
 namespace SerialLoops.ViewModels.Editors;
 
-public class CharacterSpriteEditorViewModel : EditorViewModel
+public partial class CharacterSpriteEditorViewModel : EditorViewModel
 {
     private CharacterSpriteItem _sprite;
     private CharacterItem _character;
@@ -104,7 +106,61 @@ public class CharacterSpriteEditorViewModel : EditorViewModel
 
     private async Task ReplaceSprite()
     {
-        await Task.Delay(10);
+        string baseFile = (await Window.Window.ShowOpenFilePickerAsync(Strings.CharacterSpriteEditorSelectBase,
+            [new(Strings.Image_Files) { Patterns = Shared.SupportedImageFiletypes }]))?.TryGetLocalPath();
+        if (string.IsNullOrEmpty(baseFile))
+        {
+            return;
+        }
+        string[] eyeFiles = (await Window.Window.ShowOpenMultiFilePickerAsync(Strings.CharacterSpriteEditorSelectEyeFrames,
+                [new(Strings.Image_Files) { Patterns = Shared.SupportedImageFiletypes }]))?
+            .Select(f => f.TryGetLocalPath()).ToArray();
+        if (eyeFiles is null || eyeFiles.Length == 0)
+        {
+            return;
+        }
+        string[] mouthFiles = (await Window.Window.ShowOpenMultiFilePickerAsync(Strings.CharacterSpriteEditorSelectMouthFrames,
+                [new(Strings.Image_Files) { Patterns = Shared.SupportedImageFiletypes }]))?
+            .Select(f => f.TryGetLocalPath()).ToArray();
+        if (mouthFiles is null || mouthFiles.Length == 0)
+        {
+            return;
+        }
+
+        SKBitmap baseLayout = SKBitmap.Decode(baseFile);
+        Match eyePosMatch = EyePosRegex().Match(Path.GetFileNameWithoutExtension(baseFile));
+        Match mouthPosMatch = MouthPosRegex().Match(Path.GetFileNameWithoutExtension(baseFile));
+        short eyePosX = eyePosMatch.Success ? short.Parse(eyePosMatch.Groups["x"].Value) : (short)0;
+        short eyePosY = eyePosMatch.Success ? short.Parse(eyePosMatch.Groups["y"].Value) : (short)0;
+        short mouthPosX = mouthPosMatch.Success ? short.Parse(mouthPosMatch.Groups["x"].Value) : (short)0;
+        short mouthPosY = mouthPosMatch.Success ? short.Parse(mouthPosMatch.Groups["y"].Value) : (short)0;
+
+        List<SKBitmap> eyeFrames = eyeFiles.OrderBy(f => f).Select(f => SKBitmap.Decode(f)).ToList();
+        short[] eyeTimings = new short[eyeFrames.Count];
+        Array.Fill<short>(eyeTimings, 32);
+        for (int i = 0; i < eyeTimings.Length; i++)
+        {
+            if (Path.GetFileNameWithoutExtension(eyeFiles[i])!.EndsWith("f", StringComparison.OrdinalIgnoreCase))
+            {
+                eyeTimings[i] = short.Parse(Path.GetFileNameWithoutExtension(eyeFiles[i]).Split('_').Last()[..^1]);
+            }
+        }
+        List<(SKBitmap Frame, short Timing)> eyeFramesAndTimings = eyeFrames.Zip(eyeTimings).ToList();
+
+        List<SKBitmap> mouthFrames = mouthFiles.OrderBy(f => f).Select(f => SKBitmap.Decode(f)).ToList();
+        short[] mouthTimings = new short[mouthFrames.Count];
+        Array.Fill<short>(mouthTimings, 32);
+        for (int i = 0; i < mouthTimings.Length; i++)
+        {
+            if (Path.GetFileNameWithoutExtension(mouthFiles[i])!.EndsWith("f", StringComparison.OrdinalIgnoreCase))
+            {
+                mouthTimings[i] = short.Parse(Path.GetFileNameWithoutExtension(mouthFiles[i]).Split('_').Last()[..^1]);
+            }
+        }
+        List<(SKBitmap Frame, short Timing)> mouthFramesAndTimings = mouthFrames.Zip(mouthTimings).ToList();
+
+        _sprite.SetSprite(baseLayout, eyeFramesAndTimings, mouthFramesAndTimings, eyePosX, eyePosY, mouthPosX, mouthPosY);
+        Description.UnsavedChanges = true;
     }
 
     private async Task ExportFrames()
@@ -188,4 +244,11 @@ public class CharacterSpriteEditorViewModel : EditorViewModel
             await new ProgressDialog { DataContext = tracker }.ShowDialog(Window.Window);
         }
     }
+
+    [GeneratedRegex(@"_(?<frameCount>\d{1,4})f(?:_|$)", RegexOptions.IgnoreCase, "en-US")]
+    private static partial Regex FrameCountRegex();
+    [GeneratedRegex(@"_E(?<x>\d{1,3}),(?<y>\d{1,3})(?:_|$)")]
+    private static partial Regex EyePosRegex();
+    [GeneratedRegex(@"_M(?<x>\d{1,3}),(?<y>\d{1,3})(?:_|$)")]
+    private static partial Regex MouthPosRegex();
 }

--- a/src/SerialLoops/ViewModels/Editors/EditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/EditorViewModel.cs
@@ -10,6 +10,7 @@ namespace SerialLoops.ViewModels.Editors;
 public class EditorViewModel(ItemDescription item, MainWindowViewModel window, ILogger log, Project project = null, EditorTabsPanelViewModel tabs = null, ItemExplorerPanelViewModel explorer = null) : ViewModelBase
 {
     public MainWindowViewModel Window { get; protected set; } = window;
+    public int ClosedIndex { get; set; }
     protected ILogger _log = log;
     protected Project _project = project;
     protected EditorTabsPanelViewModel _tabs = tabs;

--- a/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/ItemDispimgScriptCommandEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/ScriptCommandEditors/ItemDispimgScriptCommandEditorViewModel.cs
@@ -100,7 +100,7 @@ public class ItemDispimgScriptCommandEditorViewModel : ScriptCommandEditorViewMo
 public readonly struct LocalizedItemLocation(ItemItem.ItemLocation location)
 {
     public ItemItem.ItemLocation Location { get; } = location;
-    public override string ToString() => Strings.ResourceManager.GetString(Location.ToString());
+    public override string ToString() => Strings.ResourceManager.GetString($"ItemLocation{Location}");
 }
 
 public readonly struct LocalizedItemTransition(ItemItem.ItemTransition transition)

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -134,7 +134,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         SaveHotKey = GuiExtensions.CreatePlatformAgnosticCtrlGesture(Key.S);
         SearchHotKey = GuiExtensions.CreatePlatformAgnosticCtrlGesture(Key.F);
-        CloseProjectKey = GuiExtensions.CreatePlatformAgnosticCtrlGesture(Key.W);
+        CloseProjectKey = GuiExtensions.CreatePlatformAgnosticCtrlGesture(Key.Q);
 
         NewProjectCommand = ReactiveCommand.CreateFromTask(NewProjectCommand_Executed);
         OpenProjectCommand = ReactiveCommand.CreateFromTask(OpenProjectCommand_Executed);

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -1281,10 +1281,9 @@ public partial class MainWindowViewModel : ViewModelBase
                             {
                                 emulatorExecutable = PatchableConstants.FlatpakProcess;
                             }
-                            if (emulatorExecutable.EndsWith(".app"))
+                            else if (emulatorExecutable.EndsWith(".app"))
                             {
-                                emulatorExecutable = Path.Combine(CurrentConfig.EmulatorPath, "Contents", "MacOS",
-                                    Path.GetFileNameWithoutExtension(CurrentConfig.EmulatorPath));
+                                emulatorExecutable = "open";
                             }
 
                             string[] emulatorArgs = [Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")];
@@ -1293,6 +1292,14 @@ public partial class MainWindowViewModel : ViewModelBase
                                 emulatorArgs =
                                 [
                                     ..PatchableConstants.FlatpakProcessBaseArgs, "run", CurrentConfig.EmulatorFlatpak,
+                                    Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds"),
+                                ];
+                            }
+                            else if (emulatorExecutable == "open")
+                            {
+                                emulatorArgs =
+                                [
+                                    CurrentConfig.EmulatorPath, "--args",
                                     Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds"),
                                 ];
                             }

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -370,10 +370,10 @@ public partial class MainWindowViewModel : ViewModelBase
                         SaveProject_Executed();
                         if (!skipBuild)
                         {
-                            //BuildIterativeProject_Executed(sender, e); // make sure we lock in the changes
+                            BuildIterativeCommand.Execute(null); // make sure we lock in the changes
                         }
                         break;
-                    default:
+                    case ButtonResult.Cancel:
                         cancel = true;
                         if (e is not null)
                         {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -1362,6 +1362,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             insertionPoint--;
         }
+        NativeMenu fileMenu = ((NativeMenuItem)menu.Items.First(m => m is NativeMenuItem nm && nm.Header == Strings._File)).Menu;
 
         // FILE (additions and removals)
         NativeMenuItem projectRenameItem = (NativeMenuItem)WindowMenu[MenuHeader.FILE].Menu!.Items
@@ -1372,23 +1373,28 @@ public partial class MainWindowViewModel : ViewModelBase
         NativeMenuItem projectDeleteItem = (NativeMenuItem)WindowMenu[MenuHeader.FILE].Menu.Items
             .First(m => m is NativeMenuItem nm && nm.Header?.Equals(Strings.ProjectDeleteText) == true);
         WindowMenu[MenuHeader.FILE].Menu.Items.Remove(projectRenameItem);
+        fileMenu!.Items.Remove(projectRenameItem);
         WindowMenu[MenuHeader.FILE].Menu.Items.Remove(projectDuplicateItem);
+        fileMenu.Items.Remove(projectDuplicateItem);
         WindowMenu[MenuHeader.FILE].Menu.Items.Remove(projectDeleteItem);
+        fileMenu.Items.Remove(projectDeleteItem);
 
-        WindowMenu[MenuHeader.FILE].Menu.Items.Insert(projectAreaIndex, new NativeMenuItem
+        NativeMenuItem projectSaveItem = new()
         {
             Header = Strings.Save_Project,
             Command = SaveProjectCommand,
             Icon = ControlGenerator.GetIcon("Save", Log),
             Gesture = SaveHotKey,
-        });
-        WindowMenu[MenuHeader.FILE].Menu.Items.Insert(projectAreaIndex + 1, new NativeMenuItem
+        };
+        NativeMenuItem projectCloseItem = new()
         {
             Header = Strings.Close_Project,
             Command = CloseProjectCommand,
             Icon = ControlGenerator.GetIcon("Close", Log),
             Gesture = CloseProjectKey,
-        });
+        };
+        WindowMenu[MenuHeader.FILE].Menu.Items.Insert(projectAreaIndex, projectSaveItem);
+        WindowMenu[MenuHeader.FILE].Menu.Items.Insert(projectAreaIndex + 1, projectCloseItem);
 
         // PROJECT
         WindowMenu.Add(MenuHeader.PROJECT, new(Strings._Project));

--- a/src/SerialLoops/ViewModels/Panels/EditorTabsPanelViewModel.cs
+++ b/src/SerialLoops/ViewModels/Panels/EditorTabsPanelViewModel.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Avalonia.Input;
 using HaruhiChokuretsuLib.Util;
 using MsBox.Avalonia.Enums;
 using ReactiveUI;
@@ -11,6 +13,7 @@ using SerialLoops.Assets;
 using SerialLoops.Lib;
 using SerialLoops.Lib.Items;
 using SerialLoops.Lib.SaveFile;
+using SerialLoops.Lib.Util;
 using SerialLoops.Utility;
 using SerialLoops.ViewModels.Editors;
 
@@ -28,12 +31,25 @@ public class EditorTabsPanelViewModel : ViewModelBase
     [Reactive]
     public bool ShowTabsPanel { get; set; }
 
-    public ICommand TabSwitchedCommand { get; set; }
     public ObservableCollection<EditorViewModel> Tabs { get; set; } = [];
+    private readonly DropOutStack<EditorViewModel> _closedTabs = new(20);
+
+    public ICommand CloseCurrentTabCommand { get; }
+    public ICommand ReopenTabCommand { get; }
+
+    [Reactive]
+    public KeyGesture CloseTabKeyGesture { get; set; }
+    [Reactive]
+    public KeyGesture ReopenTabKeyGesture { get; set; }
 
     public EditorTabsPanelViewModel(MainWindowViewModel mainWindow, Project project, ILogger log)
     {
-        TabSwitchedCommand = ReactiveCommand.Create(OnTabSwitched);
+        CloseCurrentTabCommand = ReactiveCommand.Create(CloseCurrentTab);
+        ReopenTabCommand = ReactiveCommand.Create(ReopenTab);
+
+        CloseTabKeyGesture = GuiExtensions.CreatePlatformAgnosticCtrlGesture(Key.W);
+        ReopenTabKeyGesture = GuiExtensions.CreatePlatformAgnosticCtrlGesture(Key.T, KeyModifiers.Shift);
+
         MainWindow = mainWindow;
         _project = project;
         _log = log;
@@ -58,6 +74,22 @@ public class EditorTabsPanelViewModel : ViewModelBase
             SelectedTab = newTab;
         }
         ShowTabsPanel = Tabs.Any();
+    }
+
+    private void CloseCurrentTab()
+    {
+        Tabs.Remove(SelectedTab);
+        ShowTabsPanel = Tabs.Any();
+    }
+
+    private void ReopenTab()
+    {
+        EditorViewModel mostRecentTab = _closedTabs.Pop();
+        if (mostRecentTab is not null)
+        {
+            Tabs.Insert(mostRecentTab.ClosedIndex > Tabs.Count ? Tabs.Count : mostRecentTab.ClosedIndex, mostRecentTab);
+            SelectedTab = mostRecentTab;
+        }
     }
 
     private EditorViewModel CreateTab(ItemDescription item)
@@ -147,12 +179,7 @@ public class EditorTabsPanelViewModel : ViewModelBase
         }
     }
 
-    private void OnTabSwitched()
-    {
-
-    }
-
-    public async Task OnTabClosed(EditorViewModel closedEditor)
+    public async Task OnTabClosed(EditorViewModel closedEditor, int closedIndex)
     {
         if (closedEditor.Description.Type is ItemDescription.ItemType.BGM or ItemDescription.ItemType.Voice or ItemDescription.ItemType.SFX)
         {
@@ -194,12 +221,9 @@ public class EditorTabsPanelViewModel : ViewModelBase
                     break;
             }
         }
-        ShowTabsPanel = Tabs.Any();
-    }
 
-    public void OnTabMiddleClicked()
-    {
-        Tabs.Remove(SelectedTab);
+        closedEditor.ClosedIndex = closedIndex;
+        _closedTabs.Push(closedEditor);
         ShowTabsPanel = Tabs.Any();
     }
 }

--- a/src/SerialLoops/Views/Dialogs/AddScriptSectionDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/AddScriptSectionDialog.axaml
@@ -22,7 +22,7 @@
             <StackPanel Orientation="Vertical" Spacing="3">
                 <TextBlock Text="{x:Static assets:Strings.Section_Name_}"/>
                 <StackPanel Orientation="Horizontal" Spacing="2">
-                    <TextBox Text="{Binding SectionName}"/>
+                    <TextBox Text="{Binding SectionName}" Name="NameBox"/>
                 </StackPanel>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="5">

--- a/src/SerialLoops/Views/Dialogs/AddScriptSectionDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/AddScriptSectionDialog.axaml.cs
@@ -1,4 +1,7 @@
+using System.Text.RegularExpressions;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace SerialLoops.Views.Dialogs;
 
@@ -7,6 +10,24 @@ public partial class AddScriptSectionDialog : Window
     public AddScriptSectionDialog()
     {
         InitializeComponent();
+        NameBox.AddHandler(TextInputEvent, NameBox_TextInput, RoutingStrategies.Tunnel);
     }
+
+    private void NameBox_TextInput(object sender, TextInputEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(e.Text) && !AllowedCharactersRegex().IsMatch(e.Text))
+        {
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        NameBox.Focus();
+    }
+
+    [GeneratedRegex(@"[A-Za-z0-9_]")]
+    private static partial Regex AllowedCharactersRegex();
 }
 

--- a/src/SerialLoops/Views/Dialogs/ProjectCreationDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/ProjectCreationDialog.axaml.cs
@@ -10,7 +10,7 @@ public partial class ProjectCreationDialog : Window
     public ProjectCreationDialog()
     {
         InitializeComponent();
-        NameBox.AddHandler(KeyDownEvent, NameBox_KeyDown, RoutingStrategies.Tunnel);
+        NameBox.AddHandler(TextInputEvent, NameBox_TextInput, RoutingStrategies.Tunnel);
     }
 
     protected override void OnLoaded(RoutedEventArgs e)
@@ -18,12 +18,11 @@ public partial class ProjectCreationDialog : Window
         NameBox.Focus();
     }
 
-    private void NameBox_KeyDown(object sender, KeyEventArgs e)
+    private void NameBox_TextInput(object sender, TextInputEventArgs e)
     {
-        if (!string.IsNullOrEmpty(e.KeySymbol) && !AllowedCharactersRegex().IsMatch(e.KeySymbol) && e.Key != Key.Back)
+        if (!string.IsNullOrEmpty(e.Text) && !AllowedCharactersRegex().IsMatch(e.Text))
         {
             e.Handled = true;
-            return;
         }
     }
 

--- a/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml
@@ -23,7 +23,7 @@
 
             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding NewName}"
                      Watermark="{x:Static assets:Strings.Haroohie}" Margin="10 0 0 0"
-                     Width="200" Name="NameBox" KeyDown="NameBox_KeyDown"/>
+                     Width="200" Name="NameBox"/>
 
             <StackPanel Grid.Row="1" Grid.Column="1" HorizontalAlignment="Right" Orientation="Horizontal" Spacing="5"
                         Margin="0 30 0 0">

--- a/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/ProjectRenameDuplicateDialog.axaml.cs
@@ -10,14 +10,14 @@ public partial class ProjectRenameDuplicateDialog : Window
     public ProjectRenameDuplicateDialog()
     {
         InitializeComponent();
+        NameBox.AddHandler(TextInputEvent, NameBox_TextInput, RoutingStrategies.Tunnel);
     }
 
-    private void NameBox_KeyDown(object sender, KeyEventArgs e)
+    private void NameBox_TextInput(object sender, TextInputEventArgs e)
     {
-        if (!string.IsNullOrEmpty(e.KeySymbol) && !Regex.IsMatch(e.KeySymbol, @"[A-Za-z\d-_\.]") && e.Key != Key.Back)
+        if (!string.IsNullOrEmpty(e.Text) && !AllowedCharactersRegex().IsMatch(e.Text))
         {
             e.Handled = true;
-            return;
         }
     }
 
@@ -26,5 +26,8 @@ public partial class ProjectRenameDuplicateDialog : Window
         base.OnLoaded(e);
         NameBox.Focus();
     }
+
+    [GeneratedRegex(@"[A-Za-z\d-_\.]")]
+    private static partial Regex AllowedCharactersRegex();
 }
 

--- a/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml
+++ b/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml
@@ -17,6 +17,10 @@
     </UserControl.Resources>
 
     <Grid>
+        <StackPanel IsVisible="False" Margin="5">
+            <Button Command="{Binding CloseCurrentTabCommand}" HotKey="{Binding CloseTabKeyGesture}"/>
+            <Button Command="{Binding ReopenTabCommand}" HotKey="{Binding ReopenTabKeyGesture}"/>
+        </StackPanel>
         <tab:TabsControl Name="Tabs" ShowDefaultAddButton="False" ItemsSource="{Binding Tabs}"
                          ContainerClearing="Tabs_ContainerClearing" IsVisible="{Binding ShowTabsPanel}"
                          SelectedItem="{Binding SelectedTab}" LastTabClosedAction="{x:Null}"
@@ -26,11 +30,6 @@
                          CloseAllToRightHeaderText="{x:Static assets:Strings.TabaloniaCloseAllToRight}"
                          CloseAllToLeftHeaderText="{x:Static assets:Strings.TabaloniaCloseAllToLeft}"
                          CloseAllHeaderText="{x:Static assets:Strings.TabaloniaCloseAll}">
-            <i:Interaction.Behaviors>
-                <ia:EventTriggerBehavior EventName="SelectionChanged" SourceObject="{Binding #Tabs}">
-                    <ia:InvokeCommandAction Command="{Binding TabSwitchedCommand}"/>
-                </ia:EventTriggerBehavior>
-            </i:Interaction.Behaviors>
             <tab:TabsControl.ItemTemplate>
                 <DataTemplate DataType="editors:EditorViewModel">
                     <StackPanel Orientation="Horizontal" Spacing="3" Name="TabHeader">

--- a/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml.cs
+++ b/src/SerialLoops/Views/Panels/EditorTabsPanel.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using SerialLoops.ViewModels.Editors;
 using SerialLoops.ViewModels.Panels;
+using Tabalonia.Controls;
 
 namespace SerialLoops.Views.Panels;
 
@@ -14,6 +15,7 @@ public partial class EditorTabsPanel : Panel
 
     private async void Tabs_ContainerClearing(object sender, ContainerClearingEventArgs e)
     {
-        await ((EditorTabsPanelViewModel)DataContext!).OnTabClosed((EditorViewModel)e.Container.DataContext);
+        await ((EditorTabsPanelViewModel)DataContext!).OnTabClosed((EditorViewModel)e.Container.DataContext,
+            ((TabsControl)sender).IndexFromContainer(e.Container));
     }
 }


### PR DESCRIPTION
A bunch of fixes/new features per requests from user studies.

Features:
* Text drawing & charset have been updated to account for the updates to the font width hack
* Ctrl-W has been rebound to close tab with Ctrl-Q being used to close the project. Ctrl-Shift-T now reopens the most recent previously closed tab (pops it off a stack of depth 20)
* Save Project and Close Project have been transplanted to the file menu, while project rename/duplicate/delete transpose themselves from the file menu to the project menu after a project has been loaded (since they have slightly different functionality between those two views, this makes a lot of sense)
* Sprite selection now happens automatically when you pick a dialogue speaker if there is a previous command with the same speaker and a non-exited sprite set -- nice little convenience factor

Fixes:
* Release text now notes that Docker Desktop requires you to _restart_ your computer as this seems more effective usually than just logging out
* Item location strings were not showing up; fixed here
* Our code for launching the emulator on macOS only worked for melonDS; it has now been genericized so it's a) more correct and b) also works with DeSmuME (important for older macs especially)
* Maps were broken by a previous change to layouts in the choku lib; this change has been reverted with some sadness
* The code to make it so you can't put spaces in project names has been fixed to work on macOS and also has been applied (even more strictly) to script sections to prevent gcc errors

Drafting for now as there is more to come but want you to be able to see what's happening so far.