### PR TITLE
Incorporate feedback from Flathub review

### DIFF
--- a/install/linux/flatpak/club.haroohie.SerialLoops.desktop
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Serial Loops
+Comment=Editor for Suzumiya Haruhi no Chokuretsu
+Exec=SerialLoops
+Icon=club.haroohie.SerialLoops
+Terminal=false
+Type=Application
+Categories=Development;GUIDesigner

--- a/install/linux/flatpak/club.haroohie.SerialLoops.metainfo.xml
+++ b/install/linux/flatpak/club.haroohie.SerialLoops.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>club.haroohie.SerialLoops</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Serial Loops</name>
+  <launchable type="desktop-id">club.haroohie.SerialLoops.desktop</launchable>
+  <summary>Editor for Suzumiya Haruhi no Chokuretsu</summary>
+  <description>
+    <p>
+      Serial Loops is a full-fledged editor for the Nintendo DS game Suzumiya Haruhi no Chokuretsu (The Series of Haruhi Suzumiya).
+      In its current state, it allows you to edit nearly everything about the game, and more is planned for the future. Please check
+      our documentation on our website for more information on how to use it!
+    </p>
+    <ul>
+      <li>Fully edit the game's scripts, completely rewriting your own Haruhi visual novel with a powerful preview feature!</li>
+      <li>Completely change the game's scenario, moving events around in the order you'd like them to occur!</li>
+      <li>Replace the game's graphics, including backgrounds, CGs, character sprites, chibis, and more!</li>
+      <li>Edit the game's soundtrack, swapping out background music and voice lines! (SFX coming in a future release!)</li>
+      <li>Edit character nameplates, topics, UI text, tutorial mappings, and dialogue colors!</li>
+      <li>Apply pre-written assembly hacks for even greater control of the game!</li>
+      <li>Partial editing of group selections, puzzles, and chess puzzles, and viewable maps!</li>
+      <li>A full save editor for editing save games as well!</li>
+    </ul>
+  </description>
+  <branding>
+    <color type="primary" scheme_preference="light">#9accfe</color>
+    <color type="primary" scheme_preference="dark">#042058</color>
+  </branding>
+  <screenshots>
+    <screenshot>
+      <screenshot type="default">
+        <caption>Serial Loops script editor</caption>
+        <image>https://raw.githubusercontent.com/haroohie-club/SerialLoops/0.3.3/install/linux/flatpak/screenshots/script_editor.png</image>
+      </screenshot>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Serial Loops startup screen</caption>
+      <image>https://raw.githubusercontent.com/haroohie-club/SerialLoops/0.3.3/install/linux/flatpak/screenshots/main_screen.png</image>
+    </screenshot>
+    <screenshot>
+      <screenshot type="default">
+        <caption>Serial Loops map editor</caption>
+        <image>https://raw.githubusercontent.com/haroohie-club/SerialLoops/0.3.3/install/linux/flatpak/screenshots/map_editor.png</image>
+      </screenshot>
+    </screenshot>
+  </screenshots>
+  <developer_name>The Haroohie Translation Club</developer_name>
+  <url type="homepage">https://haroohie.club/chokuretsu/serial-loops</url>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="v0.3.3" date="2025-08-20">
+      <description>
+        <p>
+          We removed our dependencies on devkitARM and make and have switched to using LLVM and ninja. This makes it easier
+          to use Serial Loops on all platforms as it significantly easier to install and use these dependencies.
+        </p>
+        <p>This is also our initial release on Flathub!</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/src/SerialLoops.Lib/ConfigUser.cs
+++ b/src/SerialLoops.Lib/ConfigUser.cs
@@ -41,6 +41,7 @@ public class ConfigUser
     public bool CheckForUpdates { get; set; }
     public bool PreReleaseChannel { get; set; }
     public string DisplayFont { get; set; }
+    public bool FirstTimeFlatpak { get; set; }
 
     public void Save(ILogger log)
     {
@@ -72,16 +73,16 @@ public class ConfigUser
 
         // Pull in new hacks in case we've updated the program with more
         List<AsmHack> builtinHacks = JsonSerializer.Deserialize<List<AsmHack>>(File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "hacks.json")));
