### PR TITLE
Correct Flatpak emulator launch

### DIFF
--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -59,7 +59,7 @@ modules:
     buildsystem: simple
     sources:
       - type: git
-        url: https://github.com/haroohie-club/SerialLoops.git
+        url: https://github.com/jonko0493/SerialLoops.git
         branch: main
       - ./nuget-sources.json
       - type: patch
@@ -79,7 +79,7 @@ modules:
       - SLVersion=$(cat VERSION) SLAssemblyVersion=$(sed -n 's/apre/8888/p' VERSION) dotnet publish src/SerialLoops/SerialLoops.csproj -c Release -f net8.0 --no-self-contained --source ./nuget-sources
       - mkdir -p ${FLATPAK_DEST}/bin
       - cp -r src/SerialLoops/bin/Release/net8.0/publish/* ${FLATPAK_DEST}/bin
-      - sed -i "s/#VERSION#/$SLVersion/g" club.haroohie.SerialLoops.desktop
+      - sed -i "s/#VERSION#/$(cat VERSION)/g" club.haroohie.SerialLoops.desktop
       - install -Dm644 AppIcon.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/club.haroohie.SerialLoops.svg
       - install -Dm644 club.haroohie.SerialLoops.metainfo.xml ${FLATPAK_DEST}/share/metainfo/club.haroohie.SerialLoops.metainfo.xml
       - install -Dm644 club.haroohie.SerialLoops.desktop ${FLATPAK_DEST}/share/applications/club.haroohie.SerialLoops.desktop

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -59,8 +59,8 @@ modules:
     buildsystem: simple
     sources:
       - type: git
-        url: https://github.com/jonko0493/SerialLoops.git
-        branch: FixupFlatpak
+        url: https://github.com/haroohie-club/SerialLoops.git
+        branch: main
       - ./nuget-sources.json
       - type: patch
         path: patches/sandbox.patch

--- a/install/linux/flatpak/club.haroohie.SerialLoops.yaml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.yaml
@@ -60,7 +60,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/jonko0493/SerialLoops.git
-        branch: main
+        branch: FixupFlatpak
       - ./nuget-sources.json
       - type: patch
         path: patches/sandbox.patch

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -2689,7 +2689,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to start emulator. Check the logs for more information.&quot;.
+        ///   Looks up a localized string similar to Failed to start emulator. Check the logs for more information..
         /// </summary>
         public static string EmulatorLaunchFailedErrorMessage {
             get {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -2689,6 +2689,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to start emulator. Check the logs for more information.&quot;.
+        /// </summary>
+        public static string EmulatorLaunchFailedErrorMessage {
+            get {
+                return ResourceManager.GetString("EmulatorLaunchFailedErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Encoding.
         /// </summary>
         public static string Encoding {
@@ -3884,15 +3893,6 @@ namespace SerialLoops.Assets {
         public static string Failed_to_set_viewr_contents_for_script_command_list_panel_ {
             get {
                 return ResourceManager.GetString("Failed to set viewr contents for script command list panel.", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to start emulator.
-        /// </summary>
-        public static string Failed_to_start_emulator {
-            get {
-                return ResourceManager.GetString("Failed to start emulator", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.en-GB.resx
+++ b/src/SerialLoops/Assets/Strings.en-GB.resx
@@ -929,9 +929,6 @@
   <data name="Failed to set viewr contents for script command list panel." xml:space="preserve">
     <value>Failed to set viewr contents for script command list panel.</value>
   </data>
-  <data name="Failed to start emulator" xml:space="preserve">
-    <value>Failed to start emulator</value>
-  </data>
   <data name="Failed to unpack ROM" xml:space="preserve">
     <value>Failed to unpack ROM</value>
   </data>

--- a/src/SerialLoops/Assets/Strings.it.resx
+++ b/src/SerialLoops/Assets/Strings.it.resx
@@ -465,9 +465,6 @@
   <data name="Export Frames" xml:space="preserve">
     <value>Esporta frames</value>
   </data>
-  <data name="Failed to start emulator" xml:space="preserve">
-    <value>Impossibile avviare l'emulatore</value>
-  </data>
   <data name="Failed to load BGM file: file not found." xml:space="preserve">
     <value>Errore caricare file BGM: File non trovato.</value>
   </data>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -1069,9 +1069,6 @@ In order to preserve state, no hacks were applied.</value>
   <data name="Failed to set viewr contents for script command list panel." xml:space="preserve">
     <value>Failed to set viewr contents for script command list panel.</value>
   </data>
-  <data name="Failed to start emulator" xml:space="preserve">
-    <value>Failed to start emulator</value>
-  </data>
   <data name="Failed to unpack ROM" xml:space="preserve">
     <value>Failed to unpack ROM</value>
   </data>
@@ -3695,5 +3692,8 @@ item in the dropdown!</value>
   </data>
   <data name="OggDecodeFailedMessage" xml:space="preserve">
     <value>Failed to decode provided ogg file; only Vorbis and Opus codecs are supported.</value>
+  </data>
+  <data name="EmulatorLaunchFailedErrorMessage" xml:space="preserve">
+    <value>Failed to start emulator. Check the logs for more information."</value>
   </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3694,6 +3694,6 @@ item in the dropdown!</value>
     <value>Failed to decode provided ogg file; only Vorbis and Opus codecs are supported.</value>
   </data>
   <data name="EmulatorLaunchFailedErrorMessage" xml:space="preserve">
-    <value>Failed to start emulator. Check the logs for more information."</value>
+    <value>Failed to start emulator. Check the logs for more information.</value>
   </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.zh-Hans.resx
+++ b/src/SerialLoops/Assets/Strings.zh-Hans.resx
@@ -992,9 +992,6 @@
   <data name="Failed to set viewr contents for script command list panel." xml:space="preserve">
     <value>为脚本命令列表面板设置查看器内容失败。</value>
   </data>
-  <data name="Failed to start emulator" xml:space="preserve">
-    <value>启动模拟器失败</value>
-  </data>
   <data name="Failed to unpack ROM" xml:space="preserve">
     <value>解压缩 ROM失败</value>
   </data>

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -1367,6 +1367,14 @@ public partial class MainWindowViewModel : ViewModelBase
                             emulatorProcess.ErrorDataReceived += (_, e) => Log.LogWarning(e.Data);
                             emulatorProcess.Start();
                             emulatorProcess.BeginErrorReadLine();
+                            Task.Run(() =>
+                            {
+                                emulatorProcess.WaitForExit();
+                                if (emulatorProcess.ExitCode != 0)
+                                {
+                                    Log.LogError(Strings.EmulatorLaunchFailedErrorMessage);
+                                }
+                            });
                         }
                         catch (Exception ex)
                         {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -1336,7 +1336,8 @@ public partial class MainWindowViewModel : ViewModelBase
                             }
 
                             string[] emulatorArgs = [Path.Combine(OpenProject.MainDirectory, $"{OpenProject.Name}.nds")];
-                            if (emulatorExecutable.Equals(PatchableConstants.FlatpakProcess))
+                            if (emulatorExecutable.Equals(PatchableConstants.FlatpakProcess)
+                                && !string.IsNullOrWhiteSpace(CurrentConfig.EmulatorFlatpak))
                             {
                                 emulatorArgs =
                                 [

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -1367,11 +1367,6 @@ public partial class MainWindowViewModel : ViewModelBase
                             emulatorProcess.ErrorDataReceived += (_, e) => Log.LogWarning(e.Data);
                             emulatorProcess.Start();
                             emulatorProcess.BeginErrorReadLine();
-                            emulatorProcess.WaitForExit();
-                            if (emulatorProcess.ExitCode != 0)
-                            {
-                                Log.LogError(Strings.EmulatorLaunchFailedErrorMessage);
-                            }
                         }
                         catch (Exception ex)
                         {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -1361,15 +1361,10 @@ public partial class MainWindowViewModel : ViewModelBase
                                 ];
                             }
                             Log.Log($"Launching emulator executable '{emulatorExecutable}' with args '{string.Join(' ', emulatorArgs)}'");
-                            ProcessStartInfo emulatorPsi = new(emulatorExecutable, emulatorArgs)
-                            {
-                                RedirectStandardOutput = true, RedirectStandardError = true,
-                            };
+                            ProcessStartInfo emulatorPsi = new(emulatorExecutable, emulatorArgs) { RedirectStandardError = true };
                             Process emulatorProcess = new() { StartInfo = emulatorPsi };
-                            emulatorProcess.OutputDataReceived += (_, e) => Log.Log(e.Data);
                             emulatorProcess.ErrorDataReceived += (_, e) => Log.LogWarning(e.Data);
                             emulatorProcess.Start();
-                            emulatorProcess.BeginOutputReadLine();
                             emulatorProcess.BeginErrorReadLine();
                             emulatorProcess.WaitForExit();
                             if (emulatorProcess.ExitCode != 0)


### PR DESCRIPTION
This fixes launching non-Flatpak emulators from Flatpak. The emulator executable has to be located somewhere the sandbox has access to, but if it is it should be able to launch it without issue. Additionally, this adds error logging for emulators which should prove useful for diagnosing similar issues in the future.