### PR TITLE
Add automated CG thumbnail replacement

### DIFF
--- a/src/SerialLoops.Lib/Items/BackgroundItem.cs
+++ b/src/SerialLoops.Lib/Items/BackgroundItem.cs
@@ -252,41 +252,38 @@ public class BackgroundItem : Item, IPreviewableGraphic
 
         SKBitmap centeredBitmap;
         SKCanvas canvas;
+        SKPaint paint = new() { IsAntialias = true, IsDither = true };
         switch (BackgroundType)
         {
             case BgType.TEX_CG:
             {
                 centeredBitmap = new(96, 128);
-                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(96, 72), SKSamplingOptions.Default);
                 canvas = new(centeredBitmap);
-                canvas.DrawBitmap(actualSizeBitmap, 0, 12);
+                canvas.DrawImage(SKImage.FromBitmap(image), new(0, 0, image.Width, image.Height), new SKRect(0, 12, 96, 84), new(SKCubicResampler.Mitchell), paint);
                 break;
             }
 
             case BgType.TEX_CG_SINGLE:
             {
                 centeredBitmap = new(96, 128);
-                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(96, 96), SKSamplingOptions.Default);
                 canvas = new(centeredBitmap);
-                canvas.DrawBitmap(actualSizeBitmap, 0, 0);
+                canvas.DrawImage(SKImage.FromBitmap(image), new(0, 0, image.Width, image.Height), new SKRect(0, 0, 96, 96), new(SKCubicResampler.Mitchell), paint);
                 break;
             }
 
             case BgType.TEX_CG_WIDE:
             {
                 centeredBitmap = new(128, 128);
-                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(128, 72), SKSamplingOptions.Default);
                 canvas = new(centeredBitmap);
-                canvas.DrawBitmap(actualSizeBitmap, 0, 12);
+                canvas.DrawImage(SKImage.FromBitmap(image), new(0, 0, image.Width, image.Height), new SKRect(0, 12, 128, 84), new(SKCubicResampler.Mitchell), paint);
                 break;
             }
 
             case BgType.TEX_CG_DUAL_SCREEN:
             {
                 centeredBitmap = new(96, 128);
-                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(112, 124), SKSamplingOptions.Default);
                 canvas = new(centeredBitmap);
-                canvas.DrawBitmap(actualSizeBitmap, 8, 2);
+                canvas.DrawImage(SKImage.FromBitmap(image), new(0, 0, image.Width, image.Height), new SKRect(8, 2, 120, 126), new(SKCubicResampler.Mitchell), paint);
                 break;
             }
 

--- a/src/SerialLoops.Lib/Items/BackgroundItem.cs
+++ b/src/SerialLoops.Lib/Items/BackgroundItem.cs
@@ -19,7 +19,7 @@ public class BackgroundItem : Item, IPreviewableGraphic
     public BgType BackgroundType { get; set; }
     public string CgName { get; set; }
     public int Flag { get; set; }
-    public short ExtrasShort { get; set; }
+    public GraphicsFile Thumbnail { get; set; }
     public byte ExtrasByte { get; set; }
 
     public BackgroundItem(string name) : base(name, ItemType.Background)
@@ -34,10 +34,10 @@ public class BackgroundItem : Item, IPreviewableGraphic
         CgExtraData cgEntry = project.Extra.Cgs.AsParallel().FirstOrDefault(c => c.BgId == Id);
         if (cgEntry is not null)
         {
-            CgName = cgEntry?.Name?.GetSubstitutedString(project);
-            Flag = cgEntry?.Flag ?? 0;
-            ExtrasShort = cgEntry?.Unknown02 ?? 0;
-            ExtrasByte = cgEntry?.Unknown04 ?? 0;
+            CgName = cgEntry.Name?.GetSubstitutedString(project);
+            Flag = cgEntry.Flag;
+            Thumbnail = project.Grp.GetFileByIndex(cgEntry.ThumbnailIndex);
+            ExtrasByte = cgEntry.Unknown04;
         }
     }
 
@@ -211,6 +211,109 @@ public class BackgroundItem : Item, IPreviewableGraphic
                 break;
             }
         }
