### PR TITLE
Make section edges aware of specific calling command in graph

### DIFF
--- a/src/SerialLoops.Lib/Items/ScriptItem.cs
+++ b/src/SerialLoops.Lib/Items/ScriptItem.cs
@@ -78,7 +78,9 @@ public class ScriptItem : Item
                     {
                         Graph.AddEdge(new()
                         {
-                            Source = section, Target = ((ScriptSectionScriptParameter)command.Parameters[4]).Section
+                            Source = section,
+                            SourceCommandIndex = command.Index,
+                            Target = ((ScriptSectionScriptParameter)command.Parameters[4]).Section,
                         });
                         Graph.AddEdgeRange(Event.ScriptSections.Where(s =>
                             Event.LabelsSection.Objects.Where(l =>
@@ -101,7 +103,8 @@ public class ScriptItem : Item
                             Graph.AddEdge(new()
                             {
                                 Source = section,
-                                Target = ((ScriptSectionScriptParameter)command.Parameters[0]).Section
+                                SourceCommandIndex = command.Index,
+                                Target = ((ScriptSectionScriptParameter)command.Parameters[0]).Section,
                             });
                         }
                         catch (ArgumentOutOfRangeException)
@@ -119,6 +122,7 @@ public class ScriptItem : Item
                             Graph.AddEdge(new()
                             {
                                 Source = section,
+                                SourceCommandIndex = command.Index,
                                 Target = ((ScriptSectionScriptParameter)command.Parameters[1]).Section
                             });
                         }
@@ -139,7 +143,9 @@ public class ScriptItem : Item
                         {
                             Graph.AddEdge(new()
                             {
-                                Source = section, Target = Event.ScriptSections.First(s => s.Name == "NONEMiss2")
+                                Source = section,
+                                SourceCommandIndex = command.Index,
+                                Target = Event.ScriptSections.First(s => s.Name == "NONEMiss2")
                             }); // hardcode this section, even tho you can't get to it
                         }
                     }
@@ -152,7 +158,7 @@ public class ScriptItem : Item
                                             .Cast<OptionScriptParameter>()
                                             .Where(p => p.Option.Id > 0).Select(p => p.Option.Id).Contains(l.Id))
                                     .Select(l => l.Name.Replace("/", "")).Contains(s.Name))
-                            .Select(s => new ScriptSectionEdge { Source = section, Target = s }));
+                            .Select(s => new ScriptSectionEdge { Source = section, SourceCommandIndex = command.Index, Target = s }));
                         @continue = true;
                     }
                     else if (command.Verb == CommandVerb.NEXT_SCENE)
@@ -168,7 +174,9 @@ public class ScriptItem : Item
                     {
                         Graph.AddEdge(new()
                         {
-                            Source = Event.ScriptSections[1], Target = section
+                            Source = Event.ScriptSections[1],
+                            SourceCommandIndex = section.Objects.Count - 1,
+                            Target = section,
                         }); // these particular chess files have no VGOTOs, so uh... we manually hardcode them
                     }
                 }
@@ -183,6 +191,7 @@ public class ScriptItem : Item
                     Graph.AddEdge(new()
                     {
                         Source = section,
+                        SourceCommandIndex = section.Objects.Count - 1,
                         Target = commandTree.Keys.ElementAt(commandTree.Keys.ToList().IndexOf(section) + 1)
                     });
                 }

--- a/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
+++ b/src/SerialLoops.Lib/Script/ScriptItemCommand.cs
@@ -95,7 +95,7 @@ public class ScriptItemCommand : ReactiveObject
 
             foreach (ScriptSectionEdge edge in path)
             {
-                commands.AddRange(commandTree[edge.Source]);
+                commands.AddRange(commandTree[edge.Source].Take(edge.SourceCommandIndex + 1));
             }
         }
         commands.AddRange(commandTree[Section].TakeWhile(c => c.Index != Index));

--- a/src/SerialLoops.Lib/Script/ScriptSectionEdge.cs
+++ b/src/SerialLoops.Lib/Script/ScriptSectionEdge.cs
@@ -6,6 +6,7 @@ namespace SerialLoops.Lib.Script;
 public class ScriptSectionEdge : IEdge<ScriptSection>
 {
     public ScriptSection Source { get; set; }
+    public int SourceCommandIndex { get; set; }
 
     public ScriptSection Target { get; set; }
 }


### PR DESCRIPTION
Fixes #547.

The fix for the issue is essentially to add the "source command index" (i.e. the index of the calling command) to the script section edges so that, when calculating the list of executed commands, the program knows exactly to which command the script will run before jumping to the next section. This means that commands after a VGOTO will not be included in the script preview for that section, which is exactly what we want.