-        IEnumerable<AsmHack> missingHacks = builtinHacks.Where(h => !Hacks.Contains(h));
-        if (missingHacks.Any())
+        AsmHack[] missingHacks = builtinHacks.Where(h => !Hacks.Contains(h)).ToArray();
+        if (missingHacks.Length != 0)
         {
             IO.CopyFiles(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "Hacks"), HacksDirectory, log);
             Hacks.AddRange(missingHacks);
             File.WriteAllText(Path.Combine(HacksDirectory, "hacks.json"), JsonSerializer.Serialize(Hacks));
         }
 
-        IEnumerable<AsmHack> updatedHacks = builtinHacks.Where(h => !Hacks.FirstOrDefault(o => h.Name == o.Name)?.DeepEquals(h) ?? false);
-        if (updatedHacks.Any())
+        AsmHack[] updatedHacks = builtinHacks.Where(h => !Hacks.FirstOrDefault(o => h.Name == o.Name)?.DeepEquals(h) ?? false).ToArray();
+        if (updatedHacks.Length != 0)
         {
             IO.CopyFiles(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Sources", "Hacks"), HacksDirectory, log);
             foreach (AsmHack updatedHack in updatedHacks)

--- a/src/SerialLoops.Lib/EnvironmentVariables.cs
+++ b/src/SerialLoops.Lib/EnvironmentVariables.cs
@@ -8,4 +8,5 @@ public static class EnvironmentVariables
     public const string BundledEmulator = "SL_BUNDLED_EMULATOR";
     public const string StoreSysConfig = "SL_STORE_SYS_CONFIG";
     public const string UseUpdater = "SL_USE_UPDATER";
+    public const string Sandboxed = "SL_SANDBOXED";
 }

--- a/src/SerialLoops.Lib/EnvironmentVariables.cs
+++ b/src/SerialLoops.Lib/EnvironmentVariables.cs
@@ -8,5 +8,5 @@ public static class EnvironmentVariables
     public const string BundledEmulator = "SL_BUNDLED_EMULATOR";
     public const string StoreSysConfig = "SL_STORE_SYS_CONFIG";
     public const string UseUpdater = "SL_USE_UPDATER";
-    public const string Sandboxed = "SL_SANDBOXED";
+    public const string Flatpak = "SL_FLATPAK";
 }

--- a/src/SerialLoops.Lib/Factories/ConfigFactory.cs
+++ b/src/SerialLoops.Lib/Factories/ConfigFactory.cs
@@ -244,6 +244,8 @@ public class ConfigFactory : IConfigFactory
             RemoveMissingProjects = false,
             CheckForUpdates = true,
             PreReleaseChannel = false,
+            FirstTimeFlatpak = (Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString)
+                .Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase),
         };
     }
 }

--- a/src/SerialLoops/App.axaml
+++ b/src/SerialLoops/App.axaml
@@ -40,6 +40,7 @@
         <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
         <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
+        <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
 
         <!-- Toolbar styling -->
         <Style Selector="toolbar|Toolbar">

--- a/src/SerialLoops/App.axaml
+++ b/src/SerialLoops/App.axaml
@@ -174,6 +174,10 @@
             <Setter Property="FontSize" Value="24" />
             <Setter Property="FontWeight" Value="Bold" />
         </Style>
