### PR TITLE
Fixup two search dialog bugs

### DIFF
--- a/src/SerialLoops.Lib/Project.cs
+++ b/src/SerialLoops.Lib/Project.cs
@@ -1608,6 +1608,17 @@ public partial class Project
 
     private bool ScriptIsInEpisode(ScriptItem script, int scenarioEpIndex, int scenarioNextEpIndex)
     {
+        int scriptFileScenarioIndex = GetScriptScenarioIndex(script);
+        if (scenarioNextEpIndex < 0)
+        {
+            scenarioNextEpIndex = int.MaxValue;
+        }
+
+        return scriptFileScenarioIndex > scenarioEpIndex && scriptFileScenarioIndex < scenarioNextEpIndex;
+    }
+
+    private int GetScriptScenarioIndex(ScriptItem script)
+    {
         int scriptFileScenarioIndex = Scenario.Commands.FindIndex(c => c.Verb == ScenarioCommand.ScenarioVerb.LOAD_SCENE && c.Parameter == script.Event.Index);
         if (scriptFileScenarioIndex < 0)
         {
@@ -1617,13 +1628,14 @@ public partial class Project
             {
                 scriptFileScenarioIndex = Scenario.Commands.FindIndex(c => c.Verb == ScenarioCommand.ScenarioVerb.ROUTE_SELECT && c.Parameter == ((GroupSelectionItem)groupSelection).Index);
             }
-        }
-        if (scenarioNextEpIndex < 0)
-        {
-            scenarioNextEpIndex = int.MaxValue;
+            ItemDescription otherScript = references.Find(r => r.Type == ItemType.Script);
+            if (otherScript is not null)
+            {
+                scriptFileScenarioIndex = GetScriptScenarioIndex((ScriptItem)otherScript);
+            }
         }
 
-        return scriptFileScenarioIndex > scenarioEpIndex && scriptFileScenarioIndex < scenarioNextEpIndex;
+        return scriptFileScenarioIndex;
     }
 
     [GeneratedRegex(@"\((?<num>\d+)\)")]

--- a/src/SerialLoops/Assets/Strings.Designer.cs
+++ b/src/SerialLoops/Assets/Strings.Designer.cs
@@ -1580,6 +1580,15 @@ namespace SerialLoops.Assets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search scope.
+        /// </summary>
+        public static string Conditional {
+            get {
+                return ResourceManager.GetString("Conditional", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to LLVM Path.
         /// </summary>
         public static string ConfigOptionLlvmPath {
@@ -2769,6 +2778,15 @@ namespace SerialLoops.Assets {
         public static string FirstTimeFlatpakTitleMessage {
             get {
                 return ResourceManager.GetString("FirstTimeFlatpakTitleMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Flag.
+        /// </summary>
+        public static string Flag {
+            get {
+                return ResourceManager.GetString("Flag", resourceCulture);
             }
         }
         
@@ -7958,6 +7976,15 @@ namespace SerialLoops.Assets {
         public static string TERMINAL_TYPING {
             get {
                 return ResourceManager.GetString("TERMINAL_TYPING", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Title.
+        /// </summary>
+        public static string Title {
+            get {
+                return ResourceManager.GetString("Title", resourceCulture);
             }
         }
         

--- a/src/SerialLoops/Assets/Strings.resx
+++ b/src/SerialLoops/Assets/Strings.resx
@@ -3336,4 +3336,13 @@ item in the dropdown!</value>
   <data name="PuzzleEditorUnknown04" xml:space="preserve">
     <value>Unknown 04</value>
   </data>
+  <data name="Title" xml:space="preserve">
+    <value>Title</value><comment>Search scope</comment>
+  </data>
+  <data name="Flag" xml:space="preserve">
+    <value>Flag</value><comment>Search scope</comment>
+  </data>
+  <data name="Conditional" xml:space="preserve">
+    <value>Search scope</value>
+  </data>
 </root>

--- a/src/SerialLoops/ViewModels/Dialogs/SearchDialogViewModel.cs
+++ b/src/SerialLoops/ViewModels/Dialogs/SearchDialogViewModel.cs
@@ -201,7 +201,7 @@ public class LocalizedItemScope(ItemDescription.ItemType type) : ReactiveObject
 {
     public ItemDescription.ItemType Type { get; } = type;
     public string Icon => $"avares://SerialLoops/Assets/Icons/{Type.ToString()}.svg";
-    public string DisplayText { get; } = Strings.ResourceManager.GetString($"{type.ToString()}s");
+    public string DisplayText { get; } = Strings.ResourceManager.GetString($"ItemsPanel{type.ToString().Replace("_", "")}s");
     [Reactive]
     public bool IsActive { get; set; } = true;
 }


### PR DESCRIPTION
Two small search dialog bugs:

1. Episode search was off as scripts can reference other scripts via SCENE_GOTO, which was throwing off the scenario index calculation.
2. Fallout from #562.