+
+        if (Thumbnail is not null)
+        {
+            SetThumbnail(image, log);
+        }
+        return true;
+    }
+
+    public SKBitmap GetThumbnail()
+    {
+        if (Thumbnail is null)
+        {
+            return null;
+        }
+        SKBitmap tileBitmap = new(Graphic1.Width == 512 ? 192 : 96, (Graphic1.Height + Graphic2?.Height ?? 0) >= 256 ? 128 : 96);
+        SKBitmap tiles = Thumbnail.GetImage(width: 32, transparentIndex: 0);
+        using SKCanvas tileCanvas = new(tileBitmap);
+        int currentTile = 0;
+        for (int y = 0; y < tileBitmap.Height; y += 32)
+        {
+            for (int x = 0; x < tileBitmap.Width; x += 32)
+            {
+                SKRect crop = new(0, currentTile * 32, 32, (currentTile + 1) * 32);
+                SKRect dest = new(x, y, x + 32, y + 32);
+                tileCanvas.DrawBitmap(tiles, crop, dest);
+                currentTile++;
+            }
+        }
+        tileCanvas.Flush();
+
+        return tileBitmap;
+    }
+
+    private bool SetThumbnail(SKBitmap image, ILogger log)
+    {
+        List<SKColor> replacedPalette = Helpers.GetPaletteFromImage(image, 255, log);
+        replacedPalette.Insert(0, SKColors.Transparent);
+        Thumbnail.SetPalette(replacedPalette);
+
+        SKBitmap centeredBitmap;
+        SKCanvas canvas;
+        switch (BackgroundType)
+        {
+            case BgType.TEX_CG:
+            {
+                centeredBitmap = new(96, 128);
+                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(96, 72), SKSamplingOptions.Default);
+                canvas = new(centeredBitmap);
+                canvas.DrawBitmap(actualSizeBitmap, 0, 12);
+                break;
+            }
+
+            case BgType.TEX_CG_SINGLE:
+            {
+                centeredBitmap = new(96, 128);
+                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(96, 96), SKSamplingOptions.Default);
+                canvas = new(centeredBitmap);
+                canvas.DrawBitmap(actualSizeBitmap, 0, 0);
+                break;
+            }
+
+            case BgType.TEX_CG_WIDE:
+            {
+                centeredBitmap = new(128, 128);
+                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(128, 72), SKSamplingOptions.Default);
+                canvas = new(centeredBitmap);
+                canvas.DrawBitmap(actualSizeBitmap, 0, 12);
+                break;
+            }
+
+            case BgType.TEX_CG_DUAL_SCREEN:
+            {
+                centeredBitmap = new(96, 128);
+                SKBitmap actualSizeBitmap = image.Resize(new SKSizeI(112, 124), SKSamplingOptions.Default);
+                canvas = new(centeredBitmap);
+                canvas.DrawBitmap(actualSizeBitmap, 8, 2);
+                break;
+            }
+
+            default:
+                return false;
+        }
+
+        canvas.Flush();
+
+        SKBitmap tileBitmap = new(32, centeredBitmap.Width / 32 * centeredBitmap.Height);
+        using SKCanvas tileCanvas = new(tileBitmap);
+
+        int currentTile = 0;
+        for (int y = 0; y < centeredBitmap.Height; y += 32)
+        {
+            for (int x = 0; x < centeredBitmap.Width; x += 32)
+            {
+                SKRect crop = new(x, y, x + 32, y + 32);
+                SKRect dest = new(0, currentTile * 32, 32, (currentTile + 1) * 32);
+                tileCanvas.DrawBitmap(centeredBitmap, crop, dest);
+                currentTile++;
+            }
+        }
+        tileCanvas.Flush();
+
+        Thumbnail.SetImage(tileBitmap, newSize: true);
+
         return true;
     }
 
@@ -231,6 +334,14 @@ public class BackgroundItem : Item, IPreviewableGraphic
         else if (BackgroundType == BgType.KINETIC_SCREEN)
         {
             IO.WriteStringFile(Path.Combine("assets", "graphics", $"{Graphic2.Index:X3}.scr"), JsonSerializer.Serialize(Graphic2.ScreenData), project, log);
+        }
+
+        if (Thumbnail is not null)
+        {
+            using MemoryStream thumbStream = new();
+            Thumbnail.GetImage().Encode(thumbStream, SKEncodedImageFormat.Png, 1);
+            IO.WriteBinaryFile(Path.Combine("assets", "graphics", $"{Thumbnail.Index:X3}.png"), thumbStream.ToArray(), project, log);
+            IO.WriteStringFile(Path.Combine("assets", "graphics", $"{Thumbnail.Index:X3}.gi"), Thumbnail.GetGraphicInfoFile(), project, log);
         }
     }
 

--- a/src/SerialLoops.Lib/SerialLoops.Lib.csproj
+++ b/src/SerialLoops.Lib/SerialLoops.Lib.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.1" />
     <PackageReference Include="HaroohieClub.NitroPacker" Version="3.2.6" />
-    <PackageReference Include="HaruhiChokuretsuLib" Version="0.54.1" />
+    <PackageReference Include="HaruhiChokuretsuLib" Version="0.55.0" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.4.0" />

--- a/src/SerialLoops/SerialLoops.csproj
+++ b/src/SerialLoops/SerialLoops.csproj
@@ -93,23 +93,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.3" />
+    <PackageReference Include="Avalonia" Version="11.3.4" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.4" />
     <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
     <PackageReference Include="Avalonia.Controls.PanAndZoom" Version="11.3.0" />
     <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.3" />
-    <PackageReference Include="Avalonia.Labs.Controls" Version="11.3.0" />
-    <PackageReference Include="Avalonia.Labs.Panels" Version="11.3.0" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.3" />
-    <PackageReference Include="Avalonia.Skia" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Labs.Controls" Version="11.3.1" />
+    <PackageReference Include="Avalonia.Labs.Panels" Version="11.3.1" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Skia" Version="11.3.4" />
     <PackageReference Include="Avalonia.Svg" Version="11.3.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.4" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.4" />
     <!--The behaviors packages past 11.1.0.4 break our middle click to close functionality, so we're staying on that package for now.-->
     <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.3.0.6" />
     <PackageReference Include="DialogHost.Avalonia" Version="0.9.3" />

--- a/src/SerialLoops/ViewModels/Editors/BackgroundEditorViewModel.cs
+++ b/src/SerialLoops/ViewModels/Editors/BackgroundEditorViewModel.cs
@@ -24,6 +24,7 @@ public class BackgroundEditorViewModel : EditorViewModel
     public BackgroundItem Bg { get; set; }
     public SKBitmap BgBitmap => Bg.GetBackground();
     public string BgDescription => $"{Bg.Id} (0x{Bg.Id:X3}); {Bg.BackgroundType}";
+    public SKBitmap ThumbnailBitmap => Bg.GetThumbnail();
 
     public string DescriptionToolTip => Bg.BackgroundType switch
     {
@@ -40,7 +41,7 @@ public class BackgroundEditorViewModel : EditorViewModel
     public ICommand CgNameChangeCommand { get; set; }
     public bool ShowExtras => Bg.BackgroundType != BgType.TEX_BG && Bg.BackgroundType != BgType.KINETIC_SCREEN;
     public string FlagDescription => string.Format(Strings.EditorFlagIdLabel, Bg.Flag - 1);
-    public string UnknownExtrasShortDescription => string.Format(Strings.BgEditorUnknownExtrasShort, Bg.ExtrasShort);
+
     public string UnknownExtrasByteDescription => string.Format(Strings.BgEditorUnknownExtrasByte, Bg.ExtrasByte);
 
     public BackgroundEditorViewModel(BackgroundItem item, MainWindowViewModel window, Project project, ILogger log) : base(item, window, log, project)
@@ -107,6 +108,10 @@ public class BackgroundEditorViewModel : EditorViewModel
                     if (success)
                     {
                         this.RaisePropertyChanged(nameof(BgBitmap));
+                        if (ThumbnailBitmap is not null)
+                        {
+                            this.RaisePropertyChanged(nameof(ThumbnailBitmap));
+                        }
                         Description.UnsavedChanges = true;
                     }
                 }

--- a/src/SerialLoops/Views/Editors/BackgroundEditorView.axaml
+++ b/src/SerialLoops/Views/Editors/BackgroundEditorView.axaml
@@ -36,10 +36,13 @@
                     <Svg Path="avares://SerialLoops/Assets/Icons/Help.svg" Width="16" VerticalAlignment="Center"
                          ToolTip.Tip="{x:Static assets:Strings.BackgroundEditorHelpCgName}"/>
                 </StackPanel>
-                <StackPanel Orientation="Vertical" Spacing="3">
-                    <TextBlock Text="{Binding FlagDescription}"/>
-                    <TextBlock Text="{Binding UnknownExtrasShortDescription}"/>
-                    <TextBlock Text="{Binding UnknownExtrasByteDescription}"/>
+                <StackPanel Orientation="Horizontal" Spacing="20">
+                    <StackPanel Orientation="Vertical" Spacing="3">
+                        <TextBlock Text="{Binding FlagDescription}"/>
+                        <TextBlock Text="{Binding UnknownExtrasByteDescription}"/>
+                    </StackPanel>
+                    <Image Source="{Binding ThumbnailBitmap, Converter={x:Static utility:SLConverters.SKBitmapToAvaloniaConverter}}"
+                           Width="{Binding ThumbnailBitmap.Width}" Height="{Binding ThumbnailBitmap.Height}"/>
                 </StackPanel>
             </StackPanel>
         </StackPanel>

--- a/test/SerialLoops.Tests.Headless/SerialLoops.Tests.Headless.csproj
+++ b/test/SerialLoops.Tests.Headless/SerialLoops.Tests.Headless.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless.NUnit" Version="11.3.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.3" />
+    <PackageReference Include="Avalonia.Headless.NUnit" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.350" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
@@ -19,12 +19,12 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SerialLoops.Tests.Shared/SerialLoops.Tests.Shared.csproj
+++ b/test/SerialLoops.Tests.Shared/SerialLoops.Tests.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We just found out that CGs have separate thumbnails which are specified in the extras file. This PR displays these thumbnails in the background editor and also automates replacing them when a CG with a thumbnail is replaced.