+        <Style Selector="TextBlock.h3">
+            <Setter Property="FontSize" Value="20" />
+            <Setter Property="FontWeight" Value="Bold" />
+        </Style>
         <Style Selector="TextBlock.b">
             <Setter Property="FontWeight" Value="Bold" />
         </Style>

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7191,6 +7191,24 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Application is sandboxed so logs cannot be directly opened. Logs are located at {0}.
+        /// </summary>
+        public static string SandboxedLogLocationMboxMessage {
+            get {
+                return ResourceManager.GetString("SandboxedLogLocationMboxMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sandboxed Log Location.
+        /// </summary>
+        public static string SandboxedLogLocationMboxTitle {
+            get {
+                return ResourceManager.GetString("SandboxedLogLocationMboxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
         public static string Save {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -7191,7 +7191,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application is sandboxed so logs cannot be directly opened. Logs are located at {0}.
+        ///   Looks up a localized string similar to Application is sandboxed so logs cannot be directly opened. Logs are located in the Flatpak data directory, which is typically ~/.var/app/club.haroohie.SerialLoops/SerialLoops.
         /// </summary>
         public static string SandboxedLogLocationMboxMessage {
             get {
@@ -7200,7 +7200,7 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sandboxed Log Location.
+        ///   Looks up a localized string similar to Sandboxed App Cannot Launch Log Viewer.
         /// </summary>
         public static string SandboxedLogLocationMboxTitle {
             get {

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -2040,6 +2040,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Crash Log.
+        /// </summary>
+        public static string CrashLogName {
+            get {
+                return ResourceManager.GetString("CrashLogName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create.
         /// </summary>
         public static string Create {
@@ -5124,6 +5133,24 @@ namespace SerialLoops.Assets {
         public static string Location {
             get {
                 return ResourceManager.GetString("Location", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Serial Loops Log.
+        /// </summary>
+        public static string LogName {
+            get {
+                return ResourceManager.GetString("LogName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} - Log Viewer.
+        /// </summary>
+        public static string LogViewerTitleFormatString {
+            get {
+                return ResourceManager.GetString("LogViewerTitleFormatString", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -4122,6 +4122,42 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Import Projects.
+        /// </summary>
+        public static string FirstTimeFlatpakButton {
+            get {
+                return ResourceManager.GetString("FirstTimeFlatpakButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        public static string FirstTimeFlatpakImportProjectsFolder {
+            get {
+                return ResourceManager.GetString("FirstTimeFlatpakImportProjectsFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Flatpak version of Serial Loops is sandboxed, so if you used a previous version, your projects won&apos;t show up here. Click the button below to import them!.
+        /// </summary>
+        public static string FirstTimeFlatpakMainMessage {
+            get {
+                return ResourceManager.GetString("FirstTimeFlatpakMainMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Looking for your projects?.
+        /// </summary>
+        public static string FirstTimeFlatpakTitleMessage {
+            get {
+                return ResourceManager.GetString("FirstTimeFlatpakTitleMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to FLAC files.
         /// </summary>
         public static string FLAC_files {

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3741,4 +3741,16 @@ item in the dropdown!</value>
   <data name="LogName" xml:space="preserve">
     <value>Serial Loops Log</value>
   </data>
+  <data name="FirstTimeFlatpakTitleMessage" xml:space="preserve">
+    <value>Looking for your projects?</value>
+  </data>
+  <data name="FirstTimeFlatpakMainMessage" xml:space="preserve">
+    <value>The Flatpak version of Serial Loops is sandboxed, so if you used a previous version, your projects won't show up here. Click the button below to import them!</value>
+  </data>
+  <data name="FirstTimeFlatpakButton" xml:space="preserve">
+    <value>Import Projects</value>
+  </data>
+  <data name="FirstTimeFlatpakImportProjectsFolder" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3732,4 +3732,13 @@ item in the dropdown!</value>
   <data name="SandboxedLogLocationMboxMessage" xml:space="preserve">
     <value>Application is sandboxed so logs cannot be directly opened. Logs are located in the Flatpak data directory, which is typically ~/.var/app/club.haroohie.SerialLoops/SerialLoops</value>
   </data>
+  <data name="LogViewerTitleFormatString" xml:space="preserve">
+    <value>{0} - Log Viewer</value>
+  </data>
+  <data name="CrashLogName" xml:space="preserve">
+    <value>Crash Log</value>
+  </data>
+  <data name="LogName" xml:space="preserve">
+    <value>Serial Loops Log</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3726,4 +3726,10 @@ item in the dropdown!</value>
   <data name="ObjcopyExitedWithFailureMessage" xml:space="preserve">
     <value>llvm-objcopy exited with code {0}</value>
   </data>
+  <data name="SandboxedLogLocationMboxTitle" xml:space="preserve">
+    <value>Sandboxed Log Location</value>
+  </data>
+  <data name="SandboxedLogLocationMboxMessage" xml:space="preserve">
+    <value>Application is sandboxed so logs cannot be directly opened. Logs are located at {0}</value>
+  </data>
 </root>

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3727,9 +3727,9 @@ item in the dropdown!</value>
     <value>llvm-objcopy exited with code {0}</value>
   </data>
   <data name="SandboxedLogLocationMboxTitle" xml:space="preserve">
-    <value>Sandboxed Log Location</value>
+    <value>Sandboxed App Cannot Launch Log Viewer</value>
   </data>
   <data name="SandboxedLogLocationMboxMessage" xml:space="preserve">
-    <value>Application is sandboxed so logs cannot be directly opened. Logs are located at {0}</value>
+    <value>Application is sandboxed so logs cannot be directly opened. Logs are located in the Flatpak data directory, which is typically ~/.var/app/club.haroohie.SerialLoops/SerialLoops</value>
   </data>
 </root>

--- a/src/SerialLoops/Program.cs
+++ b/src/SerialLoops/Program.cs
@@ -45,7 +45,8 @@ internal sealed class Program
             (Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
                 bool.TrueString, StringComparison.OrdinalIgnoreCase))
         {
-            return NativeLibrary.Load("SDL2-2.0", assembly, searchPath);
+            // Flatpak runtime doesn't have libSDL2.so, so we make do
+            return NativeLibrary.Load("libSDL2-2.0.so.0", assembly, searchPath);
         }
 
         return IntPtr.Zero;

--- a/src/SerialLoops/Program.cs
+++ b/src/SerialLoops/Program.cs
@@ -18,11 +18,13 @@ internal sealed class Program
     {
         try
         {
+#if !WINDOWS
             if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
                     bool.TrueString, StringComparison.OrdinalIgnoreCase))
             {
                 NativeLibrary.SetDllImportResolver(Assembly.GetAssembly(typeof(NAudio.Sdl2.WaveInSdl))!, DllImportResolver);
             }
+#endif
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
         catch (Exception ex)

--- a/src/SerialLoops/Program.cs
+++ b/src/SerialLoops/Program.cs
@@ -42,7 +42,7 @@ internal sealed class Program
     private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
         if (libraryName.Equals("SDL2") &&
-            (Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
+            (Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
                 bool.TrueString, StringComparison.OrdinalIgnoreCase))
         {
             // Flatpak runtime doesn't have libSDL2.so, so we make do

--- a/src/SerialLoops/Program.cs
+++ b/src/SerialLoops/Program.cs
@@ -18,7 +18,11 @@ internal sealed class Program
     {
         try
         {
-            NativeLibrary.SetDllImportResolver(Assembly.GetAssembly(typeof(NAudio.Sdl2.WaveInSdl))!, DllImportResolver);
+            if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
+                    bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            {
+                NativeLibrary.SetDllImportResolver(Assembly.GetAssembly(typeof(NAudio.Sdl2.WaveInSdl))!, DllImportResolver);
+            }
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
         catch (Exception ex)
@@ -41,14 +45,8 @@ internal sealed class Program
 
     private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
-        if (libraryName.Equals("SDL2") &&
-            (Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
-                bool.TrueString, StringComparison.OrdinalIgnoreCase))
-        {
+        return libraryName.Equals("SDL2") ?
             // Flatpak runtime doesn't have libSDL2.so, so we make do
-            return NativeLibrary.Load("libSDL2-2.0.so.0", assembly, searchPath);
-        }
-
-        return IntPtr.Zero;
+            NativeLibrary.Load("libSDL2-2.0.so.0", assembly, searchPath) : IntPtr.Zero;
     }
 }

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -94,6 +94,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.3" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.3" />
     <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
     <PackageReference Include="Avalonia.Controls.PanAndZoom" Version="11.3.0" />

--- a/src/SerialLoops/Utility/LoopyLogger.cs
+++ b/src/SerialLoops/Utility/LoopyLogger.cs
@@ -40,7 +40,7 @@ public class LoopyLogger : ILogger
     }
 
     private static string Stamp => $"\n({Environment.ProcessId}) {DateTimeOffset.Now} - ";
-    public static string CrashLogLocation => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "sl_crash.log");
+    public static string CrashLogLocation => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "SerialLoops", "sl_crash.log");
 
     public virtual void Log(string message)
     {
@@ -115,6 +115,10 @@ public class LoopyLogger : ILogger
     {
         string crashLog = $"{Stamp}SERIAL LOOPS CRASH: {ex.Message}\n\n{ex.StackTrace}";
         Console.WriteLine(crashLog);
+        if (!Directory.Exists(Path.GetDirectoryName(CrashLogLocation)))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(CrashLogLocation)!);
+        }
         File.AppendAllText(CrashLogLocation, crashLog);
     }
 }

--- a/src/SerialLoops/Utility/LoopyLogger.cs
+++ b/src/SerialLoops/Utility/LoopyLogger.cs
@@ -121,4 +121,9 @@ public class LoopyLogger : ILogger
         }
         File.AppendAllText(CrashLogLocation, crashLog);
     }
+
+    public string ReadLog()
+    {
+        return File.ReadAllText(_logFile);
+    }
 }

--- a/src/SerialLoops/ViewModels/Dialogs/LogViewerDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/LogViewerDialogViewModel.cs
@@ -1,4 +1,5 @@
 using System.Windows.Input;
+using AvaloniaEdit.Document;
 using ReactiveUI;
 using SerialLoops.Assets;
 using SerialLoops.Views.Dialogs;
@@ -8,14 +9,14 @@ namespace SerialLoops.ViewModels.Dialogs;
 public class LogViewerDialogViewModel : ViewModelBase
 {
     public string Title { get; set; }
-    public string Log { get; set; }
+    public TextDocument Log { get; set; }
 
     public ICommand CloseCommand { get; }
 
     public LogViewerDialogViewModel(string logName, string log)
     {
         Title = string.Format(Strings.LogViewerTitleFormatString, logName);
-        Log = log;
+        Log = new(log);
 
         CloseCommand = ReactiveCommand.Create<LogViewerDialog>(dialog => dialog.Close());
     }

--- a/src/SerialLoops/ViewModels/Dialogs/LogViewerDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/LogViewerDialogViewModel.cs
@@ -1,0 +1,22 @@
+using System.Windows.Input;
+using ReactiveUI;
+using SerialLoops.Assets;
+using SerialLoops.Views.Dialogs;
+
+namespace SerialLoops.ViewModels.Dialogs;
+
+public class LogViewerDialogViewModel : ViewModelBase
+{
+    public string Title { get; set; }
+    public string Log { get; set; }
+
+    public ICommand CloseCommand { get; }
+
+    public LogViewerDialogViewModel(string logName, string log)
+    {
+        Title = string.Format(Strings.LogViewerTitleFormatString, logName);
+        Log = log;
+
+        CloseCommand = ReactiveCommand.Create<LogViewerDialog>(dialog => dialog.Close());
+    }
+}

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -170,10 +170,18 @@ public partial class MainWindowViewModel : ViewModelBase
         BuildBaseCommand = ReactiveCommand.CreateFromTask(BuildBase_Executed);
         BuildAndRunCommand = ReactiveCommand.CreateFromTask(BuildAndRun_Executed);
 
-        ViewLogsCommand = ReactiveCommand.Create(() =>
+        ViewLogsCommand = ReactiveCommand.CreateFromTask(async Task () =>
         {
             try
             {
+                if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
+                        bool.TrueString, StringComparison.OrdinalIgnoreCase))
+                {
+                    await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,
+                        string.Format(Strings.SandboxedLogLocationMboxMessage,
+                            Path.Combine(CurrentConfig.UserDirectory, "Logs", "SerialLoops.log")),
+                        ButtonEnum.Ok, Icon.Info, Log);
+                }
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = Path.Combine(CurrentConfig.UserDirectory, "Logs", "SerialLoops.log"),
@@ -197,11 +205,21 @@ public partial class MainWindowViewModel : ViewModelBase
 
             try
             {
-                Process.Start(new ProcessStartInfo
+                if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
+                        bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
-                    FileName = Path.Combine(LoopyLogger.CrashLogLocation),
-                    UseShellExecute = true,
-                });
+                    await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,
+                        string.Format(Strings.SandboxedLogLocationMboxMessage, LoopyLogger.CrashLogLocation),
+                        ButtonEnum.Ok, Icon.Info, Log);
+                }
+                else
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = Path.Combine(LoopyLogger.CrashLogLocation),
+                        UseShellExecute = true,
+                    });
+                }
             }
             catch (Exception ex)
             {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -175,12 +175,9 @@ public partial class MainWindowViewModel : ViewModelBase
             try
             {
                 // Temp debugging
-                Log.Log("/usr/lib\n" + string.Join('\n', Directory.GetDirectories("/usr/lib")) +
-                        string.Join('\n', Directory.GetFiles("/usr/lib")));
-                Log.Log("/usr/bin\n" + string.Join('\n', Directory.GetDirectories("/usr/bin")) +
-                        string.Join('\n', Directory.GetFiles("/usr/bin")));
-                Log.Log("/usr/lib/x86_64-linux-gnu\n" + string.Join('\n', Directory.GetDirectories("/usr/lib/x86_64-linux-gnu")) +
-                        string.Join('\n', Directory.GetFiles("/usr/lib/x86_64-linux-gnu")));
+                Log.Log("/usr/lib\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/lib")));
+                Log.Log("/usr/bin\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/bin")));
+                Log.Log("/usr/lib/x86_64-linux-gnu\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/lib/x86_64-linux-gnu")));
 
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -174,6 +174,9 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             try
             {
+                // Temp debugging
+                Log.Log("/usr/lib");
+                Log.Log(string.Join('\n', Directory.GetDirectories("/usr/lib/")));
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -174,18 +174,11 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             try
             {
-                // Temp debugging
-                Log.Log("/usr/lib\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/lib")));
-                Log.Log("/usr/bin\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/bin")));
-                Log.Log("/usr/lib/x86_64-linux-gnu\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/lib/x86_64-linux-gnu")));
-                Log.Log($"/usr/lib/x86_64-linux-gnu/libSDL2.so exists: {File.Exists("/usr/lib/x86_64-linux-gnu/libSDL2.so")}");
-
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
                     await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,
-                        string.Format(Strings.SandboxedLogLocationMboxMessage,
-                            Path.Combine(CurrentConfig.UserDirectory, "Logs", "SerialLoops.log")),
+                        Strings.SandboxedLogLocationMboxMessage,
                         ButtonEnum.Ok, Icon.Info, Log);
                 }
                 Process.Start(new ProcessStartInfo
@@ -215,7 +208,7 @@ public partial class MainWindowViewModel : ViewModelBase
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
                     await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,
-                        string.Format(Strings.SandboxedLogLocationMboxMessage, LoopyLogger.CrashLogLocation),
+                        Strings.SandboxedLogLocationMboxMessage,
                         ButtonEnum.Ok, Icon.Info, Log);
                 }
                 else

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -175,9 +175,12 @@ public partial class MainWindowViewModel : ViewModelBase
             try
             {
                 // Temp debugging
-                Log.Log("/usr/lib\n" + string.Join('\n', Directory.GetDirectories("/usr/lib/")));
-                Log.Log("/usr/bin\n" + string.Join('\n', Directory.GetDirectories("/usr/bin/")));
-                Log.Log("/usr/lib/x86_64-linux-gnu\n" + string.Join('\n', Directory.GetDirectories("/usr/lib/x86_64-linux-gnu")));
+                Log.Log("/usr/lib\n" + string.Join('\n', Directory.GetDirectories("/usr/lib")) +
+                        string.Join('\n', Directory.GetFiles("/usr/lib")));
+                Log.Log("/usr/bin\n" + string.Join('\n', Directory.GetDirectories("/usr/bin")) +
+                        string.Join('\n', Directory.GetFiles("/usr/bin")));
+                Log.Log("/usr/lib/x86_64-linux-gnu\n" + string.Join('\n', Directory.GetDirectories("/usr/lib/x86_64-linux-gnu")) +
+                        string.Join('\n', Directory.GetFiles("/usr/lib/x86_64-linux-gnu")));
 
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -175,8 +175,10 @@ public partial class MainWindowViewModel : ViewModelBase
             try
             {
                 // Temp debugging
-                Log.Log("/usr/lib");
-                Log.Log(string.Join('\n', Directory.GetDirectories("/usr/lib/")));
+                Log.Log("/usr/lib\n" + string.Join('\n', Directory.GetDirectories("/usr/lib/")));
+                Log.Log("/usr/bin\n" + string.Join('\n', Directory.GetDirectories("/usr/bin/")));
+                Log.Log("/usr/lib/x86_64-linux-gnu\n" + string.Join('\n', Directory.GetDirectories("/usr/lib/x86_64-linux-gnu")));
+
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -174,7 +174,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             try
             {
-                if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
+                if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
                     await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,
@@ -204,7 +204,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
             try
             {
-                if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
+                if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
                     await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -177,15 +177,18 @@ public partial class MainWindowViewModel : ViewModelBase
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
-                    await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,
-                        Strings.SandboxedLogLocationMboxMessage,
-                        ButtonEnum.Ok, Icon.Info, Log);
+                    LogViewerDialogViewModel logViewerViewModel =
+                        new(Strings.CrashLogName, Log.ReadLog());
+                    await new LogViewerDialog() { DataContext = logViewerViewModel }.ShowDialog(Window);
                 }
-                Process.Start(new ProcessStartInfo
+                else
                 {
-                    FileName = Path.Combine(CurrentConfig.UserDirectory, "Logs", "SerialLoops.log"),
-                    UseShellExecute = true,
-                });
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = Path.Combine(CurrentConfig.UserDirectory, "Logs", "SerialLoops.log"),
+                        UseShellExecute = true,
+                    });
+                }
             }
             catch (Exception ex)
             {
@@ -207,9 +210,9 @@ public partial class MainWindowViewModel : ViewModelBase
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Flatpak) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
-                    await Window.ShowMessageBoxAsync(Strings.SandboxedLogLocationMboxTitle,
-                        Strings.SandboxedLogLocationMboxMessage,
-                        ButtonEnum.Ok, Icon.Info, Log);
+                    LogViewerDialogViewModel logViewerViewModel =
+                        new(Strings.CrashLogName, File.ReadAllText(LoopyLogger.CrashLogLocation));
+                    await new LogViewerDialog() { DataContext = logViewerViewModel }.ShowDialog(Window);
                 }
                 else
                 {

--- a/src/SerialLoops/ViewModels/MainWindowViewModel.cs
+++ b/src/SerialLoops/ViewModels/MainWindowViewModel.cs
@@ -178,6 +178,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 Log.Log("/usr/lib\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/lib")));
                 Log.Log("/usr/bin\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/bin")));
                 Log.Log("/usr/lib/x86_64-linux-gnu\n" + string.Join('\n', Directory.GetFileSystemEntries("/usr/lib/x86_64-linux-gnu")));
+                Log.Log($"/usr/lib/x86_64-linux-gnu/libSDL2.so exists: {File.Exists("/usr/lib/x86_64-linux-gnu/libSDL2.so")}");
 
                 if ((Environment.GetEnvironmentVariable(EnvironmentVariables.Sandboxed) ?? bool.FalseString).Equals(
                         bool.TrueString, StringComparison.OrdinalIgnoreCase))

--- a/src/SerialLoops/Views/Dialogs/LogViewerDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/LogViewerDialog.axaml
@@ -1,0 +1,23 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:vm="using:SerialLoops.ViewModels.Dialogs"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:assets="using:SerialLoops.Assets"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="SerialLoops.Views.Dialogs.LogViewerDialog"
+        x:DataType="vm:LogViewerDialogViewModel"
+        Title="{Binding Title}"
+        SizeToContent="WidthAndHeight"
+        Name="Dialog">
+    <Grid RowDefinitions="Auto,*,Auto" ColumnDefinitions="*,Auto" Margin="10">
+        <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"/>
+        <TextBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"
+                 Width="600" Height="400" Text="{Binding Log}"
+                 IsReadOnly="True" Margin="5"/>
+        <Button Grid.Row="2" Grid.Column="1" Content="{x:Static assets:Strings.TabaloniaCloseItem}"
+                Command="{Binding CloseCommand}"
+                CommandParameter="{Binding #Dialog}" IsCancel="True"/>
+    </Grid>
+</Window>
+

--- a/src/SerialLoops/Views/Dialogs/LogViewerDialog.axaml
+++ b/src/SerialLoops/Views/Dialogs/LogViewerDialog.axaml
@@ -4,18 +4,18 @@
         xmlns:vm="using:SerialLoops.ViewModels.Dialogs"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:assets="using:SerialLoops.Assets"
+        xmlns:avaloniaedit="using:AvaloniaEdit"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="SerialLoops.Views.Dialogs.LogViewerDialog"
         x:DataType="vm:LogViewerDialogViewModel"
         Title="{Binding Title}"
-        SizeToContent="WidthAndHeight"
+        Height="600" Width="800"
         Name="Dialog">
     <Grid RowDefinitions="Auto,*,Auto" ColumnDefinitions="*,Auto" Margin="10">
         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"/>
-        <TextBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"
-                 Width="600" Height="400" Text="{Binding Log}"
-                 IsReadOnly="True" Margin="5"/>
-        <Button Grid.Row="2" Grid.Column="1" Content="{x:Static assets:Strings.TabaloniaCloseItem}"
+        <avaloniaedit:TextEditor Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center"
+                 Document="{Binding Log}" IsReadOnly="True" Margin="5"/>
+        <Button Grid.Row="2" Grid.Column="1" Content="{x:Static assets:Strings.Exit}"
                 Command="{Binding CloseCommand}"
                 CommandParameter="{Binding #Dialog}" IsCancel="True"/>
     </Grid>

--- a/src/SerialLoops/Views/Dialogs/LogViewerDialog.axaml.cs
+++ b/src/SerialLoops/Views/Dialogs/LogViewerDialog.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SerialLoops.Views.Dialogs;
+
+public partial class LogViewerDialog : Window
+{
+    public LogViewerDialog()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/src/SerialLoops/Views/Panels/HomePanel.axaml
+++ b/src/SerialLoops/Views/Panels/HomePanel.axaml
@@ -43,7 +43,15 @@
                     <controls:LinkButton Command="{Binding MainWindow.AboutCommand}" Text="{x:Static assets:Strings.About}"/>
                 </StackPanel>
             </StackPanel>
-            <StackPanel DockPanel.Dock="Right" Margin="13" Spacing="10" MinWidth="450" MinHeight="400">
+            <StackPanel IsVisible="{Binding DisplayFirstTimeFlatpakMessage}" Spacing="10" VerticalAlignment="Center">
+                <TextBlock Classes="h3" Text="{x:Static assets:Strings.FirstTimeFlatpakTitleMessage}" HorizontalAlignment="Center"/>
+                <TextBlock TextWrapping="Wrap" Text="{x:Static assets:Strings.FirstTimeFlatpakMainMessage}"
+                           HorizontalAlignment="Center" TextAlignment="Center"/>
+                <Button Content="{x:Static assets:Strings.FirstTimeFlatpakButton}" Command="{Binding ImportProjectsCommand}"
+                        HorizontalAlignment="Center"/>
+            </StackPanel>
+            <StackPanel DockPanel.Dock="Right" Margin="13" Spacing="10" MinWidth="450" MinHeight="400"
+                        IsVisible="{Binding !DisplayFirstTimeFlatpakMessage}">
                 <TextBlock Classes="h2" Text="{x:Static assets:Strings.Recents}"/>
                 <ItemsControl ItemsSource="{Binding RecentProjects}">
                     <ItemsControl.ItemTemplate>


### PR DESCRIPTION
Adds functionality to support the requirements for inclusion in Flathub. This will be ported to the `0.3.3` tag as well, but since it only affects Flatpak behavior, we won't do another release.

We lose access to popping the log viewer within the Flatpak, so this adds a small form for viewing logs (can and should be improved). Additionally, users upgrading may be confused as to where their projects have gone, so this prompts them to port them into the flatpak data.

Pending feedback from Flathub folks, this also introduces a custom DLL import resolver for NAudio.SDL2's importing of the SDL binary -- when it detects that it's inside a Flatpak, it changes what it's looking for. This might be removed before merging if it ends up not being necessary.