### PR TITLE
Fixup Haroohie text width calculation & #Q01

### DIFF
--- a/src/SerialLoops.Lib/Util/Extensions.cs
+++ b/src/SerialLoops.Lib/Util/Extensions.cs
@@ -104,6 +104,11 @@ public static partial class Extensions
                 originalString = originalString.Replace(match.Value, match.Value.GetSubstitutedString(project));
             }
 
+            foreach (Match match in Regex.Matches(originalString, @"。Ｑ(\d{2})").Cast<Match>())
+            {
+                originalString = originalString.Replace(match.Value, match.Value.GetSubstitutedString(project));
+            }
+
             foreach (Match match in Regex.Matches(originalString, @"。ｘ(\d{2})").Cast<Match>())
             {
                 originalString = originalString.Replace(match.Value, match.Value.GetSubstitutedString(project));
@@ -467,6 +472,10 @@ public static partial class Extensions
                 else if (i < text.Length - 6 && Regex.IsMatch(text[i..(i + 6)], @"#SE\d{3}"))
                 {
                     i += 6;
+                }
+                else if (i < text.Length - 6 && Regex.IsMatch(text[i..(i + 4)], @"#Q\d{2}"))
+                {
+                    i += 4;
                 }
                 else if (i < text.Length - 4 && text[i..(i + 4)] == "#SK0")
                 {

--- a/src/SerialLoops.Lib/Util/Extensions.cs
+++ b/src/SerialLoops.Lib/Util/Extensions.cs
@@ -369,10 +369,10 @@ public static partial class Extensions
         int strWidth = 0;
         for (int i = 0; i < str.Length; i++)
         {
-            project.FontReplacement.TryGetValue(str[i], out FontReplacement fr);
+            FontReplacement fr = project.FontReplacement.ReverseLookup(str[i]);
             if ((fr?.CauseOffsetAdjust ?? false) && i < str.Length - 1)
             {
-                project.FontReplacement.TryGetValue(str[i + 1], out FontReplacement nextFr);
+                FontReplacement nextFr = project.FontReplacement.ReverseLookup(str[i + 1]);
                 if (nextFr?.TakeOffsetAdjust ?? false)
                 {
                     strWidth += fr.Offset - 1;

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7780,7 +7780,7 @@ namespace SerialLoops.Assets {
         /// <summary>
         ///   Looks up a localized string similar to Reverts the background to the last call of BG_DISP (i.e. undoes any BG_FADE or BG_DISPCG calls). This is required before returning to displaying standard TEX_BG BGs. Note that if reverting a TEX_CG_DUAL_SCREEN BG, SET_PLACE must have been used to set the place location and have it displayed.
         ///
-        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, consider  [rest of string was truncated]&quot;;.
+        ///BG_REVERT does something odd to previously displayed CGs that makes attempting to display them again after the BG_REVERT crash/freeze/soft lock the game. If you need to go back and forth between the same CGs, conside [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ScriptCommandVerbHelpBG_REVERT {
             get {


### PR DESCRIPTION
Noticed that text width calculation seemed to be broken, so I fixed it. Just a bug I introduced in #543.

Also noticed we were rendering the directives starting with `#Q` incorrectly -- and they are actually used in the game (EV1_001). So fixed that up real quick so those render